### PR TITLE
Add a missing word on the contribution landing page

### DIFF
--- a/content/contribute.md
+++ b/content/contribute.md
@@ -10,4 +10,4 @@ video-content:
 
 ## Contributions
 
-You can contribute to either the babylon.js directly or the documentation for it. The documentation is split into two parts, the 'tutorial' section and the API. The documentation for the API is written from comments within the code for Babylon.js so that details of how to contribute to the API fall under this section.
+You can contribute to either the Babylon.js engine directly or the documentation for it. The documentation is split into two parts, the 'tutorial' section and the API. The documentation for the API is written from comments within the code for Babylon.js so that details of how to contribute to the API fall under this section.


### PR DESCRIPTION
Not sure what was supposed to go there, but either "engine" or "library" would work?