### PR TITLE
Formatting, clarity, and links

### DIFF
--- a/.markdownlint.json
+++ b/.markdownlint.json
@@ -1,0 +1,9 @@
+{
+  "line-length": false,
+  "no-inline-html": {
+    "allowed_elements": ["Playground", "Youtube", "kbd"]
+  },
+  "single-title": {
+    "front_matter_title": ""
+  }
+}

--- a/.prettierrc
+++ b/.prettierrc
@@ -1,5 +1,5 @@
 {
-  "trailingComma": "all",
-  "tabWidth": 4,
-  "printWidth": 300
+    "trailingComma": "all",
+    "tabWidth": 2,
+    "printWidth": 300
 }

--- a/content/How_To/WebXR/WebXR_Controllers_Support.md
+++ b/content/How_To/WebXR/WebXR_Controllers_Support.md
@@ -1,6 +1,6 @@
 ---
 title: WebXR Controllers Support
-image: 
+image:
 description: Learn about the robust library of WebXR controllers and input supported in Babylon.js.
 keywords: babylon.js, diving deeper, WebXR, VR, AR, input, controller
 further-reading:
@@ -8,23 +8,28 @@ video-overview:
 video-content:
 ---
 
-One of the major differences between WebVR and WebXR was the support for different types of controllers. While WebVR supported the non-standard extended gamepad API and a few selected controllers, WebXR already supports a lot of different types of inputs, including touch screens, motion controllers and hands.
+One of the major differences between WebVR and WebXR was the support for different types of controllers. While WebVR supported the non-standard extended gamepad API and a few selected controllers, WebXR already supports a lot of different types of inputs, including touch screens, motion controllers, and hands.
 
 ## Some terms and classes to clear things up
 
-An XR controller comprises a lot of components that we at babylon sometimes name differently. It is also important to know the terms themselves to be able to use what you actually need. I would recommend reading the [XR Input section](https://www.w3.org/TR/webxr/#input) of the WebXR proposal draft.
+An XR controller comprises a lot of components that we at Babylon.js sometimes name differently. It is also important to know the terms themselves to be able to use what you actually need. I would recommend reading the [XR Input section](https://www.w3.org/TR/webxr/#input) of the WebXR proposal draft.
 
-An XR Session controls the input source of the current session. Every new input source connected to this session will be registered in the **inputSources** array of the native XR Session and will also trigger the `inputsourceschange` event with the new input source.
+An XR Session controls the input source of the current session. Every new input source connected to this session will be registered in the `inputSources` array of the native XR Session and will also trigger the `inputsourceschange` event with the new input source.
 
 An Input source has one of three target Ray modes - `tracked-pointer` for gamepad-like controllers, `screen` for touch-screen oriented inputs, and `gaze` for gaze-based inputs (input sources like google cardboard that has no proper way for user input).
 
-The [WebXRInput](/typedoc/classes/babylon.webxrinput) class is responsible of coordinating the addition and removal of input sources. It creates **WebXR Input Sources** classes and disposes them automatically for you.
+The [WebXRInput](/typedoc/classes/babylon.webxrinput) class is responsible of coordinating the addition and removal of input sources. It creates **WebXR Input Sources** classes and disposes of them automatically for you.
 
 Babylon's [WebXR Input Source](/typedoc/classes/babylon.webxrinputsource) class is the container for all user-input related objects. It is created automatically for you by the WebXR Input class for every controller.it is in charge of attaching the motion controller, which, in turn, is in charge of attaching the components and load the model.
 
-An input source has two important reference spaces - one it the **`targetRay`** which represents the pointer's position and direction. Think - the edge of your finger.and the **`gripSpace`** which is the base of a handheld device connected to this input source. Think - the base of your hand. The `gripSpace` is optional and is only available when a motion controller is connected. And, althou sometimes the same, the grip and target ray space can have different transformation altogether.
+An input source has two important reference spaces:
 
-A controller has an attached **motion controller** if the input source is a gamepad-like device (the oculus touch or the windows motion controllers are a good example for that). In turn, each controller has different **components** (buttons, triggers, thumbpads, touchpads) which have their state updated on each frame.
+1. The `targetRay`, which represents the pointer's position and direction. Think - the edge of your finger.
+2. The `gripSpace`, which is the base of a handheld device connected to this input source. Think - the base of your hand. The `gripSpace` is optional and is only available when a motion controller is connected.
+
+Although sometimes the same, the grip and target ray space can have different transformations.
+
+A controller has an attached **motion controller** if the input source is a gamepad-like device (the Oculus Touch or the windows motion controllers are a good example for that). In turn, each controller has different **components** (buttons, triggers, thumbpads, touchpads), which have their state updated on each frame.
 
 Note that input sources like of type `screen` are constantly created and removed when touch starts and end. This is called a transient input in the documentation.
 
@@ -50,7 +55,7 @@ As mentioned before the Input source has two reference spaces - `grip` and `targ
 
 To do that you can use the `getWorldPointerRayToRef` function:
 
-``` javascript
+```javascript
 const resultRay = new BABYLON.Ray();
 
 // get the pointer direction
@@ -69,21 +74,19 @@ This will be triggered when a motion controller, if available was initialized an
 
 #### onMeshLoadedObservable
 
-This is a helper observable and is the same as `xrController.motionController.onModelLoadedObservable` . But since the motion controller is created async, using the motionController observable will only be available after `onMotionControllerInitObservable` was triggered:
+This is a helper observable and is the same as `xrController.motionController.onModelLoadedObservable` . But since the motion controller is created async, using the `motionController` observable will only be available after `onMotionControllerInitObservable` was triggered:
 
-``` javascript
+```javascript
 // async, async, async
 xrInput.onControllerAddedObservable.add((inputSource) => {
-    inputSource.onMotionControllerInitObservable.add((motionController) => {
-        motionController.onModelLoadedObservable.add((model) => {
-
-        });
-    });
+  inputSource.onMotionControllerInitObservable.add((motionController) => {
+    motionController.onModelLoadedObservable.add((model) => {});
+  });
 });
 
 // a little cleaner
 xrInput.onControllerAddedObservable.add((inputSource) => {
-    inputSource.onModelLoadedObservable.add((model) => {});
+  inputSource.onModelLoadedObservable.add((model) => {});
 });
 ```
 
@@ -93,25 +96,25 @@ Will be triggered right at the end of the `dispose()` function of the input sour
 
 ## Motion controllers
 
-In most cases when starting a VR session, the user will have handheld devices, called here motion controllers. A motion controller will be automatically loaded, if available. A motion controller has a profile, containing its different components and their positions in the buttons and axes array, but babylon takes care of this for you so you don't have to know this to interact with the motion controller. You can see the different profiles in the [WebXR Input Profiles repository](https://github.com/immersive-web/webxr-input-profiles)
+In most cases when starting a VR session, the user will have handheld devices, called here motion controllers. A motion controller will be automatically loaded, if available. A motion controller has a profile, containing its different components and their positions in the buttons and axes array, but Babylon.js takes care of this for you so you don't have to know this to interact with the motion controller. You can see the different profiles in the [WebXR Input Profiles repository](https://github.com/immersive-web/webxr-input-profiles)
 
 ### Controller components
 
 Each motion controller has different components, that are described in its profile. Each component has one of the types:
 
-* Button
-* Trigger
-* Squeeze
-* Thumbstick
-* Touchpad
+- Button
+- Trigger
+- Squeeze
+- Thumbstick
+- Touchpad
 
-It also has a **unique** component id, which correlates to the actual component. For example, the **A button** on the oculus touch has the **type** `button` , and the **id** `a-button` .
+It also has a **unique** component id, which correlates to the actual component. For example, the **A button** on the Oculus Touch has the **type** `button` , and the **id** `a-button` .
 
 #### Get the components available
 
 To get a list of the components available, use the `getComponentIds` function. This will return an array of strings containing the IDs of the different components in this motion controller:
 
-``` javascript
+```javascript
 const ids = motionController.getComponentIds();
 // ids = ["a-button", "b-button", "xr-standard-trigger", .....]
 ```
@@ -120,21 +123,20 @@ You can also get all of the available components using the `components` public m
 
 #### Get components
 
-To get a component you need to either know its ID or type. When more than one of that type exists, the id would be better.
-The IDs can be found in the profile.
+To get a component you need to either know its ID or type. When more than one of that type exists, the id would be better. The IDs can be found in the profile.
 
 To get a component according to its ID:
 
-``` javascript
+```javascript
 const triggerComponent = motionController.getComponent("xr-standard-trigger");
 if (triggerComponent) {
-    // found, do something with it.
+  // found, do something with it.
 }
 ```
 
 To get a component of a specific type:
 
-``` javascript
+```javascript
 const squeezeComponent = motionController.getComponentOfType("squeeze");
 
 // get the first registered button component
@@ -143,11 +145,11 @@ const buttonComponent = motionController.getComponentOfType("button");
 
 to get all components of a specific type:
 
-``` javascript
+```javascript
 // get all button components
 const buttonComponents = motionController.getAllComponentsOfType("button");
 if (buttonComponents.length) {
-    // some were found
+  // some were found
 }
 ```
 
@@ -155,7 +157,7 @@ if (buttonComponents.length) {
 
 Each controller has a main component, defined by the vendor. In most cases it is the trigger component type that is the main component. To get the main component (as defined in the profile):
 
-``` javascript
+```javascript
 const mainComponent = motionController.getMainComponent();
 // mainComponent always exists!
 ```
@@ -169,43 +171,43 @@ Some types of components also have axes values (like a thumbstick or touchpad). 
 
 To know what the components supports:
 
-``` javascript
+```javascript
 if (component.isButton()) {
-    // we have a value
+  // we have a value
 }
 if (component.isAxes()) {
-    // we have axes data
+  // we have axes data
 }
 ```
 
 To get the component values at the current frame:
 
-``` javascript
+```javascript
 let value = component.value;
 if (value > 0.8) {
-    // do something nice with this value
+  // do something nice with this value
 }
 if (component.pressed) {
-    // the component is pressed, meaning value === 1
+  // the component is pressed, meaning value === 1
 }
 
 if (component.touched) {
-    // fingers are on the component, might be half-pressed or moved
+  // fingers are on the component, might be half-pressed or moved
 }
 ```
 
 To access the axes data:
 
-``` javascript
+```javascript
 let axes = component.axes;
 if (axes.x > 0.8) {
-    // do something nice with the x-axis value
+  // do something nice with the x-axis value
 }
 ```
 
 The component can also return the changes compared to the last frame. Changes are only populated when they exist, otherwise the changes map will be empty:
 
-``` javascript
+```javascript
 // maybe nothing happened between this and last frame
 if (!component.hasChanges) {
     return;
@@ -224,14 +226,14 @@ if (changes.value) {
 
 The components have two observables that can be used to fetch changes (and avoid checking value changes on each frame):
 
-``` javascript
+```javascript
 component.onButtonStateChangedObservable.add((component) => {
-    // something changed, check the changes object
+  // something changed, check the changes object
 });
 
 component.onAxisValueChangedObservable.add((values) => {
-    console.log(values.x, values.y);
-})
+  console.log(values.x, values.y);
+});
 ```
 
 ### How to get a model
@@ -250,18 +252,16 @@ Before the input-profile repository was published, Babylon had support for diffe
 
 Babylon offers local definitions for the following:
 
-* Windows Motion Controllers
-* Oculus touch 1 and 2
-* Vive
-* Generic-Button controller
+- Windows Motion Controllers
+- Oculus Touch 1 and 2
+- Vive
+- Generic-Button controller
 
 To use them, import them to your project, while not forgetting to prioritize them or disable the online repository:
 
-``` javascript
+```javascript
 // import the ones you want to use
-import {
-    WebXRMicrosoftMixedRealityController
-} from '@babylonjs/core/XR/motionController/webXRMicrosoftMixedRealityController';
+import { WebXRMicrosoftMixedRealityController } from "@babylonjs/core/XR/motionController/webXRMicrosoftMixedRealityController";
 
 // prioritize the local classes (but use online if controller not found)
 WebXRMotionControllerManager.PrioritizeOnlineRepository = false;

--- a/content/How_To/camera/Camera_Behaviors.md
+++ b/content/How_To/camera/Camera_Behaviors.md
@@ -1,6 +1,6 @@
 ---
 title: Camera Behaviors
-image: 
+image:
 description: Everything you want to know about camera behaviors.
 keywords: welcome, babylon.js, diving deeper, behaviors, cameras, camera behaviors
 further-reading:
@@ -10,18 +10,18 @@ video-content:
 
 # Applying Camera Behaviors
 
-## Bouncing behavior
+## Bouncing Behavior
 
-The bouncing behavior (`BABYLON.BouncingBehavior`) is designed to produce a small bouncing effect when an **ArcRotateCamera** reaches the lowerRadiusLimit or the upperRadiusLimit.
+The bouncing behavior (`BABYLON.BouncingBehavior`) is designed to produce a small bouncing effect when an `ArcRotateCamera` reaches the `lowerRadiusLimit` or the `upperRadiusLimit`.
 
-The bouncing behavior can be configured using the following properties:
+This behavior can be configured using the following properties:
 
-- `transitionDuration`: Define the duration of the animation, in milliseconds. By default the value is set to 450ms
-- `lowerRadiusTransitionRange`: Define the length of the distance animated by the transition when lower radius is reached. By default the value is set to 2
-- `upperRadiusTransitionRange`: Define the length of the distance animated by the transition when upper radius is reached. By default the value is set to -2
-- `autoTransitionRange`: Define a value indicating if the lowerRadiusTransitionRange and upperRadiusTransitionRange are defined automatically. Transition ranges will be set to 5% of the bounding box diagonal in world space
+- `transitionDuration`: Define the duration of the animation, in milliseconds. The default value is 450ms.
+- `lowerRadiusTransitionRange`: Define the length of the distance animated by the transition when the lower radius is reached. The default value is 2.
+- `upperRadiusTransitionRange`: Define the length of the distance animated by the transition when the upper radius is reached. The default value is -2.
+- `autoTransitionRange`: Define a value indicating if the `lowerRadiusTransitionRange` and `upperRadiusTransitionRange` are defined automatically. Transition ranges will be set to 5% of the bounding box diagonal in world space.
 
-You can easily turn on this behavior on an ArcRotateCamera with the following code:
+To enable this behavior on an `ArcRotateCamera`:
 
 ```javascript
 camera.useBouncingBehavior = true;
@@ -31,7 +31,7 @@ You can find a live demo here: <Playground id="#6FBD14" title="Bouncing Behavior
 
 ## AutoRotation Behavior
 
-The autoRotation behavior (`BABYLON.AutoRotationBehavior`) is designed to create a smooth rotation of an **ArcRotateCamera** when there is no user interaction.
+The autoRotation behavior (`BABYLON.AutoRotationBehavior`) is designed to create a smooth rotation of an `ArcRotateCamera` when there is no user interaction.
 
 This behavior can be configured with the following properties:
 
@@ -40,7 +40,7 @@ This behavior can be configured with the following properties:
 - `idleRotationSpinupTime`: Time (milliseconds) to take to spin up to the full idle rotation speed
 - `zoomStopsAnimation`: Flag that indicates if user zooming should stop animation
 
-You can easily turn on this behavior on an ArcRotateCamera with the following code:
+To enable this behavior on an `ArcRotateCamera`:
 
 ```javascript
 camera.useAutoRotationBehavior = true;
@@ -50,23 +50,22 @@ You can find a live demo here: <Playground id="#6FBD14#1" title="AutoRotation Be
 
 ## Framing Behavior
 
-The framing behavior (`BABYLON.FramingBehavior`) is designed to automatically position an **ArcRotateCamera** when its target is set to a mesh.
-It is also useful if you want to prevent the camera to go under a virtual horizontal plane.
+The framing behavior (`BABYLON.FramingBehavior`) is designed to automatically position an `ArcRotateCamera` when its target is set to a mesh. It is also useful if you want to prevent the camera from going under a virtual horizontal plane.
 
-This behavior can be configured with the following properties:
+This behavior can be configured using the following properties:
 
 - `mode`: The behavior can be configured to:
 - `BABYLON.FramingBehavior.IgnoreBoundsSizeMode`: The camera can move all the way towards the mesh
 - `BABYLON.FramingBehavior.FitFrustumSidesMode`: The camera is not allowed to zoom closer to the mesh than the point at which the adjusted bounding sphere touches the frustum sides
 - `radiusScale`: Define the scale applied to the radius (1 by default)
 - `positionY`: Define the Y offset of the primary mesh from the camera's focus (0 by default)
-- `defaultElevation`: Define the angle above/below the horizontal plane to return to when the return to default elevation idle behaviour is triggered, in radians (0.3 by default)
-- `elevationReturnTime`: Define the time (in milliseconds) taken to return to the default beta position (1500 by default). Negative value indicates camera should not return to default
+- `defaultElevation`: Define the angle above/below the horizontal plane to return to when the return to default elevation idle behavior is triggered, in radians (0.3 by default)
+- `elevationReturnTime`: Define the time (in milliseconds) taken to return to the default beta position (1500 by default). A negative value indicates the camera should not return to the default.
 - `elevationReturnWaitTime`: Define the delay (in milliseconds) taken before the camera returns to the default beta position (1000 by default)
 - `zoomStopsAnimation`: Define if user zooming should stop animation
 - `framingTime`: Define the transition time when framing the mesh, in milliseconds (1500 by default)
 
-You can easily turn on this behavior on an ArcRotateCamera with the following code:
+To enable this behavior on an `ArcRotateCamera`:
 
 ```javascript
 camera.useFramingBehavior = true;

--- a/content/How_To/camera/Customizing_Camera_Inputs.md
+++ b/content/How_To/camera/Customizing_Camera_Inputs.md
@@ -1,16 +1,16 @@
 ---
 title: Customizing Camera Inputs
-image: 
-description: Learn how to custimize input controls for Babylon.js cameras.
+image:
+description: Learn how to customize input controls for Babylon.js cameras.
 keywords: welcome, babylon.js, diving deeper, cameras, input, camera input
 further-reading:
 video-overview:
 video-content:
 ---
 
-## How To Customize Camera Inputs
+## How to Customize Camera Inputs
 
-Every Babylon.js camera will automatically handle inputs for you, once you call the camera's attachControl function. You can revoke the control by using the detachControl function. Most Babylon.js experts use a two-step process to activate and attach a camera:
+Every Babylon.js camera will automatically handle inputs for you, once you call the camera's [attachControl](/typedoc/classes/babylon.freecamera#attachcontrol) method. You can revoke the control by using the [detachControl](/typedoc/classes/babylon.freecamera#detachcontrol) method. Most Babylon.js experts use a two-step process to activate and attach a camera:
 
 ```javascript
 //First, set the scene's activeCamera... to be YOUR camera.
@@ -26,22 +26,16 @@ A simpler version might look like this:
 myCamera.attachControl(canvas);
 ```
 
-By default _noPreventDefault_ is set to false, meaning that preventDefault() is automatically called on all canvas mouse clicks and touch events.
+By default `noPreventDefault` is set to `false`, meaning that `preventDefault()` is automatically called on all canvas mouse clicks and touch events.
 
-Babylon.js v2.4 introduced a different way to manage camera inputs to provide an approach oriented toward composability of inputs.
-You can now use an input manager and each input can be seen as a plugin that is specific to this camera family, and to a given
-input type (mouse, keyboard, gamepad, device orientation, etc.).
+Babylon.js v2.4 introduced a different way to manage camera inputs to provide an approach oriented toward composability of inputs. You can now use an input manager and each input can be seen as a plugin that is specific to this camera family and to a given input type (mouse, keyboard, gamepad, device orientation, etc.).
 
-Using input manager, you can add, remove, enable, or disable any input available for the camera. You can also implement your own input mechanism or override the existing one, very easily.
+Using input managers, you can add, remove, enable, or disable any input available for the camera. You can also easily implement custom input mechanisms or override the existing ones.
 
-The input manager is available through a property called _inputs_, for example
+The input manager is available through the camera's [inputs](/typedoc/classes/babylon.freecamera#inputs) property. For example:
 
 ```javascript
-var camera = new BABYLON.FreeCamera(
-  "sceneCamera",
-  new BABYLON.Vector3(0, 1, -15),
-  scene
-);
+var camera = new BABYLON.FreeCamera("sceneCamera", new BABYLON.Vector3(0, 1, -15), scene);
 var inputManager = camera.inputs;
 ```
 
@@ -52,56 +46,40 @@ Most inputs provide settings to customize the sensibility and adapt it to your o
 Each input provides a short name available on the manager. The goal is to provide a friendly syntax when playing with your inputs.
 
 ```javascript
-var camera = new BABYLON.FreeCamera(
-  "sceneCamera",
-  new BABYLON.Vector3(0, 1, -15),
-  scene
-);
+var camera = new BABYLON.FreeCamera("sceneCamera", new BABYLON.Vector3(0, 1, -15), scene);
 camera.inputs.add(new BABYLON.FreeCameraGamepadInput());
 camera.inputs.attached.gamepad.gamepadAngularSensibility = 250;
 ```
 
 ## Adding an existing input
 
-Input manager of both ArcRotateCamera and FreeCamera expose short-hand functions for adding built-in inputs.
+The input managers of `ArcRotateCamera` and `FreeCamera` expose short-hand functions for adding built-in inputs.
 
 ```javascript
-var camera = new BABYLON.FreeCamera(
-  "sceneCamera",
-  new BABYLON.Vector3(0, 1, -15),
-  scene
-);
+var camera = new BABYLON.FreeCamera("sceneCamera", new BABYLON.Vector3(0, 1, -15), scene);
 camera.inputs.addGamepad();
 ```
 
 If you wish, you can also add an instance of your own input (we will cover how to implement your own input at the end of this article).
 
 ```javascript
-var camera = new BABYLON.FreeCamera(
-  "sceneCamera",
-  new BABYLON.Vector3(0, 1, -15),
-  scene
-);
+var camera = new BABYLON.FreeCamera("sceneCamera", new BABYLON.Vector3(0, 1, -15), scene);
 camera.inputs.add(new BABYLON.FreeCameraGamepadInput());
 ```
 
 ## Enable or disable inputs
 
-When you call "attachControl" on the camera, you are activating all inputs attached to the input manager. In the same way, you could turn off all inputs by calling "detachControl" on the camera.
+When you call `attachControl` on the camera, you are activating all inputs attached to the input manager. In the same way, you could turn off all inputs by calling `detachControl` on the camera.
 
-If you want to disable an input temporarily, you can call "detachControl" directly on the input... like this:
+If you want to disable an input temporarily, you can call `detachControl` directly on the input... like this:
 
 ```javascript
-var camera = new BABYLON.FreeCamera(
-  "sceneCamera",
-  new BABYLON.Vector3(0, 1, -15),
-  scene
-);
+var camera = new BABYLON.FreeCamera("sceneCamera", new BABYLON.Vector3(0, 1, -15), scene);
 camera.inputs.attached.mouse.detachControl();
 camera.inputs.addGamepad();
 ```
 
-You can then call "attachInput" when you want to turn it on again.
+You can then call `attachInput` when you want to turn it on again.
 
 ```javascript
 camera.inputs.attachInput(camera.inputs.attached.mouse);
@@ -109,14 +87,10 @@ camera.inputs.attachInput(camera.inputs.attached.mouse);
 
 ## Removing inputs
 
-Sometimes you want a very specific input mechanism. The best approach in such case is probably to clear all inputs and add only those you may want in your scene.
+Sometimes you want a very specific input mechanism. The best approach in such cases is probably to clear all inputs and add only those you may want in your scene.
 
 ```javascript
-var camera = new BABYLON.FreeCamera(
-  "sceneCamera",
-  new BABYLON.Vector3(0, 1, -15),
-  scene
-);
+var camera = new BABYLON.FreeCamera("sceneCamera", new BABYLON.Vector3(0, 1, -15), scene);
 camera.inputs.clear();
 camera.inputs.addMouse();
 ```
@@ -124,59 +98,56 @@ camera.inputs.addMouse();
 You can also remove a single input from your input manager. You can remove them by instance, or by Type name
 
 ```javascript
-var camera = new BABYLON.FreeCamera(
-  "sceneCamera",
-  new BABYLON.Vector3(0, 1, -15),
-  scene
-);
-//remove by instance
+var camera = new BABYLON.FreeCamera("sceneCamera", new BABYLON.Vector3(0, 1, -15), scene);
+// remove by instance
 camera.inputs.remove(camera.inputs.attached.mouse);
-//remove by type
+// remove by type
 camera.inputs.removeByType("FreeCameraKeyboardMoveInput");
 ```
 
 ## Implementing Your Own Input
 
-Your input method is created as a function object. You must them write code for several methods, with required names, that are called by the input function object. The method names and purpose are
+Your input method is created as a function object. You must then write code for several methods, with required names, that are called by the input function object. The method names and purpose are:
 
 ```javascript
-//This function must return the class name of the camera, it could be used for serializing your scene
+// This function must return the class name of the camera, it could be used for serializing your scene
 getClassName();
 
-//This function must return the simple name that will be injected in the input manager as short hand
-//for example "mouse" will turn into camera.inputs.attached.mouse
+// This function must return the simple name that will be injected in the input manager as short hand
+// for example "mouse" will turn into camera.inputs.attached.mouse
 getSimpleName();
 
-//This function must activate your input event.  Even if your input does not need a DOM element
+//T his function must activate your input event.  Even if your input does not need a DOM element
 // element and noPreventDefault must be present and used as parameter names.
 // Return void.
 attachControl(element, noPreventDefault);
 
-//Detach control must deactivate your input and release all pointers, closures or event listeners
-//element must be present as a parameter name.
+// Detach control must deactivate your input and release all pointers, closures or event listeners
+// element must be present as a parameter name.
 // Return void.
 detachControl(element);
 
-//This optional function will get called for each rendered frame, if you want to synchronize your input to rendering,
-//no need to use requestAnimationFrame. It's a good place for applying calculations if you have to.
+// This optional function will get called for each rendered frame, if you want to synchronize your
+// input to rendering, no need to use requestAnimationFrame. It's a good place for applying
+// calculations if you have to.
 // Return void.
 checkInputs();
 ```
 
 ## With Javascript
 
-This changes the normal use of the keys from moving the camera left and right, forward and back to rotating at its current position.
+This changes the normal key mappings for moving the camera left, right, forward, and back, and rotating at its current position.
 
-First remove the default keyboard input.
+First, remove the default keyboard input.
 
 ```javascript
 camera.inputs.removeByType("FreeCameraKeyboardMoveInput");
 ```
 
-Now create the new input method _FreeCameraKeyboardRotateInput_
+Now create the new input method `FreeCameraKeyboardRotateInput`:
 
 ```javascript
-var FreeCameraKeyboardRotateInput = function() {
+var FreeCameraKeyboardRotateInput = function () {
   this._keys = [];
   this.keysLeft = [37];
   this.keysRight = [39];
@@ -184,33 +155,28 @@ var FreeCameraKeyboardRotateInput = function() {
 };
 ```
 
-Add get name methods
+Add get name methods:
 
 ```javascript
-FreeCameraKeyboardRotateInput.prototype.getClassName = function() {
+FreeCameraKeyboardRotateInput.prototype.getClassName = function () {
   return "FreeCameraKeyboardRotateInput";
 };
-FreeCameraKeyboardRotateInput.prototype.getSimpleName = function() {
+FreeCameraKeyboardRotateInput.prototype.getSimpleName = function () {
   return "keyboardRotate";
 };
 ```
 
-and attach and detach methods
+and attach and detach methods:
 
 ```javascript
-FreeCameraKeyboardRotateInput.prototype.attachControl = function(
-  noPreventDefault
-) {
+FreeCameraKeyboardRotateInput.prototype.attachControl = function (noPreventDefault) {
   var _this = this;
   var engine = this.camera.getEngine();
   var element = engine.getInputElement();
   if (!this._onKeyDown) {
     element.tabIndex = 1;
-    this._onKeyDown = function(evt) {
-      if (
-        _this.keysLeft.indexOf(evt.keyCode) !== -1 ||
-        _this.keysRight.indexOf(evt.keyCode) !== -1
-      ) {
+    this._onKeyDown = function (evt) {
+      if (_this.keysLeft.indexOf(evt.keyCode) !== -1 || _this.keysRight.indexOf(evt.keyCode) !== -1) {
         var index = _this._keys.indexOf(evt.keyCode);
         if (index === -1) {
           _this._keys.push(evt.keyCode);
@@ -220,11 +186,8 @@ FreeCameraKeyboardRotateInput.prototype.attachControl = function(
         }
       }
     };
-    this._onKeyUp = function(evt) {
-      if (
-        _this.keysLeft.indexOf(evt.keyCode) !== -1 ||
-        _this.keysRight.indexOf(evt.keyCode) !== -1
-      ) {
+    this._onKeyUp = function (evt) {
+      if (_this.keysLeft.indexOf(evt.keyCode) !== -1 || _this.keysRight.indexOf(evt.keyCode) !== -1) {
         var index = _this._keys.indexOf(evt.keyCode);
         if (index >= 0) {
           _this._keys.splice(index, 1);
@@ -237,21 +200,17 @@ FreeCameraKeyboardRotateInput.prototype.attachControl = function(
 
     element.addEventListener("keydown", this._onKeyDown, false);
     element.addEventListener("keyup", this._onKeyUp, false);
-    BABYLON.Tools.RegisterTopRootEvents(canvas, [
-      { name: "blur", handler: this._onLostFocus }
-    ]);
+    BABYLON.Tools.RegisterTopRootEvents(canvas, [{ name: "blur", handler: this._onLostFocus }]);
   }
 };
 
-FreeCameraKeyboardRotateInput.prototype.detachControl = function() {
+FreeCameraKeyboardRotateInput.prototype.detachControl = function () {
   var engine = this.camera.getEngine();
   var element = engine.getInputElement();
   if (this._onKeyDown) {
     element.removeEventListener("keydown", this._onKeyDown);
     element.removeEventListener("keyup", this._onKeyUp);
-    BABYLON.Tools.UnregisterTopRootEvents(canvas, [
-      { name: "blur", handler: this._onLostFocus }
-    ]);
+    BABYLON.Tools.UnregisterTopRootEvents(canvas, [{ name: "blur", handler: this._onLostFocus }]);
     this._keys = [];
     this._onKeyDown = null;
     this._onKeyUp = null;
@@ -259,10 +218,10 @@ FreeCameraKeyboardRotateInput.prototype.detachControl = function() {
 };
 ```
 
-Optionally add checking inputs
+Optionally, add checking inputs:
 
 ```javascript
-FreeCameraKeyboardRotateInput.prototype.checkInputs = function() {
+FreeCameraKeyboardRotateInput.prototype.checkInputs = function () {
   if (this._onKeyDown) {
     var camera = this.camera;
     // Keyboard
@@ -278,45 +237,47 @@ FreeCameraKeyboardRotateInput.prototype.checkInputs = function() {
 };
 ```
 
-Finally add this new input method to the camera inputs
+Finally, add this new input method to the camera inputs:
 
 ```javascript
 camera.inputs.add(new FreeCameraKeyboardRotateInput());
 ```
 
-- <Playground id="#KHQBRL" title="Rotate Free Camera Example" description="A simple example of customizing inputs to create a Rotate Free Camera." image=""/>
+<Playground id="#KHQBRL" title="Rotate Free Camera Example" description="A simple example of customizing inputs to create a Rotate Free Camera." image=""/>
 
 ### With Typescript
 
-Using TypeScript, you could implement the interface ICameraInput.
+Using TypeScript, you could implement the interface `ICameraInput`:
 
-```javascript
+```typescript
 interface ICameraInput<TCamera extends BABYLON.Camera> {
-    // the input manager will fill the parent camera
-    camera: TCamera;
+  // the input manager will fill the parent camera
+  camera: TCamera;
 
-    //this function must return the class name of the camera, it could be used for serializing your scene
-    getClassName(): string;
+  //this function must return the class name of the camera, it could be used for serializing your scene
+  getClassName(): string;
 
-    //this function must return the simple name that will be injected in the input manager as short hand
-    //for example "mouse" will turn into camera.inputs.attached.mouse
-    getSimpleName(): string;
+  //this function must return the simple name that will be injected in the input manager as short hand
+  //for example "mouse" will turn into camera.inputs.attached.mouse
+  getSimpleName(): string;
 
-    //this function must activate your input, event if your input does not need a DOM element
-    attachControl: (element: HTMLElement, noPreventDefault?: boolean) => void;
+  //this function must activate your input, event if your input does not need a DOM element
+  attachControl: (element: HTMLElement, noPreventDefault?: boolean) => void;
 
-    //detach control must deactivate your input and release all pointers, closures or event listeners
-    detachControl: (element: HTMLElement) => void;
+  //detach control must deactivate your input and release all pointers, closures or event listeners
+  detachControl: (element: HTMLElement) => void;
 
-    //this optional function will get called for each rendered frame, if you want to synchronize your input to rendering,
-    //no need to use requestAnimationFrame. It's a good place for applying calculations if you have to
-    checkInputs?: () => void;
+  //this optional function will get called for each rendered frame, if you want to synchronize your input to rendering,
+  //no need to use requestAnimationFrame. It's a good place for applying calculations if you have to
+  checkInputs?: () => void;
 }
 ```
-## How to Make a Walk and Look Around Camera
-The following example customizes the keyboard and mouse inputs to a universal camera. With this change, using the arrow keys you can walk forwards and backwards in the scene and rotate to look left and right. Using the mouse you can look around and above and below. 
 
-In the example there are two viewports, the upper one gives a first person view as you move and look around. The lower one gives a representation of the camera and the collision volume surrounding it.
+## How to Make a Walk and Look Around Camera
+
+The following example customizes the keyboard and mouse inputs to a universal camera. With this change, using the arrow keys you can walk forwards and backward in the scene and rotate to look left and right. Using the mouse you can look around and above and below.
+
+In the example there are two viewports, the upper one gives a first-person view as you move and look around. The lower one gives a representation of the camera and the collision volume surrounding it.
 
 Remember to click on the scene before using the arrow keys.
 

--- a/content/How_To/camera/How_to_use_Multi-Views.md
+++ b/content/How_To/camera/How_to_use_Multi-Views.md
@@ -1,20 +1,20 @@
 ---
 title: MultiViews Part 2
-image: 
-description: Continue learning how to leverage multiviews in Babylon.js.
+image:
+description: Continue learning how to leverage multi-views in Babylon.js.
 keywords: welcome, babylon.js, diving deeper, multiview
 further-reading:
 video-overview:
 video-content:
 ---
 
-## How To Use Multi Views
+## How to use Multi-Views
 
-Babylon.js is able to render multi views of the same scene.
+Babylon.js can render multiple views of the same scene.
 
 ## Active cameras
 
-Basically, a scene has a `scene.activeCamera` property to define the point of view. But you can also define many active cameras with the following code:
+A scene has an [activeCamera](/typedoc/classes/babylon.scene#activecamera) property to define the point of view. But you can define many active cameras using code like this:
 
 ```javascript
 scene.activeCameras.push(camera);
@@ -36,6 +36,6 @@ A viewport is defined by the following constructor:
 BABYLON.Viewport = function (x, y, width, height);
 ```
 
-where x, y, are the lower left hand corner of the viewport followed by its width and height. Values for x, y, width and height are given as a number between 0 and 1 representing a fraction of the screen width and height respectively.
+where x, y, are the lower lefthand corner of the viewport followed by its width and height. Values for x, y, width, and height are numbers between 0 and 1 representing the fraction of the screen width and height, respectively.
 
-- <Playground id="#4JXV32" title="Viewport Example" description="A simple example of constructing a viewport." image="/img/playgroundsAndNMEs/divingDeeperMultiviews3.jpg"/>
+<Playground id="#4JXV32" title="Viewport Example" description="A simple example of constructing a viewport." image="/img/playgroundsAndNMEs/divingDeeperMultiviews3.jpg"/>

--- a/content/How_To/camera/Layermasks_and_Multi-Cam_Textures.md
+++ b/content/How_To/camera/Layermasks_and_Multi-Cam_Textures.md
@@ -1,6 +1,6 @@
 ---
 title: Layer Masks and Multi-Cam Textures
-image: 
+image:
 description: Learn how to assign different objects to different layer masks.
 keywords: welcome, babylon.js, diving deeper, layer masks, multi-cam
 further-reading:
@@ -8,9 +8,9 @@ video-overview:
 video-content:
 ---
 
-# How To Use Layermasks and Multi-Camera Textures
+# How to use Layer Masks and Multi-Camera Textures
 
-## Different meshes for multiple cameras using Layermasks
+## Different meshes for multiple cameras using layer masks
 
 A `layerMask` is a number assigned to each mesh and camera. It is used at the bit level to indicate whether lights and cameras should shine-upon or show the mesh. The default value, 0x0FFFFFFF, will cause the mesh to be illuminated and shown by any stock light and camera.
 
@@ -58,7 +58,7 @@ var light = new BABYLON.Light(...);
 light.includeOnlyWithLayerMask = 0x10000000;
 ```
 
-Finally, if there may be more lights generated later, you can register a call-back whenever a light is added:
+Finally, if there may be more lights generated later, you can register a call-back when a light is added:
 
 ```javascript
 scene.onNewLightAdded = onNewLight;
@@ -67,27 +67,23 @@ scene.onNewLightAdded = onNewLight;
 This could be:
 
 ```javascript
-onNewLight = function(newLight, positionInArray, scene) {
+onNewLight = function (newLight, positionInArray, scene) {
   newLight.excludeWithLayerMask = 0x10000000;
 };
 ```
 
 ## Gun Sight Crosshair Example
 
-Here is a simple example of using a 2nd orthographic camera which shows a gun sight. To keep it simple, emissive material was used to avoid lighting it. Just copy and paste it into any scene, then call it. The `layerMask` chosen also allows Babylon's Dialog extension to inter-operate. Perhaps these could be combined to do a heads-up tank sight with range finder.
+Here is a simple example of using a 2nd orthographic camera that shows a gun sight. To keep it simple, emissive material was used to avoid lighting it. Just copy and paste it into any scene, then call it. The `layerMask` chosen also allows Babylon's Dialog extension to inter-operate. Perhaps these could be combined to do a heads-up tank sight with a rangefinder.
 
-A commercial quality implementation would probably not use `CreateBox()`, since it creates depth faces that cannot be seen straight-on anyway. It should also take into account a window size change, unless it is a tablet app.
+A commercial-quality implementation would probably not use `CreateBox()`, since it creates depth faces that cannot be seen straight-on anyway. It should also take into account a window size change unless it is a tablet app.
 
 ```javascript
 function addGunSight(scene) {
   if (scene.activeCameras.length === 0) {
     scene.activeCameras.push(scene.activeCamera);
   }
-  var secondCamera = new BABYLON.FreeCamera(
-    "GunSightCamera",
-    new BABYLON.Vector3(0, 0, -50),
-    scene
-  );
+  var secondCamera = new BABYLON.FreeCamera("GunSightCamera", new BABYLON.Vector3(0, 0, -50), scene);
   secondCamera.mode = BABYLON.Camera.ORTHOGRAPHIC_CAMERA;
   secondCamera.layerMask = 0x20000000;
   scene.activeCameras.push(secondCamera);
@@ -139,8 +135,8 @@ function addGunSight(scene) {
 }
 ```
 
-See it in action here: <Playground id="#JU1DZP" title="Gun Sight Crosshair Example" description="A simple example of creating a gun sight crosshair using layermasks and two cameras." image="/img/playgroundsAndNMEs/divingDeeperLayerMasks1.jpg"/>
+See it in action here: <Playground id="#JU1DZP" title="Gun Sight Crosshair Example" description="A simple example of creating a gun sight crosshair using layer masks and two cameras." image="/img/playgroundsAndNMEs/divingDeeperLayerMasks1.jpg"/>
 
 Using the information here and combining it with the viewport information from the previous [section](/divingDeeper/cameras/multiViewsPart2), we can create a more complex example that includes the option to omit meshes from specific cameras.
 
-- <Playground id="#L92PHY#36" title="Picture in Picture Visual Camera" description="Using layer masks and viewports, show a visual representation of camera movement." image="/img/playgroundsAndNMEs/pipcamera.png"/>
+<Playground id="#L92PHY#36" title="Picture in Picture Visual Camera" description="Using layer masks and viewports, show a visual representation of camera movement." image="/img/playgroundsAndNMEs/pipcamera.png"/>

--- a/content/How_To/camera/Multiview.md
+++ b/content/How_To/camera/Multiview.md
@@ -1,7 +1,7 @@
 ---
 title: MultiViews Part 1
-image: 
-description: Learn how to leverage multiviews in Babylon.js.
+image:
+description: Learn how to leverage multi-views in Babylon.js.
 keywords: welcome, babylon.js, diving deeper, multiview
 further-reading:
 video-overview:
@@ -14,40 +14,34 @@ video-content:
 
 The [WebGL Multiview extension](https://www.khronos.org/registry/webgl/extensions/OVR_multiview2/) allows rendering multiple views (eg. each eye for VR scenarios) in a single render pass. This can make rendering around 1.5 to 2.0 times faster.
 
-Currently, Multiview is not supported in all browsers. If its supported the multiview capability should be present.
+Multiview is not currently supported in all browsers. If it is supported, the multiview capability should be present.
 
 ```javascript
-scene.getEngine().getCaps().multiview
+scene.getEngine().getCaps().multiview;
 ```
 
-**Note:** Multiview rendering renders to a texture array instead of a standard texture. This may be unexpected issues when applying postprocessing with custom shaders, effects or postprocessing. (e.g. highlight layer will have no effect)
+**Note:** Multiview rendering renders to a texture array instead of a standard texture. This may cause unexpected issues when applying postprocessing with custom shaders, effects, or postprocessing (_e.g._, the highlight layer will have no effect).
 
-## Using with the VRExperienceHelper
+## Using with VRExperienceHelper
 
-Multiview can be enabled by setting the useMultiview option to true.
+Multiview can be enabled by setting the `useMultiview` option to `true`.
 
 ```javascript
-scene.createDefaultVRExperience({useMultiview: true});
+scene.createDefaultVRExperience({ useMultiview: true });
 ```
 
-- <Playground id="#SRV2A0" title="VR Experience Multiview Example" description="A simple example of using multiviews for a VR experience." image="/img/playgroundsAndNMEs/divingDeeperMultiviews1.jpg"/>
+<Playground id="#SRV2A0" title="VR Experience Multiview Example" description="A simple example of using multiviews for a VR experience." image="/img/playgroundsAndNMEs/divingDeeperMultiviews1.jpg"/>
 
-## Using with VRDeviceOrientationFreeCamera to display to screen
+## Using with VRDeviceOrientationFreeCamera to display on the screen
 
-Enable through the option in the VRCameraMetrics object:
+Enable through the option in the [VRCameraMetrics](/typedoc/classes/babylon.vrcamerametrics) object:
 
 ```javascript
 // Enable multiview
 var multiviewMetrics = BABYLON.VRCameraMetrics.GetDefault();
 multiviewMetrics.multiviewEnabled = true;
 // Create camera
-var multiviewCamera = new BABYLON.VRDeviceOrientationFreeCamera(
-  "",
-  new BABYLON.Vector3(-10, 5, 0),
-  scene,
-  undefined,
-  multiviewMetrics
-);
+var multiviewCamera = new BABYLON.VRDeviceOrientationFreeCamera("", new BABYLON.Vector3(-10, 5, 0), scene, undefined, multiviewMetrics);
 ```
 
-- <Playground id="#EZDZZV" title="VRDeviceOrientationFreeCamera Multiview Example" description="A simple example of using multiviews to create a VRDeviceOrientationFreeCamera." image="/img/playgroundsAndNMEs/divingDeeperMultiviews2.jpg"/>
+<Playground id="#EZDZZV" title="VRDeviceOrientationFreeCamera Multiview Example" description="A simple example of using multiviews to create a VRDeviceOrientationFreeCamera." image="/img/playgroundsAndNMEs/divingDeeperMultiviews2.jpg"/>

--- a/content/How_To/camera/WebVR_Camera.md
+++ b/content/How_To/camera/WebVR_Camera.md
@@ -1,6 +1,6 @@
 ---
 title: WebVR Camera
-image: 
+image:
 description: Learn how to create a VR scene with the WebVR Camera.
 keywords: welcome, babylon.js, diving deeper, WebVR, WebVR Camera, vr
 further-reading:
@@ -14,56 +14,59 @@ While the WebVR camera will continue to be supported, **it is strongly recommend
 
 ## Introduction
 
-Since v2.5 Babylon.js supports WebVR using the WebVRFreeCamera.
+Since v2.5, Babylon.js supports WebVR using the `WebVRFreeCamera` camera.
 
-In Babylon v3.0 we fully support the WebVR 1.1 specifications (https://w3c.github.io/webvr/) which is supported by the latest version of Microsoft Edge, Chromium and Firefox.
+As of Babylon v3.0, we fully support the WebVR 1.1 specifications (https://w3c.github.io/webvr/), which is supported by the latest version of Microsoft Edge, Chrome, and Firefox.
 
-The WebVR camera is Babylon's simple interface to interaction with Windows Mixed Reality, HTC Vive, Oculus Rift, Google Daydream and Samsung GearVR.
+The WebVR camera is Babylon's simple interface to interaction with Windows Mixed Reality, HTC Vive, Oculus Rift, Google Daydream, and Samsung GearVR.
 
-Babylon.js also supports the VR devices' controllers - The Windows Mixed Reality controllers, HTC Vive's controllers, the Oculus touch, GearVR controller and Daydream controller - using the gamepad extension. Further details below.
+Babylon.js also supports the VR devices' controllers - The Windows Mixed Reality controllers, HTC Vive's controllers, the Oculus Touch, GearVR controller, and Daydream controller - using the gamepad extension. Further details below.
 
-To quickly get started creating WebVR scene the [WebVR Experience Helper](/divingDeeper/cameras/webVRHelper) class can be used to automatically setup the WebVR camera and enable other features such as teleportation out of the box.
+To quickly get started creating a WebVR scene, the [WebVR Experience Helper](/divingDeeper/cameras/webVRHelper) class can be used to automatically setup the WebVR camera and enable other features such as teleportation out of the box.
 
 ## Browser support
 
 ### WebVR
 
-WebVR 1.1 is enabled in specific versions of Microsoft Edge, Chromium and Firefox. To get constant status updates, please visit WebVR rocks at https://webvr.rocks/ . We support any browser that implements WebVR 1.1.
+WebVR 1.1 is enabled in specific versions of Microsoft Edge, Chrome, and Firefox. To get constant status updates, please visit WebVR Rocks at https://webvr.rocks/ . We support any browser that implements WebVR 1.1.
 
 ### WebVR controllers
 
-The WebVR controllers are offered in browsers that support the WebVR gamepad extensions - https://w3c.github.io/gamepad/extensions.html . In Chromium you must enable this API in chrome://flags in order to get it working. Make sure to visit https://mozvr.com/ for full installation instructions.
+The WebVR controllers are offered in browsers that support the WebVR gamepad extensions - https://w3c.github.io/gamepad/extensions.html .
 
 ## The WebVRFreeCamera class
 
 ### Getting started
 
-The WebVRFreeCamera is being initialized the same as a standard free camera:
+The `WebVRFreeCamera` is initialized the same as a standard free camera:
 
-`var camera = new BABYLON.WebVRFreeCamera("camera1", new BABYLON.Vector3(0, 0, 0), scene);`
+```javascript
+var camera = new BABYLON.WebVRFreeCamera("camera1", new BABYLON.Vector3(0, 0, 0), scene);
+```
 
 This will initialize a new WebVR camera and will enable WebVR in the engine.
 
 Just like any other camera, to get the camera working correctly with user input and interactions, we will need to attach the camera (and the VR device) to the canvas and the scene. To do that we use the same method we know from the free camera:
 
-`camera.attachControl(canvas, true);`
+```javascript
+camera.attachControl(canvas, true);
+```
 
-Most browsers only support attaching the VR device to the scene during a user interaction (a mouse click, for example). To get that working correctly, a simple solution would be:
+Most browsers only support attaching the VR device to the scene during user interaction (a mouse click, for example). To get that working correctly, a simple solution would be:
 
 ```javascript
-scene.onPointerDown = function() {
+scene.onPointerDown = function () {
   scene.onPointerDown = undefined;
   camera.attachControl(canvas, true);
 };
 ```
 
-What it does is attach control once the user click on the canvas, and disables the onPointerDown callback.
+What it does is attach control once the user clicks on the canvas, and disables the `onPointerDown` callback.
 
-This can be done with an HTML or a Canvas2D button as well, and using vanilla javascript event listeners. Any intentional user interaction is allowed. A mouse-move event will not trigger it, so don't bother trying. A simple example would be:
+This can be done with an HTML or a Canvas2D button as well, and using vanilla JavaScript event listeners. Any intentional user interaction is allowed. A mouse-move event will not trigger it. A simple example would be:
 
 ```javascript
 // after creating a button with vrButton as ID:
-
 let button = document.getElementById("vrButton");
 
 function attachWebVR() {
@@ -74,21 +77,21 @@ function attachWebVR() {
 button.addEventListener("click", attachWebVR, false);
 ```
 
-Don't forget to remove the event listener, other wise any click on the button will trigger the attach function. It won't attach again, but it a waste of function calls and is not needed.
+Don't forget to remove the event listener, otherwise any click on the button will trigger the attach function. It won't attach again, but it will result in unnecessary function calls.
 
 You should now be able to see your scene in the WebVR device. If not, go to troubleshooting!
 
 ### Extra WebVR transformation (Pose data)
 
-The WebVR camera is an extended FreeCamera. Apart from all of the abilities a standard FreeCamera has, the WebVR camera has 2 major extensions - an extra position and an extra rotation, which are the pose data broadcasted by the VR device connected to the browser. This means that the camera has actually two transformation - one is controlled by you, and the other by the device. They are accumulated - position is being added and rotation multiplied - in order to combine the developer's input and the VR device's pose data.
+The WebVR camera is an extended `FreeCamera`. Apart from all of the abilities a standard `FreeCamera` has, the WebVR camera has 2 major extensions - an extra position and an extra rotation, which are the pose data broadcasted by the VR device connected to the browser. This means the camera has actually two transformations - one is controlled by you, and the other by the device. They are accumulated - position is being added and rotation multiplied - in order to combine the developer's input and the VR device's pose data.
 
-To understand that think of your head and your body. Without moving your body, your head can move in all directions, and rotate in all directions. The WebVR device is your head. Your body is the regular position and rotationQuaternion we all know and love. If you rotate your body, the head rotates with it. But if you move the head, the body stays in the same position.
+To understand that think of your head and your body. Without moving your body, your head can move in all directions, and rotate in all directions. The WebVR device is your head. Your body is the regular position and `rotationQuaternion` we all know and love. If you rotate your body, the head rotates with it. But if you move the head, the body stays in the same position.
 
 This is exactly how you should see the WebVR extra transformation - your head position is set by the VR device (and cannot be interfered with). Your body (or position in the world) is fully controlled by you.
 
 This allows you to use the same code you use for a game based on the FreeCamera with the WebVR camera. the only difference is that the user will have the ability to rotate the camera locally using the VR device and not the mouse.
 
-This also allows the WebVR to be controlled by the same input devices that control the FreeCamera - keyboard, mouse (with rotation exception), XBOX controller and so on.
+This also allows the WebVR to be controlled by the same input devices that control the FreeCamera - keyboard, mouse (with rotation exception), Xbox controller and so on.
 
 ### Resetting the device's rotation
 
@@ -96,12 +99,12 @@ The device's "front" position is set by the device itself (it is set during the 
 
 `camera.resetToCurrentRotation()`.
 
-This will set the current Y axis (and Y axis direction only!!) to be the current front rotation of the user.
+This will set the current Y-axis (and Y-axis direction only!!) to be the current front rotation of the user.
 
 ### Low level fun
 
-- If you want to use the vrDevice directly, it is exposed using `camera._vrDevice`, a public hidden member in the camera.
-- If you want to use the raw pose data (Right handed data!), it is exposed at `camera.rawPose`. The rawPose has the following interface (a dream for physics lovers!):
+- If you want to use the `vrDevice` directly, it is exposed using `camera._vrDevice`, a public hidden member in the camera.
+- If you want to use the raw pose data (righthanded data!), it is exposed at `camera.rawPose`. The `rawPose` has the following interface (a dream for physics lovers!):
 
 ```javascript
 export interface DevicePose {
@@ -115,7 +118,7 @@ export interface DevicePose {
 }
 ```
 
-Note: Raw pose values are not modified based on the webVRCamera's rotation or position. To reference modified position and rotation in Babylon space, use the devicePosition and deviceRotationQuaternion fields.
+Note: Raw pose values are not modified based on the `webVRCamera`'s rotation or position. To reference modified position and rotation in Babylon space, use the `devicePosition` and `deviceRotationQuaternion` fields.
 
 ```javascript
 webVRCamera.devicePosition;
@@ -126,29 +129,29 @@ webVRCamera.leftController.deviceRotationQuaternion;
 
 ## The Gamepad Extensions support (WebVR controllers)
 
-Each VR device currently available (Windows Mixed Reality, Oculus Rift, Vive, Daydream and GearVR) has controllers that complement its usage. Windows Mixed Reality controllers, Vive controllers, Oculus touch controllers, Daydream Controller and GearVR Controller are supported by using the gamepad extensions.
+Each VR device currently available (Windows Mixed Reality, Oculus Rift, Vive, Daydream, and GearVR) has controllers that complement its usage. Windows Mixed Reality controllers, Vive controllers, Oculus Touch controllers, Daydream Controller, and GearVR Controller are supported by using the gamepad extensions.
 
 ### Init controllers
 
-During the WebVRFreeCamera initialization it will attempt to attach the controllers and detect them if found. If found, the controllers will be located at `camera.controllers` which is an array that will either have a length of 2 or 0 (GearVR and Daydream support only 1 controller). If the controllers are attached and were not detected, you could also try to manually call `camera.initControllers()` at a future time.
+During the WebVRFreeCamera initialization, it will attempt to attach the controllers and detect them if found. If found, the controllers will be located at `camera.controllers` which is an array that will either have a length of 2 or 0 (GearVR and Daydream support only 1 controller). If the controllers are attached and were not detected, you could also try to manually call `camera.initControllers()` at a future time.
 
 To fire a callback when the controllers are found you can use the optional `camera.onControllersAttached` callback:
 
 ```javascript
-onControllersAttached = function(controllers) {
+onControllersAttached = function (controllers) {
   console.log(controllers.length === 2); // outputs true;
 };
 ```
 
-Initializing the controllers using the camera will also attach them to the camera, which will allow moving the controllers together with the WebVR camera, if moved by the user.
+Initializing the controllers using the camera will also attach them to the camera. This will allow moving the controllers with the WebVR camera as the user moves them.
 
 ### Using the controllers
 
-There are a few high level implementations that are automatically assigned to a WebVR controller:
+There are a few high-level implementations that are automatically assigned to a WebVR controller:
 
 `WindowsMotionController` for the Windows Mixed Reality controllers.
 
-`OculusTouchController` for the Oculus touch.
+`OculusTouchController` for the Oculus Touch.
 
 `ViveController` for the Vive controllers.
 
@@ -158,42 +161,42 @@ There are a few high level implementations that are automatically assigned to a 
 
 each extends the `WebVRController` class, which extends the `PoseEnabledController`.
 
-To cut a long story short - Each controller is assigned the same set of functions, with the only different being the button mappings. The type of the device can be retrieved using `controller.controllerType`, which has the following values:
+To make a long story short, each controller has the same set of functions, the only difference being the button mappings. The device type can be retrieved using `controller.controllerType`, which has the following values:
 
-```javascript
-export enum PoseEnabledControllerType {
-    VIVE,
-    OCULUS,
-    WINDOWS,
-    GEAR_VR,
-    DAYDREAM,
-    GENERIC
+```typescript
+enum PoseEnabledControllerType {
+  VIVE,
+  OCULUS,
+  WINDOWS,
+  GEAR_VR,
+  DAYDREAM,
+  GENERIC,
 }
 ```
 
-This enum will be extended when needed.
+This enum will be extended as needed.
 
 ### Controller button mapping
 
 A controller button has the following set of data:
 
-```javascript
+```typescript
 interface ExtendedGamepadButton extends GamepadButton {
-    readonly pressed: boolean;
-    readonly touched: boolean;
-    readonly value: number;
+  readonly pressed: boolean;
+  readonly touched: boolean;
+  readonly value: number;
 }
 ```
 
-These values will be sent to the observers of any specific button when either on of them was changed.
+These values will be sent to the observers of any specific button when either one of them was changed.
 
-The controllers also have Axes-data, which can be compared to the stick value of an x-box controller. They consist of a 2D vector (with x and y values). Stick values (SHOULD BE) are between -1, -1 and 1, 1, with 0,0 being the default value.
+The controllers also have Axes-data, which can be compared to the stick value of an Xbox controller. They consist of a 2D vector (with x and y values). Stick values (SHOULD BE) are between -1, -1 and 1, 1, with 0,0 being the default value.
 
 - Not all buttons of each controller support all 3 values, but all 3 will always be provided. For example, the Vive's trigger doesn't support "touched", which will always be false, but will send the value data when pressed (a percentage of the press from 0 to 1).
 - Having a value does not automatically mean that "pressed" is set to true. The oculus controllers, for example, will only set the trigger's "pressed" to true when the value exceeds 0.15 (15% pressed).
 - The controllers have a "hand" assigned to them, which is a string, either "left" or "right". This can be found at controller.hand .
 
-**Abstract mapping**
+#### Abstract mapping
 
 The following observables exist on all types of WebVR controllers, in case you wish to develop an abstract solution to all VR devices and not focus on a specific device:
 
@@ -207,59 +210,59 @@ To use any of them, simple register a new function with the desired observable.
 For example, to monitor the trigger and observe pad value changes:
 
 ```javascript
-controller.onPadValuesChangedObservable.add(function(stateObject) {
+controller.onPadValuesChangedObservable.add(function (stateObject) {
   console.log(stateObject); // {x: 0.1, y: -0.3}
 });
-controller.onTriggerStateChangedObservable.add(function(stateObject) {
+controller.onTriggerStateChangedObservable.add(function (stateObject) {
   let value = stateObject.value;
   console.log(value);
 });
 ```
 
-**Windows Mixed Reality Controller mapping**
+#### Windows Mixed Reality Controller mapping
 
 The Windows Mixed Reality controller supports:
 
-1. Thumb stick axis - axis values. Mapped to `onPadValuesChangedObservable`.
-2. Thumb stick press - pressed. Mapped to `onPadStateChangedObservable`.
+1. Thumbstick axis - axis values. Mapped to `onPadValuesChangedObservable`.
+2. Thumbstick press - pressed. Mapped to `onPadStateChangedObservable`.
 3. Touchpad axis - axis values. Mapped to `onTouchpadValuesChangedObservable` and `onTrackpadValuesChangedObservable` (aliases).
 4. Touchpad press - pressed and touch. Mapped to `onTouchpadButtonStateChangedObservable` and `onTrackpadChangedObservable` (aliases).
 5. Trigger - pressed and value. Mapped to `onTriggerStateChangedObservable`
 6. Grip button - pressed. Mapped to `onMainButtonStateChangedObservable` and `onGripButtonStateChangedObservable` (aliases)
 7. Menu button - pressed. Mapped to `onSecondaryButtonStateChangedObservable` and `onMenuButtonStateChangedObservable` (aliases).
 
-**Vive Controller mapping**
+#### Vive Controller mapping
 
-The vive supports:
+The Vive supports:
 
-1. touchpad - pressed, touch and axis values. Mapped to `onPadStateChangedObservable`
-2. trigger - pressed and value. Mapped to `onTriggerStateChangedObservable`
-3. left AND right buttons together (!) - touched, pressed. Mapped to `onMainButtonStateChangedObservable`, `onRightButtonStateChangedObservable` and `onLeftButtonStateChangedObservable` (aliases to the same observable object!);
-4. menu button - touched, pressed. Mapped to `onSecondaryButtonStateChangedObservable` and `onMenuButtonStateChangedObservable` (aliases).
+1. Touchpad - pressed, touch and axis values. Mapped to `onPadStateChangedObservable`
+2. Trigger - pressed and value. Mapped to `onTriggerStateChangedObservable`
+3. Left AND right buttons together (!) - touched, pressed. Mapped to `onMainButtonStateChangedObservable`, `onRightButtonStateChangedObservable` and `onLeftButtonStateChangedObservable` (aliases to the same observable object!);
+4. Menu button - touched, pressed. Mapped to `onSecondaryButtonStateChangedObservable` and `onMenuButtonStateChangedObservable` (aliases).
 
-**Oculus touch mapping**
+#### Oculus Touch mapping
 
-The oculus touch supports 6 different buttons:
+The Oculus Touch supports 6 buttons:
 
-1. Thumb stick - touch, press, value = pressed (0,1). Mapped to `onPadStateChangedObservable`.
+1. Thumbstick - touch, press, value = pressed (0,1). Mapped to `onPadStateChangedObservable`.
 2. Index trigger - touch (?), press (only when value > 0.1). Mapped to `onTriggerStateChangedObservable`.
 3. Secondary trigger (same). Mapped to `onSecondaryTriggerStateChangedObservable`.
 4. A (right) X (left) - touch, pressed = value. Mapped to `onMainButtonStateChangedObservable`, `onAButtonStateChangedObservable` on the right hand and `onXButtonStateChangedObservable` on the left hand.
 5. B / Y - touch, pressed = value. Mapped to `onSecondaryButtonStateChangedObservable`, `onBButtonStateChangedObservable` on the right hand and `onYButtonStateChangedObservable` on the left hand.
 6. thumb rest. Mapped to `onThumbRestChangedObservable` .
 
-**Gear VR Controller mapping**
+#### Gear VR Controller mapping
 
 The Gear VR controller supports:
 
-1. trackpad - pressed, touch and axis values. Mapped to `onPadValuesChangedObservable` and `onTrackpadChangedObservable`
-2. trigger - pressed and values. Mapped to `onTriggerStateChangedObservable`
+1. Trackpad - pressed, touch, and axis values. Mapped to `onPadValuesChangedObservable` and `onTrackpadChangedObservable`
+2. Trigger - pressed and values. Mapped to `onTriggerStateChangedObservable`
 
-**Google Daydream Controller mapping**
+#### Google Daydream Controller mapping\*
 
 The Google Daydream controller supports:
 
-1. touchpad - pressed, touch and axis values. Mapped to `onPadValuesChangedObservable` and `onTriggerStateChangedObservable`
+1. Touchpad - pressed, touch and axis values. Mapped to `onPadValuesChangedObservable` and `onTriggerStateChangedObservable`
 
 note: The Daydream controller home and app buttons are not mapped in WebVR.
 
@@ -283,14 +286,14 @@ scene.createDefaultVRExperience({ controllerMeshes: true });
 
 ### Low level
 
-**Controllers without WebVR camera**
+### Controllers without WebVR camera
 
 The controllers can also be initialized without using a WebVR camera, which means - you can use them to control your regular WebGL game or 3D application.
 
 To do that, simply initialize the Gamepads Class:
 
 ```javascript
-new BABYLON.Gamepads(gp => {
+new BABYLON.Gamepads((gp) => {
   if (gp.type === BABYLON.Gamepad.POSE_ENABLED) {
     // Do something with the controller!
   }
@@ -299,20 +302,19 @@ new BABYLON.Gamepads(gp => {
 
 Note that the position will be relative to the initial VR Device that is related to those controllers.
 
-**Pose data**
+### Pose data
 
-Just like the WebVR camera, the controllers export their (right handed!!) raw pose data. The data is updated each frame at `controller.rawPose`.
+Just like the WebVR camera, the controllers export their (right-handed!) raw pose data. The data is updated each frame at `controller.rawPose`.
 
-## A few notes
+## Notes
 
 - The WebVR camera supports both left-handed systems and right-handed systems.
-- When using the oculus rift, pay attention that the oculus controller (this little )
 - To further read about WebVR try https://mozvr.com/ .
 
 ## Examples
 
-- <Playground id="G46RP6#2" title="VR Helmet Example" description="A simple example of how to leverage the WebVRFreeCamera." image=""/>
-- <Playground id="#5MV04" title="Basic VR Scene" description="A simple example of a basic VR scene." image=""/>
+<Playground id="G46RP6#2" title="VR Helmet Example" description="A simple example of how to leverage the WebVRFreeCamera." image=""/>
+<Playground id="#5MV04" title="Basic VR Scene" description="A simple example of a basic VR scene." image=""/>
 
 Enjoy!
 
@@ -323,21 +325,21 @@ Enjoy!
   Seems like a very common problem - a WebVRFreeCamera class is initialized, but you can't see a thing in the device.
 
   1. Check the console - Are you seeing any errors? COuld it be that WebVR is not supported on your browser?
-  2. in your console type `navigator.getVRDevices().then((vrs) => {console.log(vrs.length)})` . If you got 0 or an error, the device is not properly connected.
-  3. If using oculus rift - did you enable "unknown sources" in the oculus rift settings?
+  2. In your console, type `navigator.getVRDevices().then((vrs) => {console.log(vrs.length)})`. If you got 0 or an error, the device is not properly connected.
+  3. If you are using Oculus Rift, did you enable "unknown sources" in the Oculus Rift settings?
   4. Try following the instructions in https://mozvr.com/ . Does the camera work there?
 
-- The camera's rotation is changing, but i can't see a thing in my display
+- The camera's rotation is changing, but I can't see anything in my display
 
-  This error occurs when you didn't attach control to the VR device.
+  This error occurs when you didn't attach a control to the VR device.
 
-  1. Make sure that attach control is called inside a user-interaction callback. Chrome will not allow broadcasting to the VR device without user consent.
+  1. Make sure that `attachControl` is called inside a user-interaction callback. Chrome will not allow broadcasting to the VR device without user consent.
 
 - My (Vive) controllers are not detected!! HELP!!!!
 
   Ah, I know this problem.
 
-  1. Try pressing the left and right buttons of the vive controller, or the pad button of the oculus touch. This should turn them on and make them visible.
+  1. Try pressing the left and right buttons of the Vive controller, or the pad button of the Oculus Touch. This should turn them on and make them visible.
   2. Make sure you called `camera.initControllers()` !
   3. open your console, search for errors.
   4. type `navigator.getGamepads()` in your console. Is the list empty? are there controllers in the list? what controllers?
@@ -345,4 +347,4 @@ Enjoy!
 
 - Gear VR or Daydream controller models are not showing
 
-  These are 3 DoF devices (no position). The models positions aren't yet determined, but you have the rays from controller orientation and functional trigger buttons.
+  These are 3 DoF devices (no position). The model's positions aren't yet determined, but you have the rays from controller orientation and functional trigger buttons.

--- a/content/How_To/camera/camera_introduction.md
+++ b/content/How_To/camera/camera_introduction.md
@@ -1,45 +1,45 @@
 ---
 title: Camera Introduction
-image: 
+image:
 description: Introduction to the different camera types in Babylon.js.
 keywords: welcome, babylon.js, diving deeper, cameras, intro
 further-reading:
-    - title: Cameras Overview
-      url: /divingDeeper/cameras
+  - title: Cameras Overview
+    url: /divingDeeper/cameras
 video-overview:
 video-content:
 ---
 
 ## Cameras
 
-Of the many cameras available in Babylon.js the two most used are probably - the Universal Camera used for First Person Movement and the Arc Rotate Camera which is an orbital camera. Though with the advent of WebVR this may change.
+Of the many cameras available in Babylon.js, the two most used are probably the [Universal Camera](/typedoc/classes/babylon.universalcamera), used for "first-person" movement, [ArcRotateCamera](/typedoc/classes/babylon.arcrotatecamera), an orbital camera, and [WebXRCamera](/typedoc/classes/babylon.webxrcamera), used for modern virtual reality experiences.
 
-For input control by the user all cameras need to be attached to the canvas once constructed using
+For allow user input, a camera must be attached to the canvas using:
 
 ```javascript
 camera.attachControl(canvas, true);
 ```
-The second parameter is optional and defaults to **false**. When **false** then default actions on a canvas event are prevented. Set to true to allow canvas default actions.
 
-**Notes**
+The second parameter is optional and defaults to `false`, which prevents default actions on a canvas event. Set to `true` to allow canvas default actions.
 
-1. A [Gamepad](/divingDeeper/input/gamepads) may be used a controller.
-2. For touch control either [PEP](https://github.com/jquery/PEP) or [hand.js](https://github.com/Deltakosh/handjs) is needed.
+### Notes
+
+1. A [Gamepad](/divingDeeper/input/gamepads) may be used as a controller.
+2. For touch control, either [PEP](https://github.com/jquery/PEP) or [hand.js](https://github.com/Deltakosh/handjs) is needed.
 
 ## Universal Camera
 
-This was introduced with version 2.3 of Babylon.js and is controlled by the keyboard, mouse, touch or [gamepad](/divingDeeper/input/gamepads) depending on the input device used, with no need for the controller to be specified. This extends and replaces the [Free Camera](/typedoc/classes/babylon.freecamera), the [Touch Camera](/typedoc/classes/babylon.touchcamera) and the [Gamepad Camera](/typedoc/classes/babylon.gamepadcamera) which are all still available.
+This was introduced with version 2.3 of Babylon.js and is controlled by the keyboard, mouse, touch, or [gamepad](/divingDeeper/input/gamepads) depending on the input device used, with no need for the controller to be specified. This extends and replaces the [Free Camera](/typedoc/classes/babylon.freecamera), the [Touch Camera](/typedoc/classes/babylon.touchcamera) and the [Gamepad Camera](/typedoc/classes/babylon.gamepadcamera), which are all still available.
 
-The Universal Camera is now the default camera used by Babylon.js if nothing is specified, and it’s your best choice if you’d like to have a FPS-like control in your scene.
-All demos on babylonjs.com are based upon that feature. Plug a Xbox controller into your PC and using it you’ll still be able to navigate most of the demos.
+The Universal Camera is now the default camera used by Babylon.js, and it’s your best choice if you’d like to have an FPS-like control in your scene. All demos on [babylonjs.com](babylonjs.com) are based upon that feature. Plug an Xbox controller into your PC and using it you’ll still be able to navigate most of the demos.
 
 The default actions are:
 
-1. Keyboard - The left and right arrows move the camera left and right, and up and down arrows move it forwards and backwards;
+1. Keyboard - The left and right arrow keys move the camera left and right, and the up and down arrow keys move it forwards and backward;
 
 2. Mouse - Rotates the camera about the axes with the camera as origin;
 
-3. Touch - Swipe left and right to move camera left and right, and swipe up and down to move it forward and backwards;
+3. Touch - Swipe left and right to move the camera left and right, and swipe up and down to move it forward and backward;
 
 4. [gamepad](/divingDeeper/input/gamepads) - corresponds to device.
 
@@ -47,90 +47,91 @@ Optional actions are:
 
 1. MouseWheel - The scroll wheel on a mouse or scroll actions on a touchpad. <Playground id="#DWPQ9R#1" title="Adding Scroll Wheel to Universal Camera" description="A simple example of adding scroll wheel functionality to the universal camera." image="/img/playgroundsAndNMEs/divingDeeperCamerasIntro1.jpg"/>
 
-**Note**
+### Note
 
-- Using keys in the Playground requires you to click inside the rendering area to give it the focus.
+Using keys in the Playground requires you to click inside the rendering area to give it the focus.
 
 ### Constructing a Universal Camera
 
 ```javascript
-
 // Parameters : name, position, scene
-    var camera = new BABYLON.UniversalCamera("UniversalCamera", new BABYLON.Vector3(0, 0, -10), scene);
+var camera = new BABYLON.UniversalCamera("UniversalCamera", new BABYLON.Vector3(0, 0, -10), scene);
 
 // Targets the camera to a particular position. In this case the scene origin
-    camera.setTarget(BABYLON.Vector3.Zero());
+camera.setTarget(BABYLON.Vector3.Zero());
 
 // Attach the camera to the canvas
-    camera.attachControl(canvas, true);
+camera.attachControl(canvas, true);
 ```
+
 <Playground id="#DWPQ9R#1" title="Universal Camera Example" description="A simple example of how to construct a universal camera." image="/img/playgroundsAndNMEs/divingDeeperCamerasIntro2.jpg"/>
 
 ## Arc Rotate Camera
 
-This camera always points towards a given target position and can be rotated around that target with the target as the center of rotation.
-It can be controlled with cursors and mouse, or with touch events.
+This camera always points towards a given target position and can be rotated around that target with the target as the center of rotation. It can be controlled with cursors and mouse, or with touch events.
 
-Think of this camera as one orbiting its target position, or more imaginatively as a spy satellite orbiting the earth. Its position relative to the target (earth) can be set by three parameters, _alpha_ (radians) the longitudinal rotation, _beta_ (radians) the latitudinal rotation and  _radius_ the distance from the target position.
+Think of this camera as one orbiting its target position, or more imaginatively as a satellite orbiting the earth. Its position relative to the target ("Earth") can be set by three parameters:
+
+- [alpha](/typedoc/classes/babylon.arcrotatecamera#alpha) (the longitudinal rotation, in radians),
+- [beta](/typedoc/classes/babylon.arcrotatecamera#beta) (the latitudinal rotation, in radians), and
+- [radius](/typedoc/classes/babylon.arcrotatecamera#radius) (the distance from the target).
+
 Here is an illustration:
 
 ![arc rotate camera](/img/how_to/camalphabeta.jpg)
 
-Setting _beta_ to 0 or PI can, for technical reasons, cause problems and in this situation _beta_ is offset by 0.1 radians (about 0.6 degrees).
+Setting `beta` to 0 or PI can, for technical reasons, cause problems, so in this situation, `beta` is offset by 0.1 radians (about 0.6 degrees).
 
-_beta_ increases in a clockwise direction while _alpha_ increases counter clockwise.
+`beta` increases in a clockwise direction, while `alpha` increases counter-clockwise.
 
-The position of the camera can also be set from a vector which will override any current value for _alpha_, _beta_ and _radius_.
-This can be much easier than calculating the required angles.
+The position of the camera can also be set from a vector, which will override any current value for `alpha`, `beta` and `radius`. This can be much easier than calculating the required angles.
 
-Whether using the keyboard, mouse or touch swipes left right directions change _alpha_ and up down directions change _beta_.
+Whether using the keyboard, mouse, or touch swipes, left/right directions change `alpha`, and up/down directions change `beta`.
 
 ### Constructing an Arc Rotate Camera
 
 ```javascript
-
 // Parameters: name, alpha, beta, radius, target position, scene
-	var camera = new BABYLON.ArcRotateCamera("Camera", 0, 0, 10, new BABYLON.Vector3(0, 0, 0), scene);
+var camera = new BABYLON.ArcRotateCamera("Camera", 0, 0, 10, new BABYLON.Vector3(0, 0, 0), scene);
 
 // Positions the camera overwriting alpha, beta, radius
-    camera.setPosition(new BABYLON.Vector3(0, 0, 20));
+camera.setPosition(new BABYLON.Vector3(0, 0, 20));
 
 // This attaches the camera to the canvas
-    camera.attachControl(canvas, true);
+camera.attachControl(canvas, true);
 ```
+
 <Playground id="#SRZRWV#1" title="arcRotate Camera Example" description="A simple example of how to construct an arcRotate camera." image="/img/playgroundsAndNMEs/divingDeeperCamerasIntro2.jpg"/>
 
-Panning with an ArcRotateCamera is also possible by using CTRL + MouseLeftClick, the default action. You can specify to use MouseRightClick instead, by setting _useCtrlForPanning_ to false in the _attachControl_ call :
+By default, panning with an `ArcRotateCamera` is also possible by using <kbd>Ctrl</kbd> + <kbd>left mouse button</kbd>. You can use <kbd>right mouse button</kbd> instead by setting `useCtrlForPanning` to `false` in the `attachControl` call :
 
 ```javascript
-   camera.attachControl(canvas, noPreventDefault, useCtrlForPanning);
+camera.attachControl(canvas, noPreventDefault, useCtrlForPanning);
 ```
 
-If required you can also totally deactivate panning by setting :
+If required, you can also totally deactivate panning by setting :
 
 ```javascript
-   scene.activeCamera.panningSensibility = 0;
+scene.activeCamera.panningSensibility = 0;
 ```
 
 ## FollowCamera
 
-The Follow Camera does what it says on the tin. Give it a mesh as a target and from whatever position it is currently at it will move to a goal position from which to view
-the target. When the target moves so will the Follow Camera.
+The [FollowCamera](/typedoc/classes/babylon.followcamera) does what it says on the tin. Give it a mesh as a target, and from whatever position it is currently at it will move to a goal position from which to view the target. When the target moves, so will the Follow Camera.
 
 The initial position of the Follow Camera is set when it is created then the goal position is set with three parameters:
 
-1. the distance from the target - camera.radius;
+1. [radius](/typedoc/classes/babylon.followcamera#radius): the distance from the target
 
-2. the height above the target - camera.heightOffset;
+2. [heightOffset](/typedoc/classes/babylon.followcamera#heightOffset): the height above the target;
 
-3. the angle in degrees around the target in the x y plane.
+3. [rotationOffset](/typedoc/classes/babylon.followcamera#rotationOffset): the goal angle in degrees around the target in the x y plane.
 
-The speed with which the camera moves to a goal position is set through its acceleration (camera.cameraAcceleration) up to a maximum speed (camera.maxCameraSpeed).
+The speed with which the camera moves to a goal position is set through its acceleration ([cameraAcceleration](/typedoc/classes/babylon.followcamera#cameraacceleration)) up to a maximum speed ([maxCameraSpeed](/typedoc/classes/babylon.followcamera#maxcameraspeed)).
 
 ### Constructing a Follow Camera
 
 ```javascript
-
 // Parameters: name, position, scene
 var camera = new BABYLON.FollowCamera("FollowCam", new BABYLON.Vector3(0, 10, -10), scene);
 
@@ -144,77 +145,72 @@ camera.heightOffset = 10;
 camera.rotationOffset = 0;
 
 // Acceleration of camera in moving from current to goal position
-camera.cameraAcceleration = 0.005
+camera.cameraAcceleration = 0.005;
 
 // The speed at which acceleration is halted
-camera.maxCameraSpeed = 10
+camera.maxCameraSpeed = 10;
 
 // This attaches the camera to the canvas
 camera.attachControl(canvas, true);
 
 // NOTE:: SET CAMERA TARGET AFTER THE TARGET'S CREATION AND NOTE CHANGE FROM BABYLONJS V 2.5
 // targetMesh created here.
-camera.target = targetMesh;   // version 2.4 and earlier
+camera.target = targetMesh; // version 2.4 and earlier
 camera.lockedTarget = targetMesh; //version 2.5 onwards
 ```
+
 <Playground id="#SRZRWV#6" title="Follow Camera Example" description="A simple example of how to construct a follow camera." image="/img/playgroundsAndNMEs/divingDeeperCamerasIntro3.jpg"/>
 
 ## AnaglyphCameras
 
-These extend the use of the Universal and Arc Rotate Cameras for use with red and cyan 3D glasses. They use post-processing filtering techniques.
+The [AnaglyphUniversalCamera](/typedoc/classes/babylon.anaglyphuniversalcamera) and [AnaglyphArcRotateCamera](/typedoc/classes/babylon.anaglypharcrotatecamera) extend the use of the Universal and Arc Rotate Cameras for use with red and cyan 3D glasses. They use post-processing filtering techniques.
 
-### Constructing Anaglyph Universal Camera
+### Constructing an Anaglyph Universal Camera
 
 ```javascript
-
 // Parameters : name, position, eyeSpace, scene
 var camera = new BABYLON.AnaglyphUniversalCamera("af_cam", new BABYLON.Vector3(0, 1, -15), 0.033, scene);
 ```
 
-### Constructing Anaglyph ArcRotateCamera
+### Constructing an Anaglyph ArcRotateCamera
 
 ```javascript
-
 // Parameters : name, alpha, beta, radius, target, eyeSpace, scene
-var camera = new BABYLON.AnaglyphArcRotateCamera("aar_cam", -Math.PI/2, Math.PI/4, 20, new BABYLON.Vector3.Zero(), 0.033, scene);
+var camera = new BABYLON.AnaglyphArcRotateCamera("aar_cam", -Math.PI / 2, Math.PI / 4, 20, new BABYLON.Vector3.Zero(), 0.033, scene);
 ```
 
-The _eyeSpace_ parameter sets the amount of shift between the left eye view and the right eye view. Once you are wearing your 3D glasses, you might want to experiment with this float value.
+The `eyeSpace` parameter sets the amount of shift between the left-eye view and the right-eye view. Once you are wearing your 3D glasses, you might want to experiment with this float value.
 
 You can learn all about anaglyphs by visiting a [Wikipedia page that explains it thoroughly](https://en.wikipedia.org/wiki/Anaglyph_3D).
 
 ## Device Orientation Camera
 
-This is a camera specifically designed to react to device orientation events such as a modern mobile device being tilted forward or back and left or right.
+The [DeviceOrientationCamera](/typedoc/classes/babylon.deviceorientationcamera) is specifically designed to react to device orientation events such as a modern mobile device being tilted forward, back, left, or right.
 
 ### Constructing a Device Orientation Camera
 
 ```javascript
-
 // Parameters : name, position, scene
-   var camera = new BABYLON.DeviceOrientationCamera("DevOr_camera", new BABYLON.Vector3(0, 0, 0), scene);
+var camera = new BABYLON.DeviceOrientationCamera("DevOr_camera", new BABYLON.Vector3(0, 0, 0), scene);
 
-    // Targets the camera to a particular position
-    camera.setTarget(new BABYLON.Vector3(0, 0, -10));
+// Targets the camera to a particular position
+camera.setTarget(new BABYLON.Vector3(0, 0, -10));
 
-	// Sets the sensitivity of the camera to movement and rotation
-	camera.angularSensibility = 10;
-	camera.moveSensibility = 10;
+// Sets the sensitivity of the camera to movement and rotation
+camera.angularSensibility = 10;
+camera.moveSensibility = 10;
 
-    // Attach the camera to the canvas
-    camera.attachControl(canvas, true);
-
+// Attach the camera to the canvas
+camera.attachControl(canvas, true);
 ```
+
 <Playground id="#SRZRWV#3" title="Device Orientation Camera Example" description="A simple example of how to construct a Device Orientation camera." image="/img/playgroundsAndNMEs/divingDeeperCamerasIntro4.jpg"/>
 
 ## Virtual Joysticks Camera
 
-This is specifically designed to react to Virtual Joystick events.
-Virtual Joysticks are on-screen 2D graphics that are used to control the camera or other scene items.
+The [VirtualJoysticksCamera](/typedoc/classes/babylon.virtualjoystickscamera) is specifically designed to react to Virtual Joystick events. Virtual Joysticks are on-screen 2D graphics that are used to control the camera or other scene items.
 
-### Requires
-
-The third-party file [hand.js](https://archive.codeplex.com/?p=handjs).
+**Note:** This camera requires the third-party file [hand.js](https://archive.codeplex.com/?p=handjs).
 
 ### Video
 
@@ -257,64 +253,63 @@ function startGame() {
 }
 ```
 
-If you switch back to another camera, don’t forget to call the dispose() function first. Indeed, the VirtualJoysticks are creating a 2D canvas on top of the 3D WebGL canvas to draw the joysticks with cyan and yellow circles. If you forget to call the dispose() function, the 2D canvas will remain, and will continue to use touch events input.
-
+If you switch back to another camera, don’t forget to call `dispose()` first. The `VirtualJoysticks` are creating a 2D canvas on top of the 3D WebGL canvas to draw the joysticks with cyan and yellow circles. If you forget to call `dispose()`, the 2D canvas will remain and will continue to handle touch events.
 
 ## VR Device Orientation Cameras
 
-A new range of cameras.
-VR Device Orientation Camera Example (Needs VR device)
+The [VRDeviceOrientationFreeCamera](/typedoc/classes/babylon.vrdeviceorientationfreecamera), [VRDeviceOrientationArcRotateCamera](/typedoc/classes/babylon.vrdeviceorientationarcrotatecamera), and [VRDeviceOrientationGamepadCamera](/typedoc/classes/babylon.vrdeviceorientationgamepadcamera) are a newer set of cameras that extend the cameras above to handle device orientation from a VR device.
+
+Example (requires a VR device):
+
 <Playground id="#SRZRWV#4" title="VR Device Orientation Camera Example" description="A simple example of how to construct a VR Device Orientation camera." image="/img/playgroundsAndNMEs/divingDeeperCamerasIntro5.jpg"/>
 
-## Constructing the VR Device Orientation Free Camera
+## Constructing a VR Device Orientation Free Camera
 
 ```javascript
-//Parameters: name, position, scene, compensateDistortion, vrCameraMetrics
-var camera = new BABYLON.VRDeviceOrientationFreeCamera ("Camera", new BABYLON.Vector3 (-6.7, 1.2, -1.3), scene);
+// Parameters: name, position, scene, compensateDistortion, vrCameraMetrics
+var camera = new BABYLON.VRDeviceOrientationFreeCamera("Camera", new BABYLON.Vector3(-6.7, 1.2, -1.3), scene);
 ```
 
-### Constructing the VR Device Orientation Arc Rotate Camera
+### Constructing a VR Device Orientation Arc Rotate Camera
 
 ```javascript
-//Parameters: name, alpha, beta, radius, target, scene, compensateDistortion, vrCameraMetrics
-var camera = new BABYLON.VRDeviceOrientationArcRotateCamera ("Camera", Math.PI/2, Math.PI/4, 25, new BABYLON.Vector3 (0, 0, 0), scene);
+// Parameters: name, alpha, beta, radius, target, scene, compensateDistortion, vrCameraMetrics
+var camera = new BABYLON.VRDeviceOrientationArcRotateCamera("Camera", Math.PI / 2, Math.PI / 4, 25, new BABYLON.Vector3(0, 0, 0), scene);
 ```
 
-### Constructing the VR Device Orientation Gamepad Camera
+### Constructing a VR Device Orientation Gamepad Camera
 
 ```javascript
-//Parameters: name, position, scene, compensateDistortion, vrCameraMetrics
-var camera = new BABYLON.VRDeviceOrientationGamepadCamera("Camera", new BABYLON.Vector3 (-10, 5, 14));
+// Parameters: name, position, scene, compensateDistortion, vrCameraMetrics
+var camera = new BABYLON.VRDeviceOrientationGamepadCamera("Camera", new BABYLON.Vector3(-10, 5, 14));
 ```
 
 ## WebVR Free Camera
 
-**Please note that WebVR is deprecated! Please use WebXR instead**
+**NOTE:** WebVR is deprecated! Please use WebXR instead
 
-The new virtual reality camera
+[WebVRFreeCamera](/typedoc/classes/babylon.webvrfreecamera) is the legacy virtual reality camera, now intended for use with older VR device browsers that don't support the WebXR standard.
 
 ```javascript
-
 // Parameters : name, position, scene, webVROptions
-    var camera = new BABYLON.WebVRFreeCamera("WVR", new BABYLON.Vector3(0, 1, -15), scene);
+var camera = new BABYLON.WebVRFreeCamera("WVR", new BABYLON.Vector3(0, 1, -15), scene);
 ```
 
-This camera deserves a page to itself so here it is [Using the WebVR Camera](/divingDeeper/cameras/webVRCamera);
+This camera deserves its own page: [Using the WebVR Camera](/divingDeeper/cameras/webVRCamera).
 
 ## FlyCamera
 
-This camera imitates free movement in 3D space, think "a ghost in space." It comes with an option to gradually correct Roll, and also an option to mimic banked-turns.
+[FlyCamera](/typedoc/classes/babylon.flycamera) imitates free movement in 3D space, think "a ghost in space." It comes with an option to gradually correct Roll, and also an option to mimic banked-turns.
 
 Its defaults are:
 
-1. Keyboard - The __A__ and __D__ keys move the camera left and right. The __W__ and __S__ keys move it forward and backward. The __E__ and __Q__ keys move it up and down.
+1. Keyboard - The <kbd>A</kbd> and <kbd>D</kbd> keys move the camera left and right. The <kbd>W</kbd> and <kbd>S</kbd> keys move it forward and backward. The <kbd>E</kbd> and <kbd>Q</kbd> keys move it up and down.
 
-2. Mouse - Rotates the camera about the Pitch and Yaw (X, Y) axes with the camera as origin. Holding the __right mouse-button__ rotates the camera about the Roll (Z) axis with the camera as origin.
+2. Mouse - Rotates the camera about the Pitch and Yaw (X, Y) axes with the camera as the origin. Holding the <kbd>right mouse button</kbd> rotates the camera about the Roll (Z) axis with the camera as the origin.
 
 ### Constructing a Fly Camera
 
 ```javascript
-
 // Parameters: name, position, scene
 var camera = new BABYLON.FlyCamera("FlyCamera", new BABYLON.Vector3(0, 5, -10), scene);
 
@@ -340,14 +335,16 @@ Cameras in Babylon.js have [clipping planes](/divingDeeper/scene/clipPlanes) tha
 ```javascript
 camera.maxZ = 100;
 ```
-will not render anything past 100 units from camera. The same is true of the near clipping plane as well. For example, setting the near clipping plane to 10 like this:
+
+will not render anything past 100 units from the camera. The same is true of the near clipping plane as well. For example, setting the near clipping plane to 10 like this:
 
 ```javascript
 camera.minZ = 10;
 ```
+
 will not rendering anything closer than 10 units from the camera.
 
-In some cases you may not want to clip the rendering of your scene. You may want your scene to effectively render out to infinity. This can be done by setting the far clipping plane to 0 like this:
+In some cases, you may not want to clip the rendering of your scene. You may want your scene to effectively render out to infinity. This can be done by setting the far clipping plane to 0 like this:
 
 ```javascript
 camera.maxZ = 0;
@@ -359,4 +356,4 @@ Just a friendly warning, setting the far clipping plane to infinity can reduce d
 
 The cameras rely upon user inputs to move the camera. If you are happy with the camera presets Babylon.js is giving you, just stick with it.
 
-If you want to change user inputs based upon user preferences, customize one of the existing presets, or use your own input mechanisms.  Those cameras have an input manager that is designed for those advanced scenarios. Read [customizing camera inputs](/divingDeeper/cameras/customizingCameraInputs) to learn more about tweaking inputs on your cameras.
+If you want to change user inputs based upon user preferences, customize one of the existing presets, or use custom input mechanisms. Those cameras have an input manager that is designed for those advanced scenarios. Read [customizing camera inputs](/divingDeeper/cameras/customizingCameraInputs) to learn more about tweaking inputs on your cameras.

--- a/content/How_To/camera/cameras_mesh_collisions_and_gravity.md
+++ b/content/How_To/camera/cameras_mesh_collisions_and_gravity.md
@@ -1,32 +1,44 @@
 ---
 title: Camera Collisions
-image: 
+image:
 description: Dive into understanding camera collisions, mesh collisions, and gravity.
 keywords: welcome, babylon.js, diving deeper, cameras, collisions, camera collisions, gravity, mesh collisions
 further-reading:
-    - title: Cameras Overview
-      url: /divingDeeper/cameras
+  - title: Cameras Overview
+    url: /divingDeeper/cameras
 video-overview:
 video-content:
 ---
 
-## Cameras, Mesh Collisions and Gravity
+## Cameras, Mesh Collisions, and Gravity
 
-Did you ever play a FPS (First Person Shooter) game? In this tutorial, we are going to simulate the same camera movements: the camera is on the floor, in collision with the ground, and potentially in collision with any objects in the scene.
+Did you ever play an FPS (First-Person Shooter) game? In this tutorial, we are going to simulate the same camera movements: the camera is on the floor, in collision with the ground, and potentially in collision with any objects in the scene.
 
 ## How can I do this ?
 
 To replicate this movement, we have to do 3 simple steps:
 
-**1 - Define and apply gravity**
+### 1. Define and apply gravity
 
 The first thing to do is to define our gravity vector, defining the G-force.
 
-In the real world, gravity is a _force_ (ok, sort of) that is exerted downward -- _i.e._, in the negative direction along the Y axis. On Earth, this force is roughly 9.81m/s². Falling bodies *accelerate* as they fall, so it takes 1 second to fully reach this rate, then the velocity is 19.62m/s after 2 seconds, 29.43m/s after 3 seconds, etc. Eventually, wind drag matches this value and the body no longer continues so increase in velocity.
+Babylon.js [Scenes](/typedoc/classes/babylon.scene) have a [gravity](/typedoc/classes/babylon.scene#gravity) property that can be applied to any camera you've previously defined in your code. This will move the camera along the direction and speed specified (a [Vector3](/typedoc/classes/babylon.vector3) object) unless the camera's ellipsoid (see #2 below) is colliding with another mesh in that direction (such as your ground mesh) with [checkCollisions](/typedoc/classes/babylon.mesh#checkcollisions) set to `true`.
 
-BabylonJS has a `scene.gravity` vector that can be applied to any camera you've previously defined in your code. This follows a much simpler gravitational model, however -- it represents a *constant velocity*, not a force of acceleration, and it is measured in *units/frame* rather than *meters/second*. As each frame is rendered, the cameras you apply this gravity to will *move* by the vector's value in the `x`, `y`, and `z` direction, until they collide with a mesh with `checkCollisions=true` (such as your ground mesh).
+```javascript
+scene.gravity = new BABYLON.Vector3(0, -0.15, 0);
+```
 
-While BabylonJS units have no direct physical equivalent, with the default camera field of view, an approximation of 1 unit = 1 meter is a fairly standard assumption. So, if you want to approximate nominal Earth gravity, you'll need to make some assumptions about the number of frames being rendered per second, and compute a suitable vector:
+To apply the scene's gravity to your camera, set the [applyGravity](/typedoc/classes/babylon.freecamera#applygravity) property to `true`:
+
+```javascript
+camera.applyGravity = true;
+```
+
+In the real world, gravity is a _force_ (ok, sort of) that is exerted downward -- _i.e._, in a negative direction along the Y-axis. On Earth, this force is roughly 9.81m/s². Falling bodies _accelerate_ as they fall, so it takes 1 second to fully reach this velocity, then the velocity reaches 19.62m/s after 2 seconds, 29.43m/s after 3 seconds, etc. In an atmosphere, wind drag eventually matches this force and velocity ceases to increase ("terminal velocity").
+
+Babylon.js follows a much simpler gravitational model, however -- `scene.gravity` represents a _constant velocity_, not a force of acceleration, and it is measured in _units/frame_ rather than _meters/second_. As each frame is rendered, the cameras you apply this gravity to will _move_ by the vector's value along each axis (usually `x` and `z` are set to 0, but you can have "gravity" in any direction!), until a collision is detected.
+
+While Babylon.js units have no direct physical equivalent, with the default camera field of view, an approximation of 1 unit = 1 meter is a fairly standard assumption. So, if you want to approximate nominal Earth gravity, you'll need to make some assumptions about the number of frames being rendered per second, and compute a suitable vector:
 
 ```javascript
 const assumedFramesPerSecond = 60;
@@ -34,36 +46,32 @@ const earthGravity = -9.81;
 scene.gravity = new BABYLON.Vector3(0, earthGravity / assumedFramesPerSecond, 0);
 ```
 
-```javascript
-camera.applyGravity = true; 
-```
-
-Since this is computed once per frame, the camera isn't actually "moving," it is making tiny "hops" based on that gravity vector. This may be important if you are relying on collision detection to determine if the camera (or, rather, a mesh attached to it for that purpose) has "entered" or "exited" some other mesh (for example, a plane under your "ground" layer to sense a falling character and reset the game play). Depending on your chosen gravity, the starting elevation, and the position and height of the "trigger" mesh, the camera may jump *right through* the trigger mesh without ever "intersecting" it. Be sure to check the math to ensure that at least one multiple of `scene.gravity` added to the starting elevation will intersect your trigger mesh.
+Since this is computed once per frame, the camera isn't actually "moving," it is making tiny "hops" along the direction of the gravity vector. This may be important if you are relying on collision detection to determine if the camera (or, rather, a mesh attached to it for that purpose) has "entered" or "exited" some other mesh (for example, a plane under your "ground" layer to sense a falling character and reset the game play). Depending on your chosen gravity, the starting elevation, and the position and height of the "trigger" mesh, the camera may jump _right through_ the trigger mesh without ever "intersecting" it. Be sure to check the math to ensure that at least one multiple of `scene.gravity` added to the starting elevation will intersect your trigger mesh.
 
 If you need a more accurate representation of gravitational (or other) forces, you can add your own physics engine. See [Add Your Own Physics Engine](/divingDeeper/physics/addPhysicsEngine).
 
-**2 - Define an ellipsoid**
+### 2. Define an ellipsoid
 
 The next important step is to define the ellipsoid around our camera. This ellipsoid represents our player’s dimensions: a collision event will be raised when a mesh comes in contact with this ellipsoid, preventing our camera from getting too close to this mesh:
 
 ![Ellipsoid](/img/babylon101/ellipsoid.png)
 
-The _ellipsoid_ property on babylon.js cameras is default to size (0.5, 1, 0.5), but changing values will make you taller, bigger, smaller, thinner, it depends upon the adjusted axis. In the example below, we will make our camera's ellipsoid a bit bigger than the default one:
+The [ellipsoid](/typedoc/classes/babylon.freecamera#ellipsoid) property on Babylon.js cameras is default to size (0.5, 1, 0.5). Changing these values will make you taller, bigger, smaller, thinner, depending on the adjusted axis. In the example below, we will make our camera's ellipsoid a bit wider and deeper than the default one:
 
 ```javascript
 //Set the ellipsoid around the camera (e.g. your player's size)
 camera.ellipsoid = new BABYLON.Vector3(1, 1, 1);
 ```
 
-Please note that the ellipsoid for the camera is offset to always have the view point on top of the ellipsoid. You can control this behavior by updating the `camera.ellipsoidOffset` property.
+Please note that the ellipsoid for the camera is offset to always have the viewpoint on top of the ellipsoid. You can control this behavior by updating the [ellipsoidOffset](/typedoc/classes/babylon.freecamera#ellipsoidoffset) property.
 
 The computation will be the following:
 
-*finalPosition = position - vec3(0, ellipsoid.y, 0) + ellipsoidOffset*
+`finalPosition = position - vec3(0, ellipsoid.y, 0) + ellipsoidOffset`
 
-**3 - Apply collision**
+### 3. Apply collision
 
-Once you have those previous settings completed, our final step is to declare that we are interested in sensing collisions in our scene:
+Our final step is to declare that we are interested in sensing collisions in our scene:
 
 ```javascript
 // Enable Collisions
@@ -71,7 +79,7 @@ scene.collisionsEnabled = true;
 camera.checkCollisions = true;
 ```
 
-And declare which meshes could be in collision with our camera:
+And to declare which meshes could be in collision with our camera:
 
 ```javascript
 ground.checkCollisions = true;
@@ -82,13 +90,13 @@ That’s it! Easy!
 
 You can play with the scene used in this tutorial: <Playground id="#4HUQQ" title="Basic Camera Collision Example" description="A simple example of adding an ellipsoid collision buffer around a camera." image="/img/playgroundsAndNMEs/divingDeeperCameraCollisions1.jpg"/>
 
-Now, your camera is going to fall on the y-axis until it collides with the ground. And, your camera will collide with the box when you move it too near to it.
+Now, your camera is going to fall on the y-axis until it collides with the ground. And, your camera will collide with the box when you move it too close to it.
 
-**4 - Object vs. object collision**
+### 4. Object vs. object collision
 
-You can also do the same thing with a mesh by playing with _mesh.ellipsoid_ property and _mesh.moveWithCollisions(velocity)_ function. This function will try to move the mesh according to given velocity and will check if there is no collision between current mesh and all meshes with checkCollisions activated.
+You can do the same thing with a mesh by playing with the [ellipsoid](/typedoc/classes/babylon.mesh#ellipsoid) property and the [moveWithCollisions(velocity)](/typedoc/classes/babylon.mesh#movewithcollisions) function. This function will attempt to move the mesh according to a given velocity when it finds no collisions between the current mesh and any meshes with [checkCollisions](/typedoc/classes/babylon.mesh#checkcollisions) activated.
 
-You can also use _mesh.ellipsoidOffset_ to move the ellipsoid on the mesh (By default the ellipsoid is centered on the mesh)
+You can also use a mesh's [ellipsoidOffset](/typedoc/classes/babylon.mesh#ellipsoidoffset) to move the ellipsoid on the mesh (by default, the ellipsoid is centered on the mesh).
 
 ```javascript
 var speedCharacter = 8;
@@ -107,13 +115,15 @@ character.moveWithCollisions(backwards);
 ```
 
 ## ArcRotateCamera
-The ArcRotateCamera can also check collisions but instead of sliding along obstacles, this camera won't move when a collision appends.
 
-To activate collisions, just call ```camera.checkCollisions = true```. You can define the collision radius with this code:
+The `ArcRotateCamera` can also check collisions, but instead of sliding along obstacles, this camera won't move when a collision happens.
+
+To activate collisions, just set `camera.checkCollisions` to `true`. You can also define the collision radius:
 
 ```javascript
-camera.collisionRadius = new BABYLON.Vector3(0.5, 0.5, 0.5)
+camera.collisionRadius = new BABYLON.Vector3(0.5, 0.5, 0.5);
 ```
 
-## Other Types of Collisions
+## Other types of collisions
+
 Great, now you can develop a real FPS game! But maybe you would like to know when a mesh is in collision with another mesh? If that interests you, you can head on over here: [Mesh Collisions](/divingDeeper/mesh/interactions/mesh_intersect).

--- a/content/How_To/contribute/contribute_to_documentation.md
+++ b/content/How_To/contribute/contribute_to_documentation.md
@@ -2,12 +2,12 @@
 title: Contribute To The Documentation
 image:
 description: Learn how to contribute to the Babylon.js Documentation.
-keywords: welcome, babylon.js, diving deeper, contribution, contribute, open-source, oss, Documentation, docs, develope
+keywords: welcome, babylon.js, diving deeper, contribution, contribute, open-source, oss, Documentation, docs, develop
 further-reading:
-    - title: Improve API Documentation
-      url: /divingDeeper/developWithBjs/contributeToAPI
-    - title: Mastering Markdown
-      url: https://guides.github.com/features/mastering-markdown/
+  - title: Improve API Documentation
+    url: /divingDeeper/developWithBjs/contributeToAPI
+  - title: Mastering Markdown
+    url: https://guides.github.com/features/mastering-markdown/
 video-overview:
 video-content:
 ---
@@ -50,15 +50,15 @@ Do not hesitate to read the [Good Practice](/divingDeeper/developWithBjs/contrib
 
 ## Deeper Changes
 
-Sometimes, quick edits like above are not sufficient. Indeed, you might want to run the documentation locally on your computer before pushing online, just to be sure nothing is broken.
+Sometimes, quick edits like described above are not sufficient. Indeed, you might want to run the documentation locally on your computer before pushing online, just to be sure nothing is broken.
 
 Requirements:
 
--   a [Github](https://github.com) account
--   [git](https://www.git-scm.com/downloads)
--   [Github Desktop](https://desktop.github.com/) (optional, but makes local git repositories easier to use)
--   [node.js](https://nodejs.org/en/), we support node 12 and up.
--   [yarn](https://yarnpkg.com/getting-started/install)
+- a [Github](https://github.com) account
+- [git](https://www.git-scm.com/downloads)
+- [Github Desktop](https://desktop.github.com/) (optional, but makes local git repositories easier to use)
+- [node.js](https://nodejs.org/en/), we support node 12 and up.
+- [yarn](https://yarnpkg.com/getting-started/install)
 
 ### Forking
 
@@ -68,23 +68,23 @@ Start by going to the main BabylonJS [Documentation](https://github.com/BabylonJ
 
 This will make a copy of the repository, but on your account.
 
-Click on _Clone or download_ button, and _Open in Desktop_:
+Click on the _Clone or download_ button, and _Open in Desktop_:
 
 ![open locally](/img/contribute/documentation/further-open-desktop.png)
 
 Github Desktop will be opened and ask you where you want to save your fork.
 
-When the files are downloaded, open a command in this repo. It can be done quickly using Github Desktop menu:
+When the files are downloaded, open a terminal/command prompt in this repo. It can be done quickly using the Github Desktop menu:
 
 ![powershell](/img/contribute/documentation/further-powershell.png)
 
 (_you may have_ Open in Command _rather than_ Open in PowerShell _, that's not a big deal_)
 
-You need 'yarn' installed. For further information about yarn you can go to the [yarn installation guide](https://yarnpkg.com/getting-started/install).
+You need 'yarn' installed. For further information about yarn, you can go to the [yarn installation guide](https://yarnpkg.com/getting-started/install).
 
-After installing yarn type `yarn install`, press enter and wait the operation to be done.
+After installing yarn, type `yarn install`, press <kbd>enter</kbd>, and wait for the operation to finish.
 
-This fork operation has to be done only once. You're now able to run locally the documentation by following the next section.
+This fork operation only has to be done once. You're now able to run locally the documentation by following the next section.
 
 ### Running and editing the doc locally
 
@@ -100,7 +100,7 @@ Open the project using your favorite code editor. This can be done also from Git
 
 (_you may have_ Open in Atom _rather than_ Open in Visual Studio _, that's not a big deal_)
 
-You can finally starting to update the markdown files!
+You can finally start to update the markdown files!
 
 ![visual studio](/img/contribute/documentation/further-editing.png)
 
@@ -120,7 +120,7 @@ Then, on your markdown page, use this link pattern:
 ![quick description (for accessibility)](/img/divingDeeper/my_very_great_page/my-wonderful-image.jpg)
 ```
 
-Of course, try to keep image size as low as you can (while keeping a good visual quality). Our build system will do its best to optimize the image nonetheless.
+Of course, try to keep the image size as small as you can (while keeping a good visual quality). Our build system will do its best to optimize the image nonetheless.
 
 ### Adding new pages
 
@@ -155,14 +155,18 @@ For example, let's say we want to add this page. We know that our new page will 
             }
     }
     /* [...] */
-    }
+}
 ```
 
 Just add necessary information about your new page:
 
 ```javascript
 /* [...] */
-"documentKeyAndUrl": { "friendlyName": "A friendly title to your document", "children": {/* if any, children will contain the rest of the documents */}, "content": "the markdown file that correlates to this document." },
+"documentKeyAndUrl": {
+  "friendlyName": "A friendly title to your document",
+  "children": {/* if any, children will contain the rest of the documents */},
+  "content": "the markdown file that correlates to this document."
+},
 /* [...] */
 ```
 
@@ -198,36 +202,36 @@ image: /img/pageImages/nodeMaterial.jpg
 description: The Node Material is a simple, highly customizable material that you can build yourself piece by piece. Combined with the powerful node-based editor, you can easily create stunning custom GPU shaders and FX for your Babylon.js scenes.
 keywords: shaders, glsl, node editor, graphics, GPU program, material, NME, Node Material, Node Material Editor
 further-reading:
-    - title: Dedicated NME Forum Examples
-      url: https://forum.babylonjs.com/t/node-materials-examples/6048
-    - title: 3 Tips For Getting Started Building Procedural Node Material Shaders
-      url: https://babylonjs.medium.com/procedural-node-material-shaders-3-tips-for-getting-started-4089c1832dfc
-    - title: Mesh shattering with baked physics
-      url: https://babylonjs.medium.com/mesh-shattering-with-baked-physics-5b3f8f381743
-    - title: Fighting Self-Doubt, with Water
+  - title: Dedicated NME Forum Examples
+    url: https://forum.babylonjs.com/t/node-materials-examples/6048
+  - title: 3 Tips For Getting Started Building Procedural Node Material Shaders
+    url: https://babylonjs.medium.com/procedural-node-material-shaders-3-tips-for-getting-started-4089c1832dfc
+  - title: Mesh shattering with baked physics
+    url: https://babylonjs.medium.com/mesh-shattering-with-baked-physics-5b3f8f381743
+  - title: Fighting Self-Doubt, with Water
 video-content:
-    - title: Node-Based Procedural Textures
-      url: https://youtu.be/qqMuuSM7GvI
-    - title: Creating Procedural Node Materials Through Code
-      url: https://youtu.be/GrmVObi6caQ
-    - title: Node Material Post Processes
-      url: https://youtu.be/QTuL5raapQQ
-    - title: Node Material Editor Particles!!!!
-      url: https://youtu.be/fZvZMXDoVp4
-    - title: Interactive Hex Tile Series
-      url: https://www.youtube.com/playlist?list=PLsaE__vWcRamMC5oJwhrSj3x3jT9TWOPB
-    - title: Unraveling Advanced Anisotropic Reflections
+  - title: Node-Based Procedural Textures
+    url: https://youtu.be/qqMuuSM7GvI
+  - title: Creating Procedural Node Materials Through Code
+    url: https://youtu.be/GrmVObi6caQ
+  - title: Node Material Post Processes
+    url: https://youtu.be/QTuL5raapQQ
+  - title: Node Material Editor Particles!!!!
+    url: https://youtu.be/fZvZMXDoVp4
+  - title: Interactive Hex Tile Series
+    url: https://www.youtube.com/playlist?list=PLsaE__vWcRamMC5oJwhrSj3x3jT9TWOPB
+  - title: Unraveling Advanced Anisotropic Reflections
 ---
 
 ```
 
 Everything in the metadata is optional and has a different value. However, it is always better to add as much information as possible. This will help people find and use the page. And this is the goal here!
 
-The image provided will be used when sharing this link on sites supporting open graph, such as facebook, medium, twitter and so on. The default image is the babylon logo.
+The image provided will be used when sharing this link on sites supporting open graph, such as Facebook, Medium, Twitter, and so on. The default image is the Babylon.js logo.
 
 #### Internal links
 
-To link to an internal document, use its path from root without adding the domain. For example:
+To link to an internal document, use its path from the root without adding the domain. For example:
 
 ```markdown
 [Post Processes](/divingDeeper/postProcesses/usePostProcesses)
@@ -235,7 +239,7 @@ To link to an internal document, use its path from root without adding the domai
 
 ### Adding examples
 
-It is always great to provide examples in your documentation page. You can add playgrounds and NME, and they will be added automatically to the page's side menu, if you use the right markdown.
+It is always great to provide examples in your documentation page. By using the correct markdown, you can add playgrounds and NME, and they will be added automatically to the page's side menu.
 
 To add a playground, add the following code:
 
@@ -243,9 +247,9 @@ To add a playground, add the following code:
 <Playground id="playgroundId" title="Playground title" description="A short description" image="Optional image url" />
 ```
 
-The playground ID is the 6-chars id and the version number, if needed. For example: `#Y642I8#2`.
+The playground ID is the 6-character id, and the version number if needed. For example: `#Y642I8#2`.
 
-Same thing does to NME examples:
+The same applies to NME examples:
 
 ```html
 <nme id="nmeId" title="NME title" description="A short description" />
@@ -260,7 +264,7 @@ An image will be generated for each playground without an image, so don't worry 
 To add a youtube link, use the youtube markdown tag:
 
 ```html
-<Youtube id="qqMuuSM7GvI"/>
+<Youtube id="qqMuuSM7GvI" />
 ```
 
 To add an image, you can use the markdown annotation:
@@ -272,7 +276,7 @@ To add an image, you can use the markdown annotation:
 but you can also use the more advanced `<img/>` tag, that has more control over formatting, size and so on. As always, everything is optional, but very nice to have:
 
 ```html
-<img src="internal link to image" title="Image title" alt="Similar to title" width="300" height="200" caption="Copyright (or any other) caption that will appear under the image"/>
+<img src="internal link to image" title="Image title" alt="Similar to title" width="300" height="200" caption="Copyright (or any other) caption that will appear under the image" />
 ```
 
 ### Sending pull request
@@ -287,17 +291,17 @@ Add an explicit summary into the required field, and click to _Commit to master_
 
 ![pushing](/img/contribute/documentation/further-pushing.png)
 
-Then, click on _Push origin_ button:
+Then, click the _Push origin_ button:
 
 ![push](/img/contribute/documentation/further-push.png)
 
-And go to your online github repo. You can use Github Desktop for that:
+And go to your online Github repo. You can use Github Desktop for that:
 
 ![github](/img/contribute/documentation/further-github.png)
 
 For now, your fork is updated online, having your last modifications.
 
-Click on _New pull request_ button:
+Click the _New pull request_ button:
 
 ![github pull](/img/contribute/documentation/further-github-pull.png)
 
@@ -309,34 +313,35 @@ Congratulation again, you're now a documentation master!
 
 ### General
 
--   if you're not familiar with markdown, you can read this short [Github guide](https://guides.github.com/features/mastering-markdown/)
--   even if you're seeing just a tiny typo, feel free to do a pull request dedicated to it
--   do one commit per tasks, a pull request can take into account multiple commits if needed
-    -   example: if you have two pages to modify, once the first page is edited, do a commit
--   tables can be a great help for readability
--   avoid the use of first person
--   pay attention to spelling, grammar and punctuation
--   when you're not sure about a point, ask for proof-reading
+- if you're not familiar with markdown, you can read this short [Github guide](https://guides.github.com/features/mastering-markdown/)
+- even if you're seeing just a tiny typo, feel free to do a pull request dedicated to it
+- do one commit per tasks, a pull request can take into account multiple commits if needed
+  - example: if you have two pages to modify, once the first page is edited, do a commit
+- tables can be a great help for readability
+- avoid the use of first person
+- pay attention to spelling, grammar, and punctuation
+- when you're not sure about a point, ask for proof-reading
 
 ### Images
 
--   use and store images from the documentation FTP as much as possible, read [Adding new images](/divingDeeper/developWithBjs/contributeToDocs#adding-new-images)
--   be careful about image size (tip: Photoshop has a "Save for the web" export)
+- use and store images from the documentation FTP as much as possible, read [Adding new images](/divingDeeper/developWithBjs/contributeToDocs#adding-new-images)
+- be careful about image size (tip: Photoshop has a "Save for the web" export)
 
 ### Code
 
--   when showing a JavaScript block of code, inform Markdown that it's JavaScript to ensure syntax highlighting:
+- when showing a block of JavaScript or TypeScript, include the language name after the code block starting ticks to ensure syntax highlighting:
 
 ![markdown code](/img/contribute/documentation/markdown-code.png)
 
--   when quoting a property in a sentence, you can use single _\`_ char (Alt + numpad 96)
-    -   example: You can set the `roughness` of a PBR material to 1.
+- when quoting a property in a sentence, you can use single _\`_ char (<kbd>Alt</kbd> + numpad <kbd>96</kbd>)
+  - example: You can set the `roughness` of a PBR material to 1.
 
 ### Links
 
--   use relative links
-    -   example: `[Load Files with Assets Manager](/divingDeeper/developWithBjs/contributeToDocs)` instead of `[Load Files with Assets Manager](/divingDeeper/developWithBjs/contributeToDocs)`
+For links to other parts of the Babylon.js documentation and API, use relative links.
+
+For example, use `[Load Files with Assets Manager](/divingDeeper/developWithBjs/contributeToDocs)` rather than `[Load Files with Assets Manager](https://doc.babylonjs.com/divingDeeper/developWithBjs/contributeToDocs)`
 
 ## Further Reading
 
-Any articles, urls, docs, links that you'd like the reader to have as reference for a doc page, should go into the further reading section of the metadata at the top of each page.
+Any articles, URLs, documents, and links that you'd like the reader to have as a reference on the page should go into the "further reading" metadata section at the top of the page.


### PR DESCRIPTION
I went through (mostly) the Camera pages and adjusted the text to address markdown, grammar, spelling, brands, and reading clarity. I was trying to understand this content more deeply, so that was a good excuse to try to make some improvements where I found some confusion, and where Grammarly caught issues.

I also added a number of internal links from classes, methods, and properties mentioned in the pages back to the API (usually the first mention, with the following instances just back-ticked).

A number of changes were also automatically made to these same files by Prettier as I saved them, but those changes seem in line with current guidelines, so hopefully they aren't an issue. Prettier can be annoyingly opinionated, but it has done wonders for my code consistency, so I recommend it, especially when working in a team. I did address one issue in the Prettier config file so it won't add three spaces after the "-" of a list item (this also fixed the JS/TS tab spacing to 2, which isn't my personal preference but is more common).

I added a `.markdownlint.json` file to allow that tool to function without giving unnecessary warnings. One thing markdownlint caught that I wasn't sure how to address was that it flagged H1s at the top of the page where there is already a `title` in the YAML header block. It considers this a duplicate page title. For now, I disabled that error in its configuration file, but if the team's intention is to avoid H1s for that reason, it can be easily re-enabled.

I definitely let myself wander too far before I made a commit... sorry about that! I'll do smaller commits in the future.