### PR TITLE
Add an inspector extensibility example for materials

### DIFF
--- a/content/toolsAndResources/inspector.md
+++ b/content/toolsAndResources/inspector.md
@@ -261,4 +261,8 @@ myNode.inspectableCustomProperties = [
 ];
 ```
 
-<Playground id="#LQF5QR#2" title="Inspector custom properties" description="An example of inspector custom properties" image="/img/playgroundsAndNMEs/inspectorCustomProperties.jpg" />
+<Playground id="#LQF5QR#2" title="Inspector custom properties for a node" description="An example of inspector custom properties for a node" image="/img/playgroundsAndNMEs/inspectorCustomProperties.jpg" />
+
+The inspector can also be extended to allow manipulation of custom material properties.
+
+<Playground id="#LQF5QR#52" title="Inspector custom properties for a material" description="An example of inspector custom properties for a material"/>

--- a/content/toolsAndResources/inspector.md
+++ b/content/toolsAndResources/inspector.md
@@ -263,6 +263,6 @@ myNode.inspectableCustomProperties = [
 
 <Playground id="#LQF5QR#2" title="Inspector custom properties for a node" description="An example of inspector custom properties for a node" image="/img/playgroundsAndNMEs/inspectorCustomProperties.jpg" />
 
-The inspector can also be extended to allow manipulation of custom material properties.
 
+The inspector can also be extended to allow manipulation of custom material properties.
 <Playground id="#LQF5QR#52" title="Inspector custom properties for a material" description="An example of inspector custom properties for a material"/>

--- a/content/toolsAndResources/inspector.md
+++ b/content/toolsAndResources/inspector.md
@@ -197,6 +197,8 @@ This tool (available in the property pane when you select a material with textur
 
 The inspector can be easily extended to allow manipulation of custom node properties. Simply define your custom properties in the node's `inspectableCustomProperties` array, and they will be available under the CUSTOM heading after selecting the node in the inspector.
 
+<Playground id="#LQF5QR#2" title="Inspector custom properties for a node" description="An example of inspector custom properties for a node" image="/img/playgroundsAndNMEs/inspectorCustomProperties.jpg" />
+
 ```javascript
 myNode.inspectableCustomProperties = [
   {
@@ -260,9 +262,6 @@ myNode.inspectableCustomProperties = [
   }
 ];
 ```
-
-<Playground id="#LQF5QR#2" title="Inspector custom properties for a node" description="An example of inspector custom properties for a node" image="/img/playgroundsAndNMEs/inspectorCustomProperties.jpg" />
-
 
 The inspector can also be extended to allow manipulation of custom material properties.
 <Playground id="#LQF5QR#52" title="Inspector custom properties for a material" description="An example of inspector custom properties for a material"/>


### PR DESCRIPTION
Update the doc on Inspector Extensibility with an example using a material to show that both nodes **and** materials are supported. :)

I'm not sure what image if any to use for the PG link thou, should I just take a screenshot of the PG?

Also I thought it might look better with an empty line between the first PG link and the code block right after it, but I'm not sure how to add that spacing if it's needed...

Forum: https://forum.babylonjs.com/t/custom-inspector-properties-for-shadermaterial-uniforms/34921/6
The new PG example that would be added: https://playground.babylonjs.com/#LQF5QR#52