### PR TITLE
Clarify the build process for .fx shader assets

### DIFF
--- a/content/contribute/toBabylon/HowToContribute.md
+++ b/content/contribute/toBabylon/HowToContribute.md
@@ -463,7 +463,7 @@ npx build-tools -c process-assets --isCore --watch
 
 in the directory of the specific project. There should also be a `build:assets` and `watch:assets` script in the package.json of every package.
 
-Shaders are also considered to be assets. They are being processed differently, but using the same script. a shader (`.fx` file) will generate a typescript file that will be compiled as part of the build process of the library. When building, `build:assets` will be executed before `compile:source` does. The `build` script will take care of that for you. For example, `@dev/core` has the following scripts:
+Shaders are also considered to be assets. They are being processed differently, but using the same script. Processing a shader (`.fx` file) will result in a Typescript file, which will be compiled as part of the library during the build process. When building, `build:assets` will be executed before `compile:source` does. The `build` script will take care of that for you. For example, `@dev/core` has the following scripts:
 
 ```javascript
 "build": "npm run clean && npm run compile",


### PR DESCRIPTION
I meant to just fix a typo here (lowercase a), but I suppose the phrasing left me scratching my head:

If shaders are just assets that are being processed (subject) by the build tool (actor), then they can't generate (action) but rather are generated (passive)... Or did I misunderstand the process?

And yes, I may or may not be overthinking the language at times.