### PR TITLE
fixes proceduralTexturesLibrary missing img

### DIFF
--- a/content/extensions/ProceduralTexturesLibrary/BrickProceduralTexture.md
+++ b/content/extensions/ProceduralTexturesLibrary/BrickProceduralTexture.md
@@ -27,8 +27,8 @@ This texture has 4 parameters :
 - **brickColor** changes the color for the brick itself (BABYLON.Color3/4)
 
 ```javascript
-var brickMaterial = new BABYLON.StandardMaterial(name, scene);
-var brickTexture = new BABYLON.BrickProceduralTexture(name + "text", 512, scene);
+var brickMaterial = new BABYLON.StandardMaterial("brickMat", scene);
+var brickTexture = new BABYLON.BrickProceduralTexture("brickTex", 512, scene);
 brickTexture.numberOfBricksHeight = 6;
 brickTexture.numberOfBricksWidth = 10;
 brickMaterial.diffuseTexture = brickTexture;

--- a/content/extensions/ProceduralTexturesLibrary/BrickProceduralTexture.md
+++ b/content/extensions/ProceduralTexturesLibrary/BrickProceduralTexture.md
@@ -10,7 +10,7 @@ video-content:
 
 # Brick Procedural texture
 
-![Brick Procedural texture](/img/extensions/proceduraltextures/brickpt.png)
+![Brick Procedural texture](/img/extensions/proceduraltextures/brickpt.PNG)
 
 ## Using the Brick procedural texture
 
@@ -26,9 +26,10 @@ This texture has 4 parameters :
 - **jointColor** changes the color for the joint between bricks (BABYLON.Color3/4)
 - **brickColor** changes the color for the brick itself (BABYLON.Color3/4)
 
+```javascript
+var brickMaterial = new BABYLON.StandardMaterial(name, scene);
+var brickTexture = new BABYLON.BrickProceduralTexture(name + "text", 512, scene);
+brickTexture.numberOfBricksHeight = 6;
+brickTexture.numberOfBricksWidth = 10;
+brickMaterial.diffuseTexture = brickTexture;
 ```
-	var brickMaterial = new BABYLON.StandardMaterial(name, scene);
-    var brickTexture = new BABYLON.BrickProceduralTexture(name + "text", 512, scene);
-    brickTexture.numberOfBricksHeight = 6;
-    brickTexture.numberOfBricksWidth = 10;
-    brickMaterial.diffuseTexture = brickTexture;

--- a/content/extensions/ProceduralTexturesLibrary/CloudProceduralTexture.md
+++ b/content/extensions/ProceduralTexturesLibrary/CloudProceduralTexture.md
@@ -10,7 +10,7 @@ video-content:
 
 # Cloud Procedural texture
 
-![Cloud Procedural texture](/img/extensions/proceduraltextures/cloudpt.png)
+![Cloud Procedural texture](/img/extensions/proceduraltextures/cloudpt.PNG)
 
 ## Using the cloud procedural texture
 
@@ -26,12 +26,13 @@ This texture has 2 parameters :
 
 Sample to create a cloudy sky
 
-```
-var boxCloud = BABYLON.Mesh.CreateSphere("boxCloud", 100, 1000, scene);
-boxCloud.position = new BABYLON.Vector3(0, 0, 12);
+```javascript
+var cloud = BABYLON.MeshBuilder.CreateSphere("cloud", { segments: 100, diameter: 1000 }, scene);
 var cloudMaterial = new BABYLON.StandardMaterial("cloudMat", scene);
-var cloudProcText = new BABYLON.CloudProceduralTexture("cloud", 1024, scene);
-cloudMaterial.emissiveTexture = cloudProcText;
+var cloudProcTexture = new BABYLON.CloudProceduralTexture("cloudTex", 1024, scene);
+cloudMaterial.emissiveTexture = cloudProcTexture;
 cloudMaterial.backFaceCulling = false;
 cloudMaterial.emissiveTexture.coordinatesMode = BABYLON.Texture.SKYBOX_MODE;
-boxCloud.material = cloudMaterial;
+cloud.material = cloudMaterial;
+cloud.position = new BABYLON.Vector3(0, 0, 12);
+```

--- a/content/extensions/ProceduralTexturesLibrary/FireProceduralTexture.md
+++ b/content/extensions/ProceduralTexturesLibrary/FireProceduralTexture.md
@@ -10,7 +10,7 @@ video-content:
 
 # Fire Procedural texture
 
-![Fire Procedural texture](/img/extensions/proceduraltextures/firept.png)
+![Fire Procedural texture](/img/extensions/proceduraltextures/firept.PNG)
 
 ## Using the Fire procedural texture
 
@@ -26,9 +26,9 @@ This texture has 4 parameters :
 - **shift** controls the direction of the flames (BABYLON.Vector2)
 - **fireColors** is an array of 6 (BABYLON.Color3/4) defining the different color of the fire. You can define them manually of use presets available as static properties of the class (PurpleFireColors, GreenFireColors, RedFireColors, BlueFireColors)
 
-```
-    var fireMaterial = new BABYLON.StandardMaterial("fontainSculptur2", scene);
-    var fireTexture = new BABYLON.FireProceduralTexture("fire", 256, scene);
-    fireMaterial.diffuseTexture = fireTexture;
-    fireMaterial.opacityTexture = fireTexture;
+```javascript
+var fireMaterial = new BABYLON.StandardMaterial("fireMat", scene);
+var fireTexture = new BABYLON.FireProceduralTexture("fireTex", 256, scene);
+fireMaterial.diffuseTexture = fireTexture;
+fireMaterial.opacityTexture = fireTexture;
 ```

--- a/content/extensions/ProceduralTexturesLibrary/GrassProceduralTexture.md
+++ b/content/extensions/ProceduralTexturesLibrary/GrassProceduralTexture.md
@@ -10,7 +10,7 @@ video-content:
 
 # Grass Procedural texture
 
-![Grass Procedural texture](/img/extensions/proceduraltextures/grasspt.png)
+![Grass Procedural texture](/img/extensions/proceduraltextures/grasspt.PNG)
 
 ## Using the Grass procedural texture
 
@@ -24,9 +24,8 @@ This texture has 2 parameters :
 - **grassColors** is an array of 3 (BABYLON.Color3/4) for the grass. Should be green but you can create red grass if you want to (BABYLON.Color3/4)
 - **groundColor** is the base color for the ground (BABYLON.Color3/4)
 
-
-```
-    var grassMaterial = new BABYLON.StandardMaterial(name + "bawl", scene);
-    var grassTexture = new BABYLON.GrassProceduralTexture(name + "textbawl", 256, scene);
-    grassMaterial.ambientTexture = grassTexture;
+```javascript
+var grassMaterial = new BABYLON.StandardMaterial("grassMat", scene);
+var grassTexture = new BABYLON.GrassProceduralTexture("grassTex", 256, scene);
+grassMaterial.ambientTexture = grassTexture;
 ```

--- a/content/extensions/ProceduralTexturesLibrary/MarbleProceduralTexture.md
+++ b/content/extensions/ProceduralTexturesLibrary/MarbleProceduralTexture.md
@@ -10,7 +10,7 @@ video-content:
 
 # Marble Procedural texture
 
-![Marble Procedural texture](/img/extensions/proceduraltextures/marblept.png)
+![Marble Procedural texture](/img/extensions/proceduraltextures/marblept.PNG)
 
 ## Using the Marble procedural texture
 
@@ -26,11 +26,10 @@ This texture has 4 parameters :
 - **jointColor** changes the color for the joint between tiles (BABYLON.Color3/4)
 - **marbleColor** changes the color for the tile itself (BABYLON.Color3/4)
 
-
-```
-	var marbleMaterial = new BABYLON.StandardMaterial("torus", scene);
-    var marbleTexture = new BABYLON.MarbleProceduralTexture("marble", 512, scene);
-    marbleTexture.numberOfTilesHeight = 5;
-    marbleTexture.numberOfTilesWidth = 5;
-    marbleMaterial.ambientTexture = marbleTexture;
+```javascript
+var marbleMaterial = new BABYLON.StandardMaterial("marbleMat", scene);
+var marbleTexture = new BABYLON.MarbleProceduralTexture("marbleTex", 512, scene);
+marbleTexture.numberOfTilesHeight = 5;
+marbleTexture.numberOfTilesWidth = 5;
+marbleMaterial.ambientTexture = marbleTexture;
 ```

--- a/content/extensions/ProceduralTexturesLibrary/RoadProceduralTexture.md
+++ b/content/extensions/ProceduralTexturesLibrary/RoadProceduralTexture.md
@@ -10,7 +10,7 @@ video-content:
 
 # Road Procedural texture
 
-![Road Procedural texture](/img/extensions/proceduraltextures/roadpt.png)
+![Road Procedural texture](/img/extensions/proceduraltextures/roadpt.PNG)
 
 ## Using the Road procedural texture
 
@@ -23,9 +23,8 @@ A demo can be found here: <Playground id="#FBW4N#0" title="Road Procedural Textu
 This texture has 1 parameter :
 - **roadColor** is the color for the road (BABYLON.Color3/4)
 
-
-```
-    var roadmaterial = new BABYLON.StandardMaterial("road", scene);
-    var roadmaterialpt = new BABYLON.RoadProceduralTexture("customtext", 512, scene);
-    roadmaterial.diffuseTexture = roadmaterialpt;
+```javascript
+var roadmaterial = new BABYLON.StandardMaterial("roadMat", scene);
+var roadmaterialpt = new BABYLON.RoadProceduralTexture("roadTex", 512, scene);
+roadmaterial.diffuseTexture = roadmaterialpt;
 ```

--- a/content/extensions/ProceduralTexturesLibrary/WoodProceduralTexture.md
+++ b/content/extensions/ProceduralTexturesLibrary/WoodProceduralTexture.md
@@ -10,7 +10,7 @@ video-content:
 
 # Wood Procedural texture
 
-![Wood Procedural texture](/img/extensions/proceduraltextures/woodpt.png)
+![Wood Procedural texture](/img/extensions/proceduraltextures/woodpt.PNG)
 
 ## Using the Wood procedural texture
 
@@ -24,10 +24,9 @@ This texture has 2 parameters :
 - **woodColor** to modify the color of the wood in the texture (BABYLON.Color3/4)
 - **ampScale** to change the waves amplitude in the wood (BABYLON.Vector2)
 
-
-```
-	var woodMaterial = new BABYLON.StandardMaterial(name, scene);
-    var woodTexture = new BABYLON.WoodProceduralTexture(name + "text", 1024, scene);
-    woodTexture.ampScale = 80.0;
-    woodMaterial.diffuseTexture = woodTexture;
+```javascript
+var woodMaterial = new BABYLON.StandardMaterial("woodMat", scene);
+var woodTexture = new BABYLON.WoodProceduralTexture("woodTex", 1024, scene);
+woodTexture.ampScale = 80.0;
+woodMaterial.diffuseTexture = woodTexture;
 ```


### PR DESCRIPTION
- fixed proceduralTexturesLibrary sample image missing
- fixed sample code

## Targeted pages


- brick [original](https://doc.babylonjs.com/toolsAndResources/assetLibraries/proceduralTexturesLibrary/brick) -> [fixed](https://documentation-git-fork-il-m-yamagishi-fix-proc-81ce54-babylonjs.vercel.app/toolsAndResources/assetLibraries/proceduralTexturesLibrary/brick)
- cloud [original](https://doc.babylonjs.com/toolsAndResources/assetLibraries/proceduralTexturesLibrary/cloud) -> [fixed](https://documentation-git-fork-il-m-yamagishi-fix-proc-81ce54-babylonjs.vercel.app/toolsAndResources/assetLibraries/proceduralTexturesLibrary/cloud)
- fire [original](https://doc.babylonjs.com/toolsAndResources/assetLibraries/proceduralTexturesLibrary/fire) -> [fixed](https://documentation-git-fork-il-m-yamagishi-fix-proc-81ce54-babylonjs.vercel.app/toolsAndResources/assetLibraries/proceduralTexturesLibrary/fire)
- grass [original](https://doc.babylonjs.com/toolsAndResources/assetLibraries/proceduralTexturesLibrary/grass) -> [fixed](https://documentation-git-fork-il-m-yamagishi-fix-proc-81ce54-babylonjs.vercel.app/toolsAndResources/assetLibraries/proceduralTexturesLibrary/grass)
- marble [original](https://doc.babylonjs.com/toolsAndResources/assetLibraries/proceduralTexturesLibrary/marble) -> [fixed](https://documentation-git-fork-il-m-yamagishi-fix-proc-81ce54-babylonjs.vercel.app/toolsAndResources/assetLibraries/proceduralTexturesLibrary/marble)
- road [original](https://doc.babylonjs.com/toolsAndResources/assetLibraries/proceduralTexturesLibrary/road) -> [fixed](https://documentation-git-fork-il-m-yamagishi-fix-proc-81ce54-babylonjs.vercel.app/toolsAndResources/assetLibraries/proceduralTexturesLibrary/road)
- wood [original](https://doc.babylonjs.com/toolsAndResources/assetLibraries/proceduralTexturesLibrary/wood) -> [fixed](https://documentation-git-fork-il-m-yamagishi-fix-proc-81ce54-babylonjs.vercel.app/toolsAndResources/assetLibraries/proceduralTexturesLibrary/wood)