### PR TITLE
Fix typo in 3D_commerce_certif.md

### DIFF
--- a/content/How_To/3D_commerce_certif/3D_commerce_certif.md
+++ b/content/How_To/3D_commerce_certif/3D_commerce_certif.md
@@ -23,10 +23,10 @@ This program is still in its early days and as a member of this working group, t
 ## Babylon.js Sandbox - certified version
 
 A special version of the [**Babylon.js Sandbox**](https://sandbox.babylonjs.com) has been certified because a couple parameters have to be set differently than the default engine values (which cannot be changed for backward compatibility reasons):
-- Specular over alpha has to be turned off (rigth side of the picture below). It was being used to render glass before the apparition of dedicated glTF extensions such as transmission and volume.
+- Specular over alpha has to be turned off (right side of the picture below). It was being used to render glass before the apparition of dedicated glTF extensions such as transmission and volume.
 
 ![Specular over alpha turned-on (left) and off (right)](/img/how_to/3D-commerce-certif/specular-over-alpha.jpg)
-- sRGB Buffer has to be turned on (rigth side of the picture below). It has been deactived by default for performance reasons due to browser [bug](https://bugs.chromium.org/p/chromium/issues/detail?id=1256340).
+- sRGB Buffer has to be turned on (right side of the picture below). It has been deactived by default for performance reasons due to browser [bug](https://bugs.chromium.org/p/chromium/issues/detail?id=1256340).
 
 ![sRGB Buffer turned-on (left) and off (right)](/img/how_to/3D-commerce-certif/sRGB-buffer.jpg)
 


### PR DESCRIPTION
'right' was spelled 'rigth'