### PR TITLE
Fix a CSS glitch that causes shifting TOC buttons

### DIFF
--- a/components/markdownComponents/tableOfContentItem.component.tsx
+++ b/components/markdownComponents/tableOfContentItem.component.tsx
@@ -13,7 +13,8 @@ const styles = makeStyles((theme: Theme) =>
         button: {
             transform: "translate(4px, -2px)",
             padding: 1,
-            marginLeft: 8
+            marginLeft: 8,
+            height: 20,
         },
     }),
 );


### PR DESCRIPTION
When hovered, the ``button`` element can potentially cause the layout to shift (very slightly). Reducing its size doesn't seem to affect anything else, presumably because the actual image is an SVG icon which doesn't obey the CSS height rules anyway.

Fixes #563 (hopefully...).

---

Not sure if it touches anything else, but since the style originates in the TOC component I guess altering it doesn't have side effects.