### PR TITLE
WebGPU: Fix PG in fast snapshot mode

### DIFF
--- a/content/extensions/WebGPU/Optimizations/webGPUSnapshotRendering.md
+++ b/content/extensions/WebGPU/Optimizations/webGPUSnapshotRendering.md
@@ -80,7 +80,7 @@ The world matrix and the `visibility` property of a mesh is stored in a specific
 
 You should call `mesh.transferToEffect(world)` to update the uniform buffer.
 
-Here's an example: <Playground id="#7YW416#3" engine="webgpu" title="Update mesh matrix in fast SR mode" description="Demonstrates how to update the position/rotation/scaling/visibility properties of a mesh in fast snapshot rendering mode"/>
+Here's an example: <Playground id="#7YW416#7" engine="webgpu" title="Update mesh matrix in fast SR mode" description="Demonstrates how to update the position/rotation/scaling/visibility properties of a mesh in fast snapshot rendering mode" image="/img/playgroundsAndNMEs/pg-7YW416-3.png"/>
 
 ### Using the glow layer
 As demonstrated in the **Examples** section above the glow layer does not work out of the box in the fast SR mode. With a bit of manual work it can be made to work, though:


### PR DESCRIPTION
After [this optim](https://github.com/BabylonJS/Babylon.js/commit/8042d8a30f669739fbd4ace3375f49bee1464d83#diff-19548fe6a0feb27a51a0fd485c8c8b80d0bcb420434020981aaa9227349b2b63R1008), `computeWorldMatrix()` must be passed `true` for the PG to work.