### PR TITLE
Materials examples http error fixes

### DIFF
--- a/content/How_To/material/CreateBox_Per_Face_Textures_And_Colors.md
+++ b/content/How_To/material/CreateBox_Per_Face_Textures_And_Colors.md
@@ -121,7 +121,7 @@ mat.diffuseTexture = texture;
 box.material = mat;
 ```
 
-<Playground id="#ICZEXW" title="FaceUVs Example" description="Simple example of using FaceUVs to create a box." image="/img/playgroundsAndNMEs/divingDeeperFaceMaterials2.jpg"/>
+<Playground id="#ICZEXW#812" title="FaceUVs Example" description="Simple example of using FaceUVs to create a box." image="/img/playgroundsAndNMEs/divingDeeperFaceMaterials2.jpg"/>
 
 You do not have to map all the faces. When you just want one face with an image then just map that one face.
 
@@ -135,7 +135,7 @@ Take the alien sprite on row 0 and column 3 and just map this sprite to face 1.
 
   faceUV[1] = new BABYLON.Vector4(3/columns, 0, (3+1)/columns, 1/rows);
 ```
-<Playground id="#ICZEXW#1" title="Specific Sprite to Single Face" description="Simple example a single sprite on a single face of a box." image="/img/playgroundsAndNMEs/divingDeeperFaceMaterials3.jpg"/>
+<Playground id="#ICZEXW#813" title="Specific Sprite to Single Face" description="Simple example a single sprite on a single face of a box." image="/img/playgroundsAndNMEs/divingDeeperFaceMaterials3.jpg"/>
 
 As you view the box in the above playground from different angles you will notice that the whole texture atlas is applied to all the other faces, that is the default value `(0, 0, 1, 1)`. When you want to display just the one sprite on the one face and leave the others blank then you need to set all the other faceUV values to `(0, 0, 0, 0)`.
 
@@ -154,18 +154,18 @@ As you view the box in the above playground from different angles you will notic
   faceUV[1] = new BABYLON.Vector4(3/columns, 0, (3+1)/columns, 1/rows);
 ```
   
-<Playground id="#ICZEXW#2" title="Sprite On Face With Other Blank Faces" description="Simple Example of applying a sprite to the side of a box with the other box faces blank." image="/img/playgroundsAndNMEs/divingDeeperFaceMaterials4.jpg"/>
+<Playground id="#ICZEXW#814" title="Sprite On Face With Other Blank Faces" description="Simple Example of applying a sprite to the side of a box with the other box faces blank." image="/img/playgroundsAndNMEs/divingDeeperFaceMaterials4.jpg"/>
 
 Of course you can do this with one, two, three, four, or five the box faces.
 
 
 Want add some all over color to the box then just add in a_diffuseColor_ to your material.
 
-<Playground id="#ICZEXW#3" title="Sprite on Box Face With Material Color" description="Simple Example of applying a sprite to the side of a box with applied material color." image="/img/playgroundsAndNMEs/divingDeeperFaceMaterials5.jpg"/>
+<Playground id="#ICZEXW#815" title="Sprite on Box Face With Material Color" description="Simple Example of applying a sprite to the side of a box with applied material color." image="/img/playgroundsAndNMEs/divingDeeperFaceMaterials5.jpg"/>
 
 You can also use one texture atlas to apply two different images from the same sheet onto two different meshes.  
 
-<Playground id="#ICZEXW#7" title="Sprites Sheet On Faces of 2 Meshes" description="Simple Example of applying a sprite sheet to the faces of different meshes." image="/img/playgroundsAndNMEs/divingDeeperFaceMaterials6.jpg"/>
+<Playground id="#ICZEXW#816" title="Sprites Sheet On Faces of 2 Meshes" description="Simple Example of applying a sprite sheet to the faces of different meshes." image="/img/playgroundsAndNMEs/divingDeeperFaceMaterials6.jpg"/>
 
 Looking closer at the face images around the sides you will see some images are at 90 degrees to others. Unfortunately should you want to have all images around the side to have the same orientation this is not possible by only adjusting UV coordinates. What can be done by swapping coordinates is considered next, followed by a method using an adjustment to the texture atlas to orientate images on the sides.
 
@@ -202,7 +202,7 @@ faceUV = new BABYLON.Vector4(Utop_right, Vtop_right, Ubottom_left, Vbottom_left)
 
 You can use the images on the other faces in the following playground to check the change on orientation of the alien sprite in all the reflections.
 
-<Playground id="#ICZEXW#4" title="Understanding Face Orientation Wtih Sprites" description="Simple Example of applying sprites to face mesh reflection." image="/img/playgroundsAndNMEs/divingDeeperFaceMaterials7.jpg"/>
+<Playground id="#ICZEXW#817" title="Understanding Face Orientation Wtih Sprites" description="Simple Example of applying sprites to face mesh reflection." image="/img/playgroundsAndNMEs/divingDeeperFaceMaterials7.jpg"/>
 
 Since a Vector4 has the properties x, y, z, w, (in that order) setting 
 
@@ -307,7 +307,7 @@ These colors are BJS Color4-class values. The Color4 alpha values become active 
 
 Finally you can also mix per-face colors with per-face textures, and/or mix either with the material's standard colors.  
 
-<Playground id="#ICZEXW#10" title="Mixed Textures and Colors Per Face" description="Simple Example of applying different textures and colors per face." image="/img/playgroundsAndNMEs/divingDeeperFaceMaterials15.jpg"/>
+<Playground id="#ICZEXW#818" title="Mixed Textures and Colors Per Face" description="Simple Example of applying different textures and colors per face." image="/img/playgroundsAndNMEs/divingDeeperFaceMaterials15.jpg"/>
 
 ## Cylinder
 
@@ -335,7 +335,7 @@ Also note that because of how a cylinder's mesh is constructed the horizontal co
 
 An extruded polygon has three surfaces top, bottom and extruded sides, face 0 is the top, face 1 the extruded sides and face 2 the bottom.
 
-<Playground id="#RNCYVM#2" title="Extruded Polygon with Different Textures on Sides and Top" description="Simple Example of applying different textures to an extruded polygon's sides and top." image="/img/playgroundsAndNMEs/divingDeeperFaceMaterials17.jpg"/>
+<Playground id="#RNCYVM#1352" title="Extruded Polygon with Different Textures on Sides and Top" description="Simple Example of applying different textures to an extruded polygon's sides and top." image="/img/playgroundsAndNMEs/divingDeeperFaceMaterials17.jpg"/>
 
 ## Polyhedra
 

--- a/content/How_To/material/CreateBox_Per_Face_Textures_And_Colors.md
+++ b/content/How_To/material/CreateBox_Per_Face_Textures_And_Colors.md
@@ -202,7 +202,7 @@ faceUV = new BABYLON.Vector4(Utop_right, Vtop_right, Ubottom_left, Vbottom_left)
 
 You can use the images on the other faces in the following playground to check the change on orientation of the alien sprite in all the reflections.
 
-<Playground id="#ICZEXW#817" title="Understanding Face Orientation Wtih Sprites" description="Simple Example of applying sprites to face mesh reflection." image="/img/playgroundsAndNMEs/divingDeeperFaceMaterials7.jpg"/>
+<Playground id="#ICZEXW#817" title="Understanding Face Orientation With Sprites" description="Simple Example of applying sprites to face mesh reflection." image="/img/playgroundsAndNMEs/divingDeeperFaceMaterials7.jpg"/>
 
 Since a Vector4 has the properties x, y, z, w, (in that order) setting 
 

--- a/content/How_To/material/FrontandBackUV.md
+++ b/content/How_To/material/FrontandBackUV.md
@@ -51,7 +51,7 @@ plane.material = mat;
 ## Two Sided Examples
 
 <Playground id="#LXZPJK#3" title="Different Images On A Plane" description="Simple example of applying different images to the front and back of a plane." image="/img/playgroundsAndNMEs/divingDeeperFrontBack1.jpg"/>
-<Playground id="#4G18GY#2" title="Different Images On A Polygon" description="Simple example of applying different images to the front and back of a Polygon." image="/img/playgroundsAndNMEs/divingDeeperFrontBack2.jpg"/>
+<Playground id="#4G18GY#909" title="Different Images On A Polygon" description="Simple example of applying different images to the front and back of a Polygon." image="/img/playgroundsAndNMEs/divingDeeperFrontBack2.jpg"/>
 
 ## Inside and Outside Examples
 

--- a/content/How_To/material/More_Materials.md
+++ b/content/How_To/material/More_Materials.md
@@ -32,7 +32,7 @@ var myMaterial = new BABYLON.StandardMaterial("myMaterial", scene);
 myMaterial.bumpTexture = new BABYLON.Texture("PATH TO NORMAL MAP", scene);
 ```
 
-<Playground id="#20OAV9#23" title="Using Bump Maps" description="Simple example of applying bump maps." image="/img/playgroundsAndNMEs/divingDeeperMoreMaterials1.jpg" isMain={true} category="Materials"/>
+<Playground id="#20OAV9#8621" title="Using Bump Maps" description="Simple example of applying bump maps." image="/img/playgroundsAndNMEs/divingDeeperMoreMaterials1.jpg" isMain={true} category="Materials"/>
 
 ## Inverting Bumps and Dents
 Use _invertNormalMapX_ and/or _invertNormalMapY_ on the material.
@@ -54,7 +54,7 @@ with the same gradient applied to the material as in the image below.
 
 ![Opacity Material](/img/how_to/Materials/degraded_plane.png)
 
-<Playground id="#20OAV9#24" title="Using Opacity Maps" description="Simple example of applying opacity maps." image="/img/playgroundsAndNMEs/divingDeeperMoreMaterials2.jpg"/>
+<Playground id="#20OAV9#8622" title="Using Opacity Maps" description="Simple example of applying opacity maps." image="/img/playgroundsAndNMEs/divingDeeperMoreMaterials2.jpg"/>
 
 ## Applying Opacity
 Add an _opacityTexture_ to any existing texture.
@@ -82,7 +82,7 @@ To offset your texture on your mesh, you  use the _uOffset_ and _vOffset_ proper
 myMaterial.diffuseTexture.uOffset = 1.5;
 myMaterial.diffuseTexture.vOffset = 0.5;
 ```
-<Playground id="#20OAV9#25" title="UV Tiling and Offset" description="Simple example of UV tiling and offset." image="/img/playgroundsAndNMEs/divingDeeperMoreMaterials3.jpg"/>
+<Playground id="#20OAV9#8623" title="UV Tiling and Offset" description="Simple example of UV tiling and offset." image="/img/playgroundsAndNMEs/divingDeeperMoreMaterials3.jpg"/>
 
 ## Details maps
 

--- a/content/How_To/material/Using_parallax_mapping.md
+++ b/content/How_To/material/Using_parallax_mapping.md
@@ -11,7 +11,7 @@ video-content:
 
 Starting with Babylon.js v2.4, we introduced Parallax Mapping.
 
-<Playground id="#10I31V#23" title="Parallax Mapping Example" description="Simple example of using parallax mapping in your scene." image="/img/playgroundsAndNMEs/divingDeeperParallaxMapping1.jpg"/>
+<Playground id="#10I31V#408" title="Parallax Mapping Example" description="Simple example of using parallax mapping in your scene." image="/img/playgroundsAndNMEs/divingDeeperParallaxMapping1.jpg"/>
 
 ![parallax mapping example](/img/how_to/Materials/parallax-mapping.jpg)
 


### PR DESCRIPTION
### Some examples are using materials from external sources and if they are loaded over `HTTP` then this error occurs:
`
Mixed Content: The page at '<URL>' was loaded over HTTPS, but requested an insecure XMLHttpRequest endpoint '<URL>'. This request has been blocked; the content must be served over HTTPS.
`

![image](https://user-images.githubusercontent.com/4126851/189392966-1929d60a-56bb-415e-bf22-5f1fbbe9c7d5.png)

### If replace with `HTTPS` then everything works as expected
![image](https://user-images.githubusercontent.com/4126851/189393821-af33d421-01c4-4f6e-9b66-9abb3526d989.png)
