### PR TITLE
Fix typo in reflectionTexture.md

### DIFF
--- a/content/features/featuresDeepDive/materials/using/reflectionTexture.md
+++ b/content/features/featuresDeepDive/materials/using/reflectionTexture.md
@@ -35,7 +35,7 @@ Despite the "Texture" name, CubeTexture can _only_ be used with the [.reflection
 
 This classic cloudy skybox helps demonstrate skybox reflection:
 
-|+x (right)|-x (left)|-y (up)|-y (down)|+z (back)|-z (front)|
+|+x (right)|-x (left)|+y (up)|-y (down)|+z (back)|-z (front)|
 |:---:|:---:|:---:|:---:|:---:|:---:|
 |<img src="/img/getstarted/skybox_px.jpg" width="100" height="100" alt="Some clouds"/>|<img src="/img/getstarted/skybox_nx.jpg" width="100" height="100" alt="More clouds"/>|<img src="/img/getstarted/skybox_py.jpg" width="100" height="100" alt="The sun overhead"/>|<img src="/img/getstarted/skybox_ny.jpg" width="100" height="100" alt="Solid gray"/>|<img src="/img/getstarted/skybox_pz.jpg" width="100" height="100" alt="More clouds"/>|<img src="/img/getstarted/skybox_nz.jpg" width="100" height="100" alt="More clouds"/>|
 <br/>

--- a/content/features/featuresDeepDive/materials/using/reflectionTexture.md
+++ b/content/features/featuresDeepDive/materials/using/reflectionTexture.md
@@ -169,7 +169,7 @@ See the source ([reflectionFunction.fx](https://github.com/BabylonJS/Babylon.js/
 
 ### Examples with a test pattern cubemap
 
-|+x (right)|-x (left)|-y (up)|-y (down)|+z (back)|-z (front)|
+|+x (right)|-x (left)|+y (up)|-y (down)|+z (back)|-z (front)|
 |:---:|:---:|:---:|:---:|:---:|:---:|
 |<img src="/img/how_to/Materials/testcube_px.png" width="100" height="100" alt="RGT test pattern"/>|<img src="/img/how_to/Materials/testcube_nx.png" width="100" height="100" alt="LFT test pattern"/>|<img src="/img/how_to/Materials/testcube_py.png" width="100" height="100" alt="TOP test pattern"/>|<img src="/img/how_to/Materials/testcube_ny.png" width="100" height="100" alt="BOT test pattern"/>|<img src="/img/how_to/Materials/testcube_pz.png" width="100" height="100" alt="BCK test pattern"/>|<img src="/img/how_to/Materials/testcube_nz.png" width="100" height="100" alt="FRT test pattern"/>|
 <br/>


### PR DESCRIPTION
The table headers said -y instead of +y for top face of cubemap.