### PR TITLE
fix: add missing class name

### DIFF
--- a/content/How_To/Post_Process/How_to_use_RenderTargetTexture_and_multiple_passes.md
+++ b/content/How_To/Post_Process/How_to_use_RenderTargetTexture_and_multiple_passes.md
@@ -39,7 +39,7 @@ renderTarget.renderList.push(sphere); // add it to the RTT
 You can use the rendered image as the texture of an object in your main render. Just set it as the texture of a material:
 
 ```
-var mat = new BABYLON.("RTT mat", scene);
+var mat = new BABYLON.StandardMaterial("RTT mat", scene);
 mat.diffuseTexture = renderTarget;
 ```
 


### PR DESCRIPTION
I guess GitHub added or removed a newline at the end of the file. I don't know how to prevent that.