### PR TITLE
Add Section on loading draco files locally

### DIFF
--- a/content/features/featuresDeepDive/importers/glTF.md
+++ b/content/features/featuresDeepDive/importers/glTF.md
@@ -21,6 +21,22 @@ This loader supports both glTF 1.0 and 2.0 and will use the correct loader based
 <script src="babylon.glTFFileLoader.js"></script>
 ```
 
+## Loading files locally
+
+By default, the gltf loader will request additional files for [draco compression](https://google.github.io/draco/) from *preview.babylonjs.com*. In case you want to deliver these files locally (e.g. for GDPR compliance), you can set the [DracoCompression.Configuration](https://doc.babylonjs.com/typedoc/classes/BABYLON.DracoCompression) object to use local files:
+
+```typescript
+DracoCompression.Configuration = {
+  decoder: {
+    wasmUrl: "/babylon-draco-files/draco_wasm_wrapper_gltf.js",
+    wasmBinaryUrl: "/babylon-draco-files/draco_decoder_gltf.wasm",
+    fallbackUrl: "/babylon-draco-files/draco_decoder_gltf.js",
+  },
+};
+```
+
+Be sure to download the files first (from `https://preview.babylonjs.com/[FILENAME]`) and put them in a local path (`public/babylon-draco-files`, in this case).
+
 ## Warning
 
 A \_root\_ node is added to hold all the **glTF** and **glb** models and model parts are stored as sub-meshes. This is so applications that save models using a right handed system will be loaded correctly into Babylon.js when you add to your create scene function


### PR DESCRIPTION
In a privacy-aware environment, loading assets from 3rd party servers is a no-no. I just spent some time trying to figure out why and where babylon was making requests against `preview.babylonjs.com`, and how to prevent it from happening.

As far as I understand, this only happens when using the gltf loader – so I added it here.

This is a mere proposal. Feel free to add/change/move/whatever-you-see-fit.

✌️