### PR TITLE
Increase the contrast of the Table of Contents component

### DIFF
--- a/components/contentComponents/tableOfContent.component.tsx
+++ b/components/contentComponents/tableOfContent.component.tsx
@@ -10,6 +10,7 @@ const styles = makeStyles((theme: Theme) =>
             border: "1px solid #dedede",
             borderRadius: "5px",
             backgroundColor: "#f7f7f7",
+            marginBottom: "1.5rem",
             paddingLeft: "16px",
             paddingRight: "16px",
             zIndex: 100,

--- a/components/contentComponents/tableOfContent.component.tsx
+++ b/components/contentComponents/tableOfContent.component.tsx
@@ -7,6 +7,11 @@ const styles = makeStyles((theme: Theme) =>
     createStyles({
         contentRoot: {
             background: "#fafafa",
+            border: "1px solid #dedede",
+            borderRadius: "5px",
+            backgroundColor: "#f7f7f7",
+            paddingLeft: "16px",
+            paddingRight: "16px",
             zIndex: 100,
             width: "unset !important",
             "& h2": {


### PR DESCRIPTION
This makes the TOC stand out visually and the text easier to read. The padding is derived from the padding-bottom that was already in place, though I couldn't find a way to access that value directly (which would be preferable in case of future changes).

The heading uses a 13px margin so that's a bit inconsistent, but I'm not sure if it makes much of a difference visually and so I've left it as-is.

---

Before:

![image](https://user-images.githubusercontent.com/16489133/168412804-fcd269b8-26c1-44dd-af07-12998901bdd1.png)

After:

![image](https://user-images.githubusercontent.com/16489133/168412812-0ed0da24-9ddd-4305-b346-85a3bebb788d.png)

As with any visual change, it's at least partially based on personal preference (though the goal was to create a visual separation between a page's table of contents and the actual contents themselves). Feel free to disregard if you don't think this is an improvement.