### PR TITLE
Updates to height-map documentation

### DIFF
--- a/content/How_To/mesh/creation/set/height_map.md
+++ b/content/How_To/mesh/creation/set/height_map.md
@@ -25,8 +25,7 @@ Understanding height maps is the main objective of this tutorial. A height map i
 
 ![HeightMap3](/img/how_to/HeightMap/worldHeightMap.jpg)
 
-> To help you generate height-map textures (like the one above), you can use software such as “Terragen”, or ”Picogen”.
->
+> To help you generate height-map textures (like the one above), you can use software such as [Terragen](https://planetside.co.uk/free-downloads/terragen-4-free-download/), or [Picogen ](https://picogen.org/downloads.php.html)(free).
 
 ### Javascript code
 

--- a/content/How_To/mesh/creation/set/height_map.md
+++ b/content/How_To/mesh/creation/set/height_map.md
@@ -10,112 +10,77 @@ video-content:
 
 ## Introduction
 
-In this tutorial, our goal is to understand height maps, and to learn how to generate realistic grounds.
+In this tutorial, our goal is to understand height maps, a method used to generate realistic terrain. 
+Height-maps are easy to use, customizable yet produce impressive terrain:
+
+>  What we are going to try and achieve
 
 ![HeightMap](/img/how_to/HeightMap/14.png)
 
-_Final result_
+## How to do this?
 
-## How can I do this ?
+### How height-maps work
 
-### Introduction
-
-Those mountains are very easy to generate with Babylon.js, and with only a single function. But before we do that, we have to create a new material, like we have done many times before:
-
-```javascript
-// Create a material with our land texture.
-var groundMaterial = new BABYLON.StandardMaterial("ground", scene);
-groundMaterial.diffuseTexture = new BABYLON.Texture("Earth__land.jpg", scene);
-
-// This shows how we would apply this material to a plane. In our later
-// example we'll replace this with CreateGroundFromHeightMap.
-var groundPlane = BABYLON.Mesh.CreatePlane("groundPlane", 200.0, scene);
-
-// When our new mesh is read, apply our material.
-groundPlane.material = groundMaterial;
-```
-
-![HeightMap2](/img/how_to/HeightMap/14-1.png)
-
-_Our material, a texture, applied to the plane_
-
-### Explanations of a height map
-
-Understanding height maps is the main objective of this tutorial. A height map is simply a grayscale image like the one we are going to use:
+Understanding height maps is the main objective of this tutorial. A height map is simply a gray-scale texture. Each pixel in the texture maps onto the height of a point on a plane, thus the name height-map. The whiter the pixel the higher the displacement, the darker the lesser the displacement. From the variations of gray within the texture we can map out a terrain. For this example we shall use the following texture: 
 
 ![HeightMap3](/img/how_to/HeightMap/worldHeightMap.jpg)
 
-This image will now be used to generate our ground, using the different variants of gray of our picture. This image is the elevation data for your ground. Each pixel’s color is interpreted as a distance of displacement or “height” from the “floor” of your mesh. So, the whiter the pixel is, the taller your mountain will be.
-
-To help you generate those grayscale height maps, you can use software such as “Terragen”, or ”Picogen”.
+> To help you generate height-map textures (like the one above), you can use software such as “Terragen”, or ”Picogen”.
+>
 
 ### Javascript code
 
-  Now let’s see this powerful function named `CreateGroundFromHeightMap`:
+Now let’s see this powerful function named `CreateGroundFromHeightMap`:
 
 ```javascript
 // Create a material with our land texture.
-var groundMaterial = new BABYLON.StandardMaterial("ground", scene);
+let groundMaterial = new BABYLON.StandardMaterial("ground", scene);
 groundMaterial.diffuseTexture = new BABYLON.Texture("Earth__land.jpg", scene);
 
-// Use CreateGroundFromHeightMap to create a height map of 200 units by 200
+// Use CreateGroundFromHeightMap to create a height map of 20 units by 20
+// And a height of to
 // units, with 250 subdivisions in each of the `x` and `z` directions, for a
 // total of 62,500 divisions.
-var ground = BABYLON.Mesh.CreateGroundFromHeightMap("ground", "worldHeightMap.jpg", 200, 200, 250, 0, 10, scene, false, successCallback);
+const ground = BABYLON.MeshBuilder.CreateGroundFromHeightMap("gdhm", "textures/heightMap.png", {
+    width: 20, height: 20, subdivisions: 250, maxHeight: 10, minHeight: 2
+});
 
-// When our new mesh is read, apply our material.
+// Bind our material to our mesh
 ground.material = groundMaterial;
 ```
-  
-There are many parameters here:
-* _Name_
-* _Height map picture url_
-* _Width of mesh_
-* _Height of mesh_
-* _Number of subdivisions_: increase the complexity of this mesh in order to improve the visual quality of the result
 
-![HeightMap4](/img/how_to/HeightMap/14-2.png)
+The parameters passed are:
 
-* _Minimum height_ : The lowest level of the mesh
-* _Maximum height_ : the highest level of the mesh
-* _Scene_: the actual scene
-* _Updatable_: indicates if this mesh can be updated dynamically in the future (Boolean)
-* _successCallback_ : will be called after the height map was created and the vertex data is created. It is a function with the mesh as its first variable.
+- **name**: The name of the resulting mesh
+- **Height-map texture**: The URL of the height-map texture.
+- **options**: The options for producing the height-map.
+- **scene**: The scene to append the resulting mesh
+- **updatable**: Boolean to specify if the mesh should be updatable.
+- **successCallback**: Callback that resolves to the successfully produced height-map terrain.
 
-Now we have a beautiful 3D view of the earth!
+The following are options, third parameter, used to construct the height-mapped plane:
+
+* **width**: The width of the plane
+* **height**: The height of the plane
+* **minHeight**: Lowest point on the plane
+* **maxHeight**: Highest point on the plane
+* **subdivisions**: How detailed should our height-mapped plane be. Higher for higher poly count and therefore better visual quality. As seen below:
+* ![HeightMap4](/img/how_to/HeightMap/14-2.png)
+
+----
+
+> Now we can see a 3d representation of the earth's surface on a plane!
 
 ![HeightMap4](/img/how_to/HeightMap/14-3.png)
 
-In my example, I have added a skybox (like we have learned before [here](/divingDeeper/environment/environment_introduction)), and a spotlight to simulate sun activity.
-
-Here is another example showing what you can achieve withBabylon.js height maps:
+Another example showing basic lighting, height-maps and a [skybox](/divingDeeper/environment/environment_introduction) in use!
 
 ![HeightMap5](/img/how_to/HeightMap/14-4.png)
 
-### Tips
+### Tips.
 
-When the user is manipulating the camera, it can be awkward if they can see under the ground, or if they zoom-out outside the skybox. So, to avoid that kind of situation, we can constrain the camera movement:
+If a height-map negatively impacts performance try reducing the subdivisions to reduce the number of polygons on the mesh. For further documentation go [here](https://doc.babylonjs.com/typedoc/classes/babylon.groundbuilder#creategroundfromheightmap).
 
-```javascript
-var camerasBorderFunction = function () {
-    //Angle
-    if (camera.beta < 0.1)
-        camera.beta = 0.1;
-    else if (camera.beta > (Math.PI / 2) * 0.9)
-        camera.beta = (Math.PI / 2) * 0.9;
-
-    //Zoom
-    if (camera.radius > 150)
-        camera.radius = 150;
-
-    if (camera.radius < 30)
-        camera.radius = 30;
-};
-
-scene.registerBeforeRender(camerasBorderFunction);
-```
-
-You may be interested in visiting the playground demo that goes with this tutorial:
+#### Playground examples.
 
 <Playground id="#95PXRY" title="Height Map Example" description="Simple example of using a height map."/>
-


### PR DESCRIPTION
Cleared some spelling and grammar mistakes, I think. Reduced the amount of information delivered for a more streamlined learning experience. Changed code examples to use cleaner more readable code. Removed `var` in favor of `const`. Changed structure of the document a little bit.