### PR TITLE
change spaced parameter names to snake-cased

### DIFF
--- a/content/How_To/animation/animation_method.md
+++ b/content/How_To/animation/animation_method.md
@@ -12,7 +12,7 @@ video-content:
 
 ## Creating the animation
 ```javascript
-const myAnim = new BABYLON.Animation(name, property, frames per second, property type, loop mode)
+const myAnim = new BABYLON.Animation(name, property, frames_per_second, property_type, loop_mode)
 ```
 -   _name_ - _string_, name of animation
 

--- a/content/start/chap1/first_import.md
+++ b/content/start/chap1/first_import.md
@@ -17,7 +17,7 @@ The playgrounds on this page contain models (in this example, houses) which can 
 When you add a model to a scene, you are loading it through the browser. As you likely already know, loading anything from a website is an asynchronous function. Therefore, before you can do anything with your models, you first must ensure they have been loaded successfully. You can do this using the _ImportMeshAsync_ method of the _SceneLoader_, which can be done as follows:
 
 ```javascript
-BABYLON.SceneLoader.ImportMeshAsync(model name, folder path, file name, scene);
+BABYLON.SceneLoader.ImportMeshAsync(model_name, folder_path, file_name, scene);
 ```
 
 The scene parameter is optional and will default to the current scene. The first parameter can be any one of three types depending whether you want to load all the models, just one model or a list of models.

--- a/content/start/chap7/lights.md
+++ b/content/start/chap7/lights.md
@@ -14,7 +14,7 @@ video-content:
 So far we have just used the hemispheric light for all the scenes. There are a range of lights but for the moment the only new one we will introduce is the spot light. This can be positioned anywhere and given a direction in which to shine. The spread of the light is given by an angle in radians, the larger the angle the wider the spread. The final parameter indicates how fast the light will fall away, the larger the number the less distance the light will shine. The spot light can be given a color.
 
 ```javascript
-const lampLight = new BABYLON.SpotLight("name", position, direction, angle of spread, speed of disipation);
+const lampLight = new BABYLON.SpotLight("name", position, direction, angle_of_spread, speed_of_disipation);
 lampLight.diffuse = BABYLON.Color3.Yellow();
 ```
 We will add a spot light to a street lamp. In order to create a lamp post we introduce another way of creating a mesh by extruding a shape along a path.

--- a/content/start/chap7/shadows.md
+++ b/content/start/chap7/shadows.md
@@ -35,7 +35,7 @@ The first parameter is the size of a shadow map and the light generating the sha
 We also need to add a mesh that will cast the shadow.
 
 ```javascript
-shadowGenerator.addShadowCaster(casting mesh, true);
+shadowGenerator.addShadowCaster(casting_mesh, true);
 ```
 
 The optional second parameter, which has default value false, will add any children of the mesh to the shadow caster.

--- a/content/start/chap8/camera.md
+++ b/content/start/chap8/camera.md
@@ -14,7 +14,7 @@ video-content:
 Currently we are using the *ArcRotateCamera* which has us orbiting the village world from a distance. How about a view from inside the village? Let's parent the camera to the character walking around the village and with a few adjustments to values look around from over his shoulder. The creation of the *ArcRotateCamera* has this form,
 
 ```javascript
-const camera = new BABYLON.ArcRotateCamera("name", alpha angle, beta angle, radius, target position);
+const camera = new BABYLON.ArcRotateCamera("name", alpha_angle, beta_angle, radius, target_position);
 ```
 
 As will all cameras in order to move it in response to user input we need to attach it to the canvas.


### PR DESCRIPTION
Hi, I've noticed some function parameter names have spaces within themselves.

I understand it is for the sake of readability, but IMHO, it might cause confusion to some readers.

I, for one, had to re-read the function signature while careful reading.

Thus, I propose the following changes.

- **AS IS**
<img src="https://user-images.githubusercontent.com/83917784/175927346-997182e4-4af4-4512-83f2-8912b3d5071b.jpg" width="600" />

- **TO BE**
<img src="https://user-images.githubusercontent.com/83917784/175927357-4d96b48d-2c50-4c88-8cc7-bf27c758d728.jpg" width="600" />

&nbsp;

I personally think these changes are better as they explicitly show parameter boundaries, especially when a certain parameter gets line-wrapped as in the following example (see `target position`):

<img src="https://user-images.githubusercontent.com/83917784/175930686-8eeac1df-916a-409c-a6ae-155defda3159.jpg" width="600" />

