### PR TITLE
Clarify wording for subdivisions property.

### DIFF
--- a/content/features/featuresDeepDive/mesh/creation/set/ground.md
+++ b/content/features/featuresDeepDive/mesh/creation/set/ground.md
@@ -25,7 +25,7 @@ const ground = BABYLON.MeshBuilder.CreateGround("ground", options, scene); //sce
 | width        | _(number)_ size of the width              | 1             |
 | height       | _(number)_ size of the height             | 1             |
 | updatable    | _(boolean)_ true if the mesh is updatable | false         |
-| subdivisions | _(number)_ number of square subdivisions  | 1             |
+| subdivisions | _(number)_ number of square subdivisions along each axis  | 1             |
 
 ### Example
 


### PR DESCRIPTION
Clarify wording for subdivisions property.
The previous version implied total subdivisions due to the word 'square'. Ideally I'd remove the word 'square' from the revised version too. (setting 100 for subdivisions and getting 10000 squares can cause scenes to slow down a tad).