### PR TITLE
Added the blend modes tutorial in statics.json

### DIFF
--- a/data/statics.json
+++ b/data/statics.json
@@ -307,6 +307,10 @@
         {
           "title": "How to use EdgesRenderer",
           "filename": "How_to_use_EdgesRenderer"
+        },
+        {
+          "title": "How to use Blend Modes",
+          "filename": "How_to_use_Blend_Modes"
         }
       ]
     },


### PR DESCRIPTION
The tutorial appears when we search for "blend", but then the server gives off a 404. See: http://doc.babylonjs.com/search?q=blend&page=1&max=25&bf=tutorials

I suspect this is because there was no reference to the MD file in here!