### PR TITLE
Create a top-level Contributing page

### DIFF
--- a/configuration/structure.json
+++ b/configuration/structure.json
@@ -1251,6 +1251,13 @@
             "friendlyName": "Playground search",
             "children": {},
             "content": ""
+        },
+        "contribute": {
+            "friendlyName": "Contribute to Babylon.js",
+            "children": {
+
+            },
+            "content":"landing_pages/contribute_to_babylonjs"
         }
     },
     "navOverrides": { "previous": "" }

--- a/content/landing_pages/contribute_to_babylonjs.md
+++ b/content/landing_pages/contribute_to_babylonjs.md
@@ -1,0 +1,21 @@
+---
+title: Contribute to Babylon.js
+image:
+description: Learn how you can get involved with Babylon.js.
+keywords: babylon.js, contribution
+further-reading:
+video-overview:
+video-content:
+---
+
+# Contribute to Babylon.js
+
+Thank you for your interest in helping to improve Babylon.js! In this section, you'll find all the information that you need to make a successful contribution to the project. No matter if you're a seasoned veteran or you've never contributed to an open source project before - we've got you covered. Please don't hesitate to ask on the [community forums](https://forum.babylonjs.com/) should you have any questions.
+
+## Contributing Code
+
+To learn how you can contribute to the engine itself, see [Start Contributing to Babylon.js](divingDeeper/developWithBjs/howToStart).
+
+## Contributing Documentation
+
+If you'd like to update the documentation website, you can find instructions here: [Contribute to the Documentation](divingDeeper/developWithBjs/contributeToDocs)


### PR DESCRIPTION
IMHO, this is critical information that will be of interest to anyone who might consider becoming an active contributor, especially new users who haven't contributed before. Hiding it deep down in the hierarchy of documentation pages seems unwise. Removing barriers to entry like this should increase the amount and quality of contributions that Babylon can attract.

---

I only linked to the existing documentation pages as I didn't want to shuffle things around too much without your input, but I think it would be an improvement if those pages were to be moved to this top-level and highly-visible category, split into multiple sub-pages for the different tasks, and organized in a way that's less daunting and chaotic to help new contributors out.

I've seen #483 , but it's unclear what the status is and there are way too many changes to reasonably digest. It does seem like it's doing just what I suggested, albeit slightly differently. Maybe we can combine the ideas and make smaller changes iteratively?