### PR TITLE
Updated Custom Camera Input Playground to prevent Engine dispose from stopping prematurely

### DIFF
--- a/content/How_To/camera/Customizing_Camera_Inputs.md
+++ b/content/How_To/camera/Customizing_Camera_Inputs.md
@@ -319,4 +319,4 @@ In the example there are two viewports, the upper one gives a first-person view 
 
 Remember to click on the scene before using the arrow keys.
 
-<Playground id="#CTCSWQ#1" title="Walk and Look Camera Example" description="A simple example of customizing camera inputs to create a walk and look camera." image="/img/playgroundsAndNMEs/divingDeeperCustomCameraInput1.jpg"/>
+<Playground id="#CTCSWQ#945" title="Walk and Look Camera Example" description="A simple example of customizing camera inputs to create a walk and look camera." image="/img/playgroundsAndNMEs/divingDeeperCustomCameraInput1.jpg"/>


### PR DESCRIPTION
While investigating an issue, there was an issue found with the PG https://playground.babylonjs.com/#CTCSWQ#1 where a call to `BABYLON.Tools.UnregisterTopRootEvents` was missing a parameter.  This was causing an exception to be thrown during the Engine dispose process forcing it to end early.  This PR contains an updated reference to a PG with the correct function call.