### PR TITLE
Add WebXR ES6 module info and example with vite

### DIFF
--- a/content/How_To/WebXR/Introduction_To_WebXR.md
+++ b/content/How_To/WebXR/Introduction_To_WebXR.md
@@ -164,6 +164,33 @@ And that's it!
 
 Make sure to read more on the [WebXR Experience Helper](/divingDeeper/webXR/webXRExperienceHelpers) for further tips and tricks, and take a look at our [Demos and examples](/divingDeeper/webXR/webXRDemos) page.
 
+### ES6 support with Tree Shaking
+
+When using [Babylon.js ES6 support with tree shaking](divingDeeper/developWithBjs/treeShaking), import WebXR modules from:
+
+ *  `@babylonjs/core/XR/*`
+
+And import loaders and side-effects for loading default controller models from the [WebXR Input Profiles](https://github.com/immersive-web/webxr-input-profiles) github repository.
+
+For example:
+
+```javascript
+import { WebXRDefaultExperience } from '@babylonjs/core/XR/webXRDefaultExperience.js'
+
+// Enable GLTF/GLB loader for loading controller models from WebXR Input registry
+import '@babylonjs/loaders/glTF'
+
+// Without this next import, an error message like this occurs loading controller models:
+//  Build of NodeMaterial failed" error when loading controller model
+//  Uncaught (in promise) Build of NodeMaterial failed: input rgba from block
+//  FragmentOutput[FragmentOutputBlock] is not connected and is not optional.
+import '@babylonjs/core/Materials/Node/Blocks'
+
+```
+See also:
+ * [WebXR Controllers Support](/divingDeeper/webXR/webXRInputControllerSupport)
+ * [WebXR with Vite](/divingDeeper/webXR/webXRDemos#webxr-with-vite)
+
 ## Migrating from WebVR
 
 WebVR is deprecated and will soon end its life in most if not all browsers. It is highly recommended to port all WebVR implementations to WebXR.

--- a/content/How_To/WebXR/WebXR_Demos_and_Examples.md
+++ b/content/How_To/WebXR/WebXR_Demos_and_Examples.md
@@ -78,3 +78,136 @@ panel.addControl(picker);
 <Playground id="#JA1ND3#161" title="Mansion" description="Mansion Demo"/>
 <Playground id="#TJIGQ1#3" title="Hill Valley" description="Hill Valley"/>
 <Playground id="#JA1ND3#164" title="Espilit" description="Espilit"/>
+
+## WebXR with Vite
+Step-by-step project setup using Vite and Babylon.js ES6 modules for
+WebXR development.
+
+### Install Vite
+```bash
+## Setup vite
+npm create vite@latest
+##> Project name: babylon-webxr-test
+##> Select a framework: vanilla
+##> Select a variant: vanilla-ts
+```
+
+### Install @babylonjs ES6 packages
+```bash
+npm install @babylonjs/core@^5.0.0-beta.8
+npm install @babylonjs/loaders@^5.0.0-beta.8
+```
+
+### Enable HTTPS dev server
+HTTPS is required by most VR devices. Create or modify `vite.config.ts`:
+```javascript
+import { defineConfig } from 'vite'
+
+// https://vitejs.dev/config/
+export default defineConfig({
+  server: {
+    port: 3443,
+    https: true,
+    // Uncomment to allow access from network
+    // (or use `npm run dev -- -- host=0.0.0.0`)
+    //host: '0.0.0.0',
+  },
+})
+```
+
+### Setup a basic WebXR scene
+Modify `main.ts`:
+```javascript
+import './style.css'
+
+import { ArcRotateCamera } from '@babylonjs/core/Cameras/arcRotateCamera.js'
+import { Color3 } from "@babylonjs/core/Maths/math.color.js"
+import { Engine } from '@babylonjs/core/Engines/engine.js'
+import { HemisphericLight } from '@babylonjs/core/Lights/hemisphericLight.js'
+import { Mesh } from "@babylonjs/core/Meshes/mesh"
+import { MeshBuilder } from "@babylonjs/core/Meshes/meshBuilder.js"
+import { Scene } from '@babylonjs/core/scene.js'
+import { StandardMaterial } from "@babylonjs/core/Materials/standardMaterial.js"
+import { Vector3 } from '@babylonjs/core/Maths/math.vector.js'
+import { WebXRDefaultExperience } from '@babylonjs/core/XR/webXRDefaultExperience.js'
+
+// Used for the scene.createDefaultEnvironment
+import "@babylonjs/core/Helpers/sceneHelpers"
+
+// Enable GLTF/GLB loader for loading controller models from WebXR Input registry
+import '@babylonjs/loaders/glTF'
+
+// Without this next import, an error message like this occurs loading controller models:
+//  Build of NodeMaterial failed" error when loading controller model
+//  Uncaught (in promise) Build of NodeMaterial failed: input rgba from block
+//  FragmentOutput[FragmentOutputBlock] is not connected and is not optional.
+import '@babylonjs/core/Materials/Node/Blocks'
+
+// Create a canvas element for rendering
+const app = document.querySelector<HTMLDivElement>('#app')
+const canvas = document.createElement('canvas')
+app?.appendChild(canvas)
+
+// Create engine and a scene
+const babylonEngine = new Engine(canvas, true)
+const scene = new Scene(babylonEngine)
+
+// Add a basic light
+new HemisphericLight('light1', new Vector3(0, 2, 0), scene)
+
+// Create a default environment (skybox, ground mesh, etc)
+const envHelper = scene.createDefaultEnvironment({
+  skyboxSize: 30,
+  groundColor: new Color3(0.5, 0.5, 0.5),
+})
+
+// Add a camera for the non-VR view in browser
+const camera = new ArcRotateCamera("Camera", -(Math.PI / 4) * 3, Math.PI / 4, 10, new Vector3(0, 0, 0), scene);
+camera.attachControl(true)
+
+// Add a sphere to have something to look at
+const sphereD = 1.0
+const sphere = MeshBuilder.CreateSphere('xSphere', { segments: 16, diameter: sphereD }, scene)
+sphere.position.x = 0
+sphere.position.y = sphereD * 2
+sphere.position.z = 0
+const rMat = new StandardMaterial("matR", scene)
+rMat.diffuseColor = new Color3(1.0, 0, 0)
+sphere.material = rMat
+
+// Setup default WebXR experience
+// Use the enviroment floor to enable teleportation
+WebXRDefaultExperience.CreateAsync(scene, {
+  floorMeshes: [envHelper?.ground as Mesh],
+  optionalFeatures: true,
+})
+
+// Run render loop
+babylonEngine.runRenderLoop(() => {
+  scene.render()
+})
+```
+
+Corresponding git repo: [kaliatech/babylon-docs-vite-webxr](https://github.com/kaliatech/babylon-docs-vite-webxr)
+
+### Run server and verify
+Start vite dev server and make it accessible from the network:
+```bash
+npm run dev -- --host 0.0.0.0
+```
+
+Browsing to `https://<your-server-ip>:3443` on a desktop machine should show the basic scene. If
+the [WebXR API Emulator](https://github.com/MozillaReality/WebXR-emulator-extension) is enabled, you
+should also see Babylon.js's default VR headset mode icon
+
+If viewing from within a headset, the controller models should correspond to what is available in the global 
+registry for your device.
+
+To check TypeScript types and build:
+```bash
+npm run build
+```
+Using the setup above, vite reports a vendor.js size of ~2.4MB (536k gzipped) as of babylon-5.0.0-beta.8.
+
+
+


### PR DESCRIPTION
Changes:
 * Adds section to "Introduction to WebXR" regarding ES6 modules and imports
 * Adds section to "WebXR Demos and Examples" showing a simple Vite/Typescript/ES6 project setup.

Related forum post:
 * https://forum.babylonjs.com/t/webxr-project-setup-with-babylon-js-5-and-vite/27654

To Check:
 * I included comments regarding the need to import `@babylonjs/core/Materials/Node/Blocks` to avoid an error I was seeing. I haven't discussed with anyone on babylon.js team as to if that is expected.
 * I linked to a personal git repo for the example as a convenience.  Allowed? It could be removed without impacting usefulness of the docs.
 
 