### PR TITLE
Fix video links in RTS Game video tutorial

### DIFF
--- a/content/guidedLearning/videos/RTSGameDev.md
+++ b/content/guidedLearning/videos/RTSGameDev.md
@@ -7,27 +7,23 @@ further-reading:
 video-overview:
 video-content:
     - title: RTS Game
-      url: https://www.youtube.com/watch?v=i7tdJpf6Pnc&list=PLCrwuqjmVebK8M9DW_MNOxqn5ic6hF4ua&index=1
-    - title: RTS Game Development Series
-      url: https://www.youtube.com/playlist?list=PLCrwuqjmVebK8M9DW_MNOxqn5ic6hF4ua      
+      url: https://www.youtube.com/watch?v=i7tdJpf6Pnc
 ---
 
 
 Hello, my name is Nikos and I run a YouTube channel catering for programmers.
 
-Have you ever wanted to build an awesome RTS game using Babylon.js?
-Have you ever wondered how all the units in a RTS game go about their tasks?
+Have you ever wanted to build an awesome Real-Time Strategy (RTS) game using Babylon.js?
+Have you ever wondered how all the units in an RTS game go about their tasks?
 
 I invite you to come and build one and learn together with me as we build a unique RTS game called Density Wars!
 The game will involve you having to strategically position the units to beat your opponents. The units can link up their firepower when closer together, but you will have to balance local fire power against the overall progression of the battle.
 
-Come and participate in this evolving RTS game series on YouTube by watching the trailer episode here:
+The RTS Game Development series consists of these episodes:
 
-[![First video in the series](https://img.youtube.com/vi/i7tdJpf6Pnc/0.jpg)](https://www.youtube.com/watch?v=i7tdJpf6Pnc&list=PLCrwuqjmVebK8M9DW_MNOxqn5ic6hF4ua&index=1 "Lets build an online RTS game together - JavaScript RTS game development series - Part 1 ")
-
-Full playlist:
-
-[RTS game development series](https://www.youtube.com/playlist?list=PLCrwuqjmVebK8M9DW_MNOxqn5ic6hF4ua)
+1. [Lets build an online RTS game together](https://www.youtube.com/watch?v=i7tdJpf6Pnc)
+2. [The RTS game project structure](https://www.youtube.com/watch?v=nbmYIcwZEys)
+3. [Rectangular Unit selection](https://www.youtube.com/watch?v=NO820DfNAew)
 
 You will benefit greatly in this series as we learn together how to make a full RTS realtime game, including server side code.
 


### PR DESCRIPTION
The referenced playlist doesn't exist anymore. 

It seems the author never really finished the series, but I found the 3 parts he did make, and linked them directly in the document.  

The repository still exists, although it also links to the non-existent playlist.