### PR TITLE
Fix Erosion WebGPU demo

### DIFF
--- a/content/How_To/shaders/compute_shader.md
+++ b/content/How_To/shaders/compute_shader.md
@@ -123,7 +123,7 @@ As the storage buffers we use to compute the particle positions and velocities w
 
 ### Hydraulic erosion
 
-<Playground id="#C90R62#10" engine="webgpu" title="Hydraulic erosion" description="Simulate erosion to make terrains look more natural"/>
+<Playground id="#C90R62#12" engine="webgpu" title="Hydraulic erosion" description="Simulate erosion to make terrains look more natural"/>
 
 This is a port of the great project [Hydraulic-Erosion](https://github.com/SebLague/Hydraulic-Erosion): all credits to sebastlague@gmail.com!
 


### PR DESCRIPTION
Removing WGSL ignore which looks deprecated between https://playground.babylonjs.com/#C90R62#10 and https://playground.babylonjs.com/#C90R62#12