### PR TITLE
Updated event how to with example of passing callback as key trigger paramater

### DIFF
--- a/content/features/featuresDeepDive/events/actions.md
+++ b/content/features/featuresDeepDive/events/actions.md
@@ -157,7 +157,7 @@ scene.actionManager.registerAction(
 );
 ```
 
-For more advanced use cases, you can pass a callback function as a parameter value:
+For more advanced use cases, you can pass a callback function as a parameter value (Available from 5.47.0):
 
 ```javascript
 scene.actionManager.registerAction(

--- a/content/features/featuresDeepDive/events/actions.md
+++ b/content/features/featuresDeepDive/events/actions.md
@@ -157,6 +157,20 @@ scene.actionManager.registerAction(
 );
 ```
 
+For more advanced use cases, you can pass a callback function as a parameter value:
+
+```javascript
+scene.actionManager.registerAction(
+    new BABYLON.ExecuteCodeAction(
+        {
+            trigger: BABYLON.ActionManager.OnKeyUpTrigger,
+            parameter: function(actionEvent) { return actionEvent.sourceEvent.key === 'R'; }
+        },
+        function () { console.log('R button was pressed'); }
+    )
+);
+```
+
 ## Available Actions
 Most of the actions have a `propertyPath` property. This string defines the path to the property to affect with the action. 
 You can use direct values like `position` or `diffuse`. But you can also provide complex paths like `position.x`


### PR DESCRIPTION
This PR adds an example on how to make use the new callback for key up/down triggers . It belongs together with this [PR](https://github.com/BabylonJS/Babylon.js/pull/13538).