### PR TITLE
Fix 19 broken links in "Playground" & "Framework Versions" docs section

### DIFF
--- a/content/landing_pages/PGsupport/Playground.md
+++ b/content/landing_pages/PGsupport/Playground.md
@@ -55,7 +55,7 @@ In Typescript mode the menu has an orange color theme
 - **Language**: Typescript/JavaScript switch.
 - **Run** ![run](/public/img/features/pgsupport/run.jpg): Commands the playground to try to render your scene.
 - **Save** ![save](/public/img/features/pgsupport/save.jpg): Causes your scene to be permanently stored in the playground's database and it will issue a unique URL for each save. On save you will be asked to complete the metadata so that it can be searched for. Once saved it is a good idea to bookmark the page so you can return to it later. You could then share the URL with others, for example, if it is not working as you expect you can ask a question in the forum along with the link to your playground.
-- **Download** ![zip](/img/features/PGsupport/zip.jpg): Allows you to download a zip file named *sample.zip*. Once downloaded and unzipped, you will see a file named `index.html` 
+- **Download** ![zip](/public/img/features/pgsupport/zip.jpg): Allows you to download a zip file named *sample.zip*. Once downloaded and unzipped, you will see a file named `index.html` 
 which contains everything necessary to run the code in your browser, including links to external *babylon.js* and other files.
 - **New** ![new](/img/features/PGsupport/new.jpg): Places a basic `createScene()` function into the editor along with code to initialise the scene variable and provide a camera.
 - **Clear** ![clear](/img/features/PGsupport/clear.jpg): Empties all the code out of the playground editor.  You could then paste in any createScene function you are working on locally.

--- a/content/landing_pages/PGsupport/Playground.md
+++ b/content/landing_pages/PGsupport/Playground.md
@@ -57,7 +57,7 @@ In Typescript mode the menu has an orange color theme
 - **Save** ![save](/public/img/features/pgsupport/save.jpg): Causes your scene to be permanently stored in the playground's database and it will issue a unique URL for each save. On save you will be asked to complete the metadata so that it can be searched for. Once saved it is a good idea to bookmark the page so you can return to it later. You could then share the URL with others, for example, if it is not working as you expect you can ask a question in the forum along with the link to your playground.
 - **Download** ![zip](/public/img/features/pgsupport/zip.jpg): Allows you to download a zip file named *sample.zip*. Once downloaded and unzipped, you will see a file named `index.html` 
 which contains everything necessary to run the code in your browser, including links to external *babylon.js* and other files.
-- **New** ![new](/img/features/PGsupport/new.jpg): Places a basic `createScene()` function into the editor along with code to initialise the scene variable and provide a camera.
+- **New** ![new](/public/img/features/pgsupport/new.jpg): Places a basic `createScene()` function into the editor along with code to initialise the scene variable and provide a camera.
 - **Clear** ![clear](/img/features/PGsupport/clear.jpg): Empties all the code out of the playground editor.  You could then paste in any createScene function you are working on locally.
 - **Settings** ![set](/img/features/PGsupport/set.jpg): The Settings button has a sub menu with extra options
   - *Theme*: Choose the theme for the playground

--- a/content/landing_pages/PGsupport/Playground.md
+++ b/content/landing_pages/PGsupport/Playground.md
@@ -123,7 +123,7 @@ You can have fun showing directly your playground imbedded into your message, us
 <iframe src="https://www.babylonjs-playground.com/frame.html#6F0LKI#2" width="400px" height="250px" ></iframe>
 ```
 
-![playground forum sharing ways](/img/features/pgsupport/pg-forum-sharing-ways.jpg)
+![playground forum sharing ways](/public/img/features/pgsupport/pg-forum-sharing-ways.jpg)
 > *so many ways to share an issue*
 
 ## Compilation Errors

--- a/content/landing_pages/PGsupport/Playground.md
+++ b/content/landing_pages/PGsupport/Playground.md
@@ -30,7 +30,7 @@ You can write the code in JavaScript or Typescript. The playground software comp
 
 ## Overview
 
-![Playground Overview](/img/how_to/Introduction/playground.jpg)
+![Playground Overview](/public/img/how_to/Introduction/playground.jpg)
 
 The Playground consists of four areas:
 

--- a/content/landing_pages/PGsupport/Playground.md
+++ b/content/landing_pages/PGsupport/Playground.md
@@ -77,7 +77,7 @@ which contains everything necessary to run the code in your browser, including l
 
 - **Menu** ![menu](/public/img/features/pgsupport/menu.jpg): Contains Run, New, Clear, Save and Zip as submenus.
 - **Code** ![code](/public/img/features/pgsupport/code.jpg): Bottom Left Corner - switch to Code View and Editor.
-- **Scene** ![scene](/img/features/PGsupport/scene.jpg): Bottom Right Corner - switch to Scene View.
+- **Scene** ![scene](/public/img/features/pgsupport/scene.jpg): Bottom Right Corner - switch to Scene View.
 
 ## Playground URL formats
 

--- a/content/landing_pages/PGsupport/Playground.md
+++ b/content/landing_pages/PGsupport/Playground.md
@@ -75,7 +75,7 @@ which contains everything necessary to run the code in your browser, including l
 
 ### Small Screens
 
-- **Menu** ![menu](/img/features/PGsupport/menu.jpg): Contains Run, New, Clear, Save and Zip as submenus.
+- **Menu** ![menu](/public/img/features/pgsupport/menu.jpg): Contains Run, New, Clear, Save and Zip as submenus.
 - **Code** ![code](/img/features/PGsupport/code.jpg): Bottom Left Corner - switch to Code View and Editor.
 - **Scene** ![scene](/img/features/PGsupport/scene.jpg): Bottom Right Corner - switch to Scene View.
 

--- a/content/landing_pages/PGsupport/Playground.md
+++ b/content/landing_pages/PGsupport/Playground.md
@@ -58,7 +58,7 @@ In Typescript mode the menu has an orange color theme
 - **Download** ![zip](/public/img/features/pgsupport/zip.jpg): Allows you to download a zip file named *sample.zip*. Once downloaded and unzipped, you will see a file named `index.html` 
 which contains everything necessary to run the code in your browser, including links to external *babylon.js* and other files.
 - **New** ![new](/public/img/features/pgsupport/new.jpg): Places a basic `createScene()` function into the editor along with code to initialise the scene variable and provide a camera.
-- **Clear** ![clear](/img/features/PGsupport/clear.jpg): Empties all the code out of the playground editor.  You could then paste in any createScene function you are working on locally.
+- **Clear** ![clear](/public/img/features/pgsupport/clear.jpg): Empties all the code out of the playground editor.  You could then paste in any createScene function you are working on locally.
 - **Settings** ![set](/img/features/PGsupport/set.jpg): The Settings button has a sub menu with extra options
   - *Theme*: Choose the theme for the playground
   - *Font size*: Set the font size in the editor.

--- a/content/landing_pages/PGsupport/Playground.md
+++ b/content/landing_pages/PGsupport/Playground.md
@@ -47,7 +47,7 @@ The space for the coding editor and rendering area can be adjusted by dragging t
 
 In Typescript mode the menu has an orange color theme
 
-![Playground Typescript Menu](/img/how_to/Introduction/pgmenu_ts.jpg)
+![Playground Typescript Menu](/public/img/how_to/Introduction/pgmenu_ts.jpg)
 
 ### Large Screen
 

--- a/content/landing_pages/PGsupport/Playground.md
+++ b/content/landing_pages/PGsupport/Playground.md
@@ -59,7 +59,7 @@ In Typescript mode the menu has an orange color theme
 which contains everything necessary to run the code in your browser, including links to external *babylon.js* and other files.
 - **New** ![new](/public/img/features/pgsupport/new.jpg): Places a basic `createScene()` function into the editor along with code to initialise the scene variable and provide a camera.
 - **Clear** ![clear](/public/img/features/pgsupport/clear.jpg): Empties all the code out of the playground editor.  You could then paste in any createScene function you are working on locally.
-- **Settings** ![set](/img/features/PGsupport/set.jpg): The Settings button has a sub menu with extra options
+- **Settings** ![set](/public/img/features/pgsupport/set.jpg): The Settings button has a sub menu with extra options
   - *Theme*: Choose the theme for the playground
   - *Font size*: Set the font size in the editor.
   - *Safe Mode*: When the checkbox is ticked the playground issues a "leaving the page?" confirmation warning when you try to unload/reload a freshly-edited, un-saved scene.

--- a/content/landing_pages/PGsupport/Playground.md
+++ b/content/landing_pages/PGsupport/Playground.md
@@ -53,7 +53,7 @@ In Typescript mode the menu has an orange color theme
 
 - **Title and Version**: As stated.
 - **Language**: Typescript/JavaScript switch.
-- **Run** ![run](/img/features/PGsupport/run.jpg): Commands the playground to try to render your scene.
+- **Run** ![run](/public/img/features/pgsupport/run.jpg): Commands the playground to try to render your scene.
 - **Save** ![save](/img/features/PGsupport/save.jpg): Causes your scene to be permanently stored in the playground's database and it will issue a unique URL for each save. On save you will be asked to complete the metadata so that it can be searched for. Once saved it is a good idea to bookmark the page so you can return to it later. You could then share the URL with others, for example, if it is not working as you expect you can ask a question in the forum along with the link to your playground.
 - **Download** ![zip](/img/features/PGsupport/zip.jpg): Allows you to download a zip file named *sample.zip*. Once downloaded and unzipped, you will see a file named `index.html` 
 which contains everything necessary to run the code in your browser, including links to external *babylon.js* and other files.

--- a/content/landing_pages/PGsupport/Playground.md
+++ b/content/landing_pages/PGsupport/Playground.md
@@ -76,7 +76,7 @@ which contains everything necessary to run the code in your browser, including l
 ### Small Screens
 
 - **Menu** ![menu](/public/img/features/pgsupport/menu.jpg): Contains Run, New, Clear, Save and Zip as submenus.
-- **Code** ![code](/img/features/PGsupport/code.jpg): Bottom Left Corner - switch to Code View and Editor.
+- **Code** ![code](/public/img/features/pgsupport/code.jpg): Bottom Left Corner - switch to Code View and Editor.
 - **Scene** ![scene](/img/features/PGsupport/scene.jpg): Bottom Right Corner - switch to Scene View.
 
 ## Playground URL formats

--- a/content/landing_pages/PGsupport/Playground.md
+++ b/content/landing_pages/PGsupport/Playground.md
@@ -54,7 +54,7 @@ In Typescript mode the menu has an orange color theme
 - **Title and Version**: As stated.
 - **Language**: Typescript/JavaScript switch.
 - **Run** ![run](/public/img/features/pgsupport/run.jpg): Commands the playground to try to render your scene.
-- **Save** ![save](/img/features/PGsupport/save.jpg): Causes your scene to be permanently stored in the playground's database and it will issue a unique URL for each save. On save you will be asked to complete the metadata so that it can be searched for. Once saved it is a good idea to bookmark the page so you can return to it later. You could then share the URL with others, for example, if it is not working as you expect you can ask a question in the forum along with the link to your playground.
+- **Save** ![save](/public/img/features/pgsupport/save.jpg): Causes your scene to be permanently stored in the playground's database and it will issue a unique URL for each save. On save you will be asked to complete the metadata so that it can be searched for. Once saved it is a good idea to bookmark the page so you can return to it later. You could then share the URL with others, for example, if it is not working as you expect you can ask a question in the forum along with the link to your playground.
 - **Download** ![zip](/img/features/PGsupport/zip.jpg): Allows you to download a zip file named *sample.zip*. Once downloaded and unzipped, you will see a file named `index.html` 
 which contains everything necessary to run the code in your browser, including links to external *babylon.js* and other files.
 - **New** ![new](/img/features/PGsupport/new.jpg): Places a basic `createScene()` function into the editor along with code to initialise the scene variable and provide a camera.

--- a/content/landing_pages/PGsupport/Playground.md
+++ b/content/landing_pages/PGsupport/Playground.md
@@ -43,7 +43,7 @@ The space for the coding editor and rendering area can be adjusted by dragging t
 
 ## The Menu
 
-![Playground Menu](/img/how_to/Introduction/pgmenu.jpg)
+![Playground Menu](/public/img/how_to/Introduction/pgmenu.jpg)
 
 In Typescript mode the menu has an orange color theme
 

--- a/content/landing_pages/PGsupport/Playground.md
+++ b/content/landing_pages/PGsupport/Playground.md
@@ -128,7 +128,7 @@ You can have fun showing directly your playground imbedded into your message, us
 
 ## Compilation Errors
 
-![compilation error popup](/img/features/pgsupport/pg-compilation-error.jpg)
+![compilation error popup](/public/img/features/pgsupport/pg-compilation-error.jpg)
 
 Any errors in your playground are flagged with a red pop-up box containing limited information. After making an adjustment to your code, you need not close the compilation error pop-up.  It should close automatically at the next Run, if all errors have been corrected.
 

--- a/content/landing_pages/PGsupport/Playground.md
+++ b/content/landing_pages/PGsupport/Playground.md
@@ -71,7 +71,7 @@ which contains everything necessary to run the code in your browser, including l
   - *Inspector*: The checkbox toggles the playground scene inspector which shows a multitude of variable values.
   - *Metadata*: This is where you describe your playground allowing yourself and other to search the playground database for examples of use.
 - **Version**: Allows and shows your choice of the BABYLON.js framework, either the current stable one or the latest preview version.
-- **Examples** ![examples](/img/features/PGsupport/ex.jpg): A drop down menu giving examples of playgrounds with a search filter.
+- **Examples** ![examples](/public/img/features/pgsupport/ex.jpg): A drop down menu giving examples of playgrounds with a search filter.
 
 ### Small Screens
 

--- a/content/resources/Reference/Framework_versions.md
+++ b/content/resources/Reference/Framework_versions.md
@@ -18,7 +18,7 @@ Babylon comes in two different versions - the preview version and the stable ver
 
 Both versions are considered to be stable and can be used in production. In certain cases (if we still haven't introduced any new features we don't want to have on the stable branch) the preview and the stable versions are identical.
 
-Both versions have their own CDN endpoint. The preview version is available on [preview.babylonjs.com](https://preview.babylonjs.com) and the stable version is available on [cdn.babylonjs.com](https://cdn.babylonjs.com).
+Both version editions can be found on [Github](https://github.com/BabylonJS/Babylon.js#cdn).
 
 When a new version is released on npm it is tagged with either stable or preview.
 

--- a/content/resources/Reference/Framework_versions.md
+++ b/content/resources/Reference/Framework_versions.md
@@ -52,7 +52,7 @@ Our preview CDN is updated every night with the latest features and bug fixes, e
 
 We have two flavors of releases:
 
-- [UMD packages](/divingDeeper/developWithBjs/npmSupport)
+- [UMD packages](/content/landing_pages/Support/NPM_Support.md)
 - [ES6 packages](/divingDeeper/developWithBjs/treeShaking)
 
 When developing please make sure to pick the one that fits your architecture. We recommend using the ES6 packages which allow your to reduce the final release's size using tree shaking.

--- a/content/resources/Reference/Framework_versions.md
+++ b/content/resources/Reference/Framework_versions.md
@@ -53,6 +53,6 @@ Our preview CDN is updated every night with the latest features and bug fixes, e
 We have two flavors of releases:
 
 - [UMD packages](/content/landing_pages/Support/NPM_Support.md)
-- [ES6 packages](/divingDeeper/developWithBjs/treeShaking)
+- [ES6 packages](/content/landing_pages/Support/ES6_Support.md)
 
 When developing please make sure to pick the one that fits your architecture. We recommend using the ES6 packages which allow your to reduce the final release's size using tree shaking.


### PR DESCRIPTION
Remaining links that I can't seem to fix are listed at #534.

Sorry for all the large amount of commits, still a n00b with Git. Feel free to "squash" all commits into one, singular commit.
I kind of lost track of the commit naming, my bad as well. 😊 