### PR TITLE
Simplify the opening of the Babylon Server section

### DIFF
--- a/content/contribute/toBabylon/HowToContribute.md
+++ b/content/contribute/toBabylon/HowToContribute.md
@@ -770,7 +770,7 @@ Note about dev host - the dev host is not using any best practices for productio
 
 #### Babylon Server
 
-A new package introduced in the Babylon server, which is a direct copy of the Babylon CDN structure. The Babylon server serves javascript files, along with sourcemaps and declarations.
+The Babylon server is a direct copy of the Babylon CDN structure. It serves javascript files, along with sourcemaps and declarations.
 
 Similar to the dev host, the Babylon server will take the latest compiled code from the dev (or lts) packages and serve it to the browser. The default address for the local CDN is [http://localhost:1338](http://localhost:1338)
 


### PR DESCRIPTION
I assume this was supposed to be: "[...] IS the Babylon server" (typo)

Even so, referring to something as "new" (or relying on temporal language in general) is risky because it won't take long before the section is out of date - see https://developers.google.com/style/timeless-documentation

Remediating this issue also opens up an opportunity for simplification without losing anything of value. Huge fan :-)