### PR TITLE
Fix missing title in 'Transparent Rendering' page

### DIFF
--- a/content/resources/Manual/Transparency_and_How_Meshes_Are_Rendered.md
+++ b/content/resources/Manual/Transparency_and_How_Meshes_Are_Rendered.md
@@ -82,7 +82,7 @@ The goal is either to optimize the scene by rendering meshes to the depth buffer
 
 These will be the easiest to render: their polygons are fully drawn on screen with their colors and textures. A depth buffer will be used to make sure nothing is drawn over something that is closer to the camera.
 
-# Alpha Tested Meshes
+## Alpha Tested Meshes
 
 Same as opaque meshes, except that some parts of these meshes can be defined as completely transparent. Alpha test means that each pixel of the mesh can be either opaque (and then drawn on screen and in the depth buffer) or transparent, which means the pixel is completely discarded. Although very efficient, this type of render usually produces aliased borders and does not allow for smooth transparency effects.
 


### PR DESCRIPTION
The 'Alpha Tested Meshes' title is missing in the document. This is to fix the title error.

![image](https://user-images.githubusercontent.com/5469750/154375317-f2d699a2-3ffe-442a-8aec-e0545d6785a6.png)
