### PR TITLE
update playground folder link

### DIFF
--- a/content/resources/Playground_aspects/Playground_Textures.md
+++ b/content/resources/Playground_aspects/Playground_Textures.md
@@ -14,7 +14,7 @@ video-content:
 
 ## Textures Available To the Playground
 
-This list of files are in the [textures folder](https://github.com/BabylonJS/Babylon.js/tree/master/Playground/textures) of the Playground and can be loaded as Textures, CubeTextures or HDRCubeTextures.
+This list of files are in the [textures folder](https://github.com/BabylonJS/Babylon.js/tree/master/packages/tools/playground/public/textures) of the Playground and can be loaded as Textures, CubeTextures or HDRCubeTextures.
 
 ## Diffuse / Albedo maps
 

--- a/content/resources/Playground_aspects/meshes_to_load.md
+++ b/content/resources/Playground_aspects/meshes_to_load.md
@@ -25,7 +25,7 @@ Some meshes appear in both file locations.
 
 ## From the Playground Scenes Folder
 
-This list of files is in the github repo [scenes folder](https://github.com/BabylonJS/Babylon.js/tree/master/Playground/scenes) of the Playground and are available for use.
+This list of files is in the github repo [scenes folder](https://github.com/BabylonJS/Babylon.js/tree/master/packages/tools/playground/public/scenes) of the Playground and are available for use.
 
 Using a `scene` method to append or import scenes or meshes, the `rootUrl` parameter has the form `scenes/` or `scenes/folder/` and the `filename` parameter is as given below. The playground will show the actual terms required.
 


### PR DESCRIPTION
Ref https://forum.babylonjs.com/t/the-textures-folder-link-in-the-texture-library-documentation-is-invalid/29900