### PR TITLE
Update gltfExporter.md with Bayblon.js exporter capabilities

### DIFF
--- a/content/extensions/glTFExporter/glTFExporter.md
+++ b/content/extensions/glTFExporter/glTFExporter.md
@@ -107,7 +107,7 @@ BABYLON.GLTF2Export.GLBAsync(scene, "fileName", options).then((glb) => {
   - ✔️ Metal Roughness Materials [pbrMetallicRoughness](https://github.com/KhronosGroup/glTF/tree/master/specification/2.0#metallic-roughness-material)
     - A conversion from `StandardMaterial` to `MetallicRoughness` has been implemented to try to match as close as visibly possible, though not all Babylon.js features are supported in glTF.
   - ❌ Specular Glossiness Materials Extension [KHR_materials_pbrSpecularGlossiness](https://github.com/KhronosGroup/glTF/tree/master/extensions/2.0/Khronos/KHR_materials_pbrSpecularGlossiness)
-    - `SpecularGlossiness` has been superseeded by KHR_materials_specular. PBRSpecularGlossiness will not be supported.
+    - `SpecularGlossiness` has been superseeded by KHR_materials_specular. `KHR_materials_pbrSpecularGlossiness` will not be supported.
   - ❌ Specular Materials Extension [KHR_materials_specular](https://github.com/KhronosGroup/glTF/pull/1719/files?short_path=3757306#diff-3757306b203ae39ab0610702c04a45d4d598b904fe8ba4961ebc1c0409730b45)
   - ❌ Material Index of Refraction Extension [KHR_materials_ior](https://github.com/KhronosGroup/glTF/pull/1718/files?short_path=4698aba#diff-4698abaf20aa5bce525ce57cf0def8a07a476cd9dbc961226bef22e04a6a1591)
   - ❌ Material Translucency Extension [KHR_materials_Translucency](https://github.com/KhronosGroup/glTF/pull/1825)
@@ -150,3 +150,4 @@ Key:
   - IOR [KHR_Materials_IOR](https://github.com/KhronosGroup/glTF/pull/1718) is still in draft
   - Translucency [KHR_Materials_Translucency](https://github.com/KhronosGroup/glTF/pull/1825) is still in draft
 - Camera Serialization [Babylon.js #9146](https://github.com/BabylonJS/Babylon.js/issues/9146)
+- Mesh Instancing Extension [Babylon.js #7522](https://github.com/BabylonJS/Babylon.js/issues/7522)

--- a/content/extensions/glTFExporter/glTFExporter.md
+++ b/content/extensions/glTFExporter/glTFExporter.md
@@ -95,7 +95,7 @@ BABYLON.GLTF2Export.GLBAsync(scene, "fileName", options).then((glb) => {
 - ✔️ Node Export
 - ⚠️ Camera Export
     - Cameras are currently exported as an empty nodes.
-    
+
 - ✔️ Mesh Export
   - ✔️ Multiple UV sets
   - ✔️ Morph Targets
@@ -107,7 +107,7 @@ BABYLON.GLTF2Export.GLBAsync(scene, "fileName", options).then((glb) => {
   - ✔️ Metal Roughness Materials [pbrMetallicRoughness](https://github.com/KhronosGroup/glTF/tree/master/specification/2.0#metallic-roughness-material)
     - A conversion from `StandardMaterial` to `MetallicRoughness` has been implemented to try to match as close as visibly possible, though not all Babylon.js features are supported in glTF.
   - ❌ Specular Glossiness Materials Extension [KHR_materials_pbrSpecularGlossiness](https://github.com/KhronosGroup/glTF/tree/master/extensions/2.0/Khronos/KHR_materials_pbrSpecularGlossiness)
-    - SpecularGlossiness has been superseeded by KHR_materials_specular. PBRSpecularGlossiness will not be supported.
+    - `SpecularGlossiness` has been superseeded by KHR_materials_specular. PBRSpecularGlossiness will not be supported.
   - ❌ Specular Materials Extension [KHR_materials_specular](https://github.com/KhronosGroup/glTF/pull/1719/files?short_path=3757306#diff-3757306b203ae39ab0610702c04a45d4d598b904fe8ba4961ebc1c0409730b45)
   - ❌ Material Index of Refraction Extension [KHR_materials_ior](https://github.com/KhronosGroup/glTF/pull/1718/files?short_path=4698aba#diff-4698abaf20aa5bce525ce57cf0def8a07a476cd9dbc961226bef22e04a6a1591)
   - ❌ Material Translucency Extension [KHR_materials_Translucency](https://github.com/KhronosGroup/glTF/pull/1825)
@@ -117,16 +117,16 @@ BABYLON.GLTF2Export.GLBAsync(scene, "fileName", options).then((glb) => {
   - ✔️ Double sided materials
   - ❌ Material variants [KHR_materials_variants](https://github.com/KhronosGroup/glTF/tree/master/extensions/2.0/Khronos/KHR_materials_variants)
 
-    
+
 - ✔️ Animation
-  - ✔️ Node Translate, Rotate, Scaling animation 
+  - ✔️ Node Translate, Rotate, Scaling animation
   - ✔️ Skeletal Animation
     - As skeletons in glTF are represented as collections of nodes in the scene, skeletal animation is exported as TRS animation
   - ✔️ Morph Target Weight Animation
   - ✔️ Multiple animations
     - In scene, AnimationGroups will be exported as a single glTF Animation.
     - In scene, Animations not associated with an AnimationGroup will be exported as a single glTF animation.
-   
+
 - ✔️ Buffer View and Accessor Reuse
 - ✔️ Extras Data
 - ❌ XMP Metadata [KHR_XMP](https://github.com/KhronosGroup/glTF/tree/master/extensions/2.0/Khronos/KHR_xmp)
@@ -138,7 +138,6 @@ Key:
     ✔️ Full support
     ⚠️ Partial Support
     ❌ No Support
-    ❔ Needs Data
 
 
 ## Coming soon

--- a/content/extensions/glTFExporter/glTFExporter.md
+++ b/content/extensions/glTFExporter/glTFExporter.md
@@ -90,18 +90,63 @@ BABYLON.GLTF2Export.GLBAsync(scene, "fileName", options).then((glb) => {
 ```
 
 ## Supported features
+- ✔️ Scene JSON string Export (.gltf)
+- ✔️ Scene Binary Export (.glb)
+- ✔️ Node Export
+- ⚠️ Camera Export
+    - Cameras are currently exported as an empty nodes.
+    
+- ✔️ Mesh Export
+  - ✔️ Multiple UV sets
+  - ✔️ Morph Targets
+  - ✔️ Skinned Meshes
+  - ❌ Mesh Instancing Extension [EXT_mesh_gpu_instancing](https://github.com/KhronosGroup/glTF/tree/master/extensions/2.0/Vendor/EXT_mesh_gpu_instancing)
+  - ❌ Draco Mesh Compression Extension [KHR_draco_mesh_compression](https://github.com/KhronosGroup/glTF/tree/master/extensions/2.0/Khronos/KHR_draco_mesh_compression)
 
-- Currently the following material types are supported:
-  - `PBRMaterial`
-    - Not all Babylon `PBRMaterial` features are supported in glTF.
-  - `MetallicRoughnessMaterial`
-  - `StandardMaterial`
-    - A conversion from `StandardMaterial` to `MetallicRoughness` has been implemented to try to match as close as visibly possible, though not allBabylon.js features are supported in glTF.
-  - `SpecularGlossinessMaterial`
-    - glTF Exporter converts `SpecularGlossiness` materials to `MetallicRoughness` to match core glTF 2.0 specification.
-- Node-based TRS animation
+- ⚠️ Material Export
+  - ✔️ Metal Roughness Materials [pbrMetallicRoughness](https://github.com/KhronosGroup/glTF/tree/master/specification/2.0#metallic-roughness-material)
+    - A conversion from `StandardMaterial` to `MetallicRoughness` has been implemented to try to match as close as visibly possible, though not all Babylon.js features are supported in glTF.
+  - ❌ Specular Glossiness Materials Extension [KHR_materials_pbrSpecularGlossiness](https://github.com/KhronosGroup/glTF/tree/master/extensions/2.0/Khronos/KHR_materials_pbrSpecularGlossiness)
+    - SpecularGlossiness has been superseeded by KHR_materials_specular. PBRSpecularGlossiness will not be supported.
+  - ❌ Specular Materials Extension [KHR_materials_specular](https://github.com/KhronosGroup/glTF/pull/1719/files?short_path=3757306#diff-3757306b203ae39ab0610702c04a45d4d598b904fe8ba4961ebc1c0409730b45)
+  - ❌ Material Index of Refraction Extension [KHR_materials_ior](https://github.com/KhronosGroup/glTF/pull/1718/files?short_path=4698aba#diff-4698abaf20aa5bce525ce57cf0def8a07a476cd9dbc961226bef22e04a6a1591)
+  - ❌ Material Translucency Extension [KHR_materials_Translucency](https://github.com/KhronosGroup/glTF/pull/1825)
+  - ❌ Unlit Materials Extension [KHR_materials_unlit](https://github.com/KhronosGroup/glTF/tree/master/extensions/2.0/Khronos/KHR_materials_unlit)
+  - ✔️ Occlusion, Roughness, Emissive (ORM) map
+  - ✔️ Material Alpha Coverage modes
+  - ✔️ Double sided materials
+  - Material variants [KHR_materials_variants]()
+    
+- ✔️ Animation
+  - ✔️ Node Translate, Rotate, Scaling animation 
+  - ✔️ Skeletal Animation
+    - As skeletons in glTF are represented as collections of nodes in the scene, skeletal animation is exported as TRS animation
+  - ✔️ Morph Target Weight Animation
+  - ✔️ Multiple animations
+    - In scene, AnimationGroups will be exported as a single glTF Animation.
+    - In scene, Animations not associated with an AnimationGroup will be exported as a single glTF animation.
+   
+- ✔️ Buffer View and Accessor Reuse
+- ✔️ Extras Data
+- ❌ XMP Metadata [KHR_XMP](https://github.com/KhronosGroup/glTF/tree/master/extensions/2.0/Khronos/KHR_xmp)
+- ⚠️ Asset Info
+    - Copyright field specification not supported.
+
+Key:
+
+    ✔️ Full support
+    ⚠️ Partial Support
+    ❌ No Support
+    ❔ Needs Data
+
 
 ## Coming soon
 
-- Skinning animation
-- Morph Targets
+- Material Extensions
+  - Clear coat [Babylon.js #10181](https://github.com/BabylonJS/Babylon.js/issues/10181)
+  - Specular [Babylon.js #8968](https://github.com/BabylonJS/Babylon.js/issues/8968), however [KHR_Materials_Specular](https://github.com/KhronosGroup/glTF/pull/1719) is still in draft
+  - Draco Mesh Compression [Babylon.js #8046](https://github.com/BabylonJS/Babylon.js/issues/8046)
+  - Volume [KHR_Materials_Volume](https://github.com/KhronosGroup/glTF/pull/1726) is still in draft
+  - IOR [KHR_Materials_IOR](https://github.com/KhronosGroup/glTF/pull/1718) is still in draft
+  - Translucency [KHR_Materials_Translucency](https://github.com/KhronosGroup/glTF/pull/1825) is still in draft
+- Camera Serialization [Babylon.js #9146](https://github.com/BabylonJS/Babylon.js/issues/9146)

--- a/content/extensions/glTFExporter/glTFExporter.md
+++ b/content/extensions/glTFExporter/glTFExporter.md
@@ -115,7 +115,8 @@ BABYLON.GLTF2Export.GLBAsync(scene, "fileName", options).then((glb) => {
   - ✔️ Occlusion, Roughness, Emissive (ORM) map
   - ✔️ Material Alpha Coverage modes
   - ✔️ Double sided materials
-  - Material variants [KHR_materials_variants]()
+  - ❌ Material variants [KHR_materials_variants](https://github.com/KhronosGroup/glTF/tree/master/extensions/2.0/Khronos/KHR_materials_variants)
+
     
 - ✔️ Animation
   - ✔️ Node Translate, Rotate, Scaling animation 


### PR DESCRIPTION
Following the criterion used for https://github.com/KhronosGroup/glTF/issues/1271, updated the documentation to reflect the current capabilities of the engine.