### PR TITLE
Builder : In the arrays, get the old comments.

### DIFF
--- a/scripts/helpers/builder/astHandler/describer.js
+++ b/scripts/helpers/builder/astHandler/describer.js
@@ -39,13 +39,12 @@ Describer.describe = function (astElement, withParams) {
 /**
  * returns comments of the given element
  * @param astElement AST TypeScript object
- * @param withParams boolean tells if th given object is commented with parameters or not
+ * @param withParams boolean tells if the given object is commented with parameters or not
  * @return string
  */
 Describer.getComments = function (astElement, astFormatted, withParams) {
 
     var serializedComments = '',
-    //Returns Comment[]
         rawComments = astElement.preComments(),
         comments = '';
 
@@ -67,9 +66,10 @@ Describer.getComments = function (astElement, astFormatted, withParams) {
         var oldLineDescription = '';
     }
 
-
     //Serialize the array of comments
-    for (var i in rawComments) serializedComments += rawComments[i].fullText() + '\n';
+    for (var i in rawComments) {
+        serializedComments += rawComments[i].fullText() + '\n';
+    }
 
 
     if (!withParams) {
@@ -139,11 +139,14 @@ Describer.getComments = function (astElement, astFormatted, withParams) {
             getOldParams.exec(oldTemp);
             getOldParams.exec(oldTemp);
 
+            /**
+             * Get the old comments from the arrays
+             * @type {Array}
+             */
             var paramOldComments = [];
             var paramOldComment = getOldParams.exec(oldTemp);
-
             while (paramOldComment != null) {
-                paramOldComments.push(paramOldComment[3]);
+                paramOldComments.push(paramOldComment[0].substr(paramOldComment[0].lastIndexOf("|")+1));
                 paramOldComment = getOldParams.exec(oldTemp);
 
             }
@@ -156,6 +159,28 @@ Describer.getComments = function (astElement, astFormatted, withParams) {
         var parametersDescription = '';
 
         parametersDescription += TypeManager.getDescriptionString(astElement.callSignature, serializedComments, true);
+
+        /**
+         * Add the old comments in the new .md
+         * In the arrays of ##Params
+          */
+
+        var paramDescLine = [];
+        var searchBreak = parametersDescription.search(/\n/);
+
+        while (searchBreak != -1) {
+
+            paramDescLine.push(parametersDescription.substring(0, searchBreak));
+            parametersDescription = parametersDescription.slice(searchBreak+1, parametersDescription.length-1);
+
+            searchBreak = parametersDescription.search(/\n/);
+        }
+
+        parametersDescription = "";
+        for(var i = 0; i < paramDescLine.length; i++) {
+            // Merge the comments with the new description
+            parametersDescription += paramDescLine[i] + paramOldComments[i] + "\n";
+        }
 
         if (funParameters.length > 0) {
             comments += '\n' + parametersHeader + parametersDescription;


### PR DESCRIPTION
This fix one of the builder bugs that Deltakosh report. When you insert a new version with the cmd "node .\scripts\helpers\builder\main.js" , it store the old descriptions from the arrays (like in 
![image](https://cloud.githubusercontent.com/assets/4868666/10395695/a66e911a-6e9e-11e5-93b4-45f828960381.png)
, then it merge it into the new MD.