### PR TITLE
Updates to the PGs on the "Examples" section of the Playground

### DIFF
--- a/content/features/featuresDeepDive/environment/reflectionProbes.md
+++ b/content/features/featuresDeepDive/environment/reflectionProbes.md
@@ -53,7 +53,7 @@ probe.attachToMesh(root);
 probe.position = new BABYLON.Vector3(0, 1, 0);
 ```
 
-If you want to try it, check this out: <Playground id="#KA93U#243" title="Reflection Probe Example" description="Simple example of how to use reflection probes in your scene." image="/img/playgroundsAndNMEs/divingDeeperReflectionProbes1.jpg"/>
+If you want to try it, check this out: <Playground id="#KA93U#243" title="Reflection Probe Example" description="Simple example of how to use reflection probes in your scene." image="/img/playgroundsAndNMEs/divingDeeperReflectionProbes1.jpg" isMain={true} category="Environment"/>
 
 ## Probes and PBR
 
@@ -73,6 +73,6 @@ mainMaterial.realTimeFilteringQuality = BABYLON.Constants.TEXTURE_FILTERING_QUAL
 
 Default is `TEXTURE_FILTERING_QUALITY_LOW`. Try with different qualities and see what's the best performance / quality tradeoff for your scene.
 
-Here is a playground example with a reflection probe and PBR material: <Playground id="#FEEK7G#116" title="Reflection Probe and PBR Example" description="Simple example of how to use reflection probes with PBR in your scene." image="/img/playgroundsAndNMEs/divingDeeperReflectionProbes2.jpg"/>
+Here is a playground example with a reflection probe and PBR material: <Playground id="#FEEK7G#116" title="Reflection Probe and PBR Example" description="Simple example of how to use reflection probes with PBR in your scene." image="/img/playgroundsAndNMEs/divingDeeperReflectionProbes2.jpg" isMain={true} category="Environment"/>
 
 You can also have a look at this [blog post](https://medium.com/@babylonjs/real-time-pbr-filtering-is-coming-to-babylon-cb0e81159d79) for more info about HDR filtering.

--- a/content/features/featuresDeepDive/gui/gui.md
+++ b/content/features/featuresDeepDive/gui/gui.md
@@ -173,7 +173,7 @@ To set value as percentage, use this construct: `control.left = "50%"`
 
 You can also not define the unit (In this case the default unit will be used): `control.width = 0.5` (which is equivalent to `control.width = "50%"`)
 
-Here is an example of how to use positions and sizes: <Playground id="#XCPP9Y#14" title="Positions and Sizes Example" description="Simple example demonstrating gui positions and sizes." image="/img/playgroundsAndNMEs/divingDeeperBabylonGUI8.jpg" isMain={true} category="GUI"/>
+Here is an example of how to use and update positions and sizes: <Playground id="#KKA6L4" title="Positions and Sizes Example" description="Simple example demonstrating how to set and update GUI positions and sizes." isMain={true} category="GUI"/>
 
 ### Tracking positions
 

--- a/content/features/featuresDeepDive/lights/shadows_csm.md
+++ b/content/features/featuresDeepDive/lights/shadows_csm.md
@@ -18,7 +18,7 @@ This is a shadow map technique, so a lot of what is said in [Shadows](/features/
 
 Note that CSM requires WebGL 2+.
 
-Here's a Playground demonstrating the CSM technique and the existing `ShadowGenerator`: <Playground id="#IIZ9UU#40" title="Cascaded Shadow Map Example" description="Simple Example of using the CSM system in your scene." image="/img/playgroundsAndNMEs/divingDeeperCSM1.jpg"/>
+Here's a Playground demonstrating the CSM technique: <Playground id="#KY0N7T" title="Cascaded Shadow Map Example" description="Simple Example of using the CSM system in your scene." isMain={true} category="Shadows"/>
 
 ## Technical overview
 

--- a/content/features/featuresDeepDive/materials/shaders/computeShader.md
+++ b/content/features/featuresDeepDive/materials/shaders/computeShader.md
@@ -141,7 +141,7 @@ The implentation in WGSL is a little less pretty than the HLSL one because at th
 
 ### Ocean demo
 
-<Playground id="#YX6IB8#152" engine="webgpu" title="Ocean demo" description="Ocean simulation" image="/img/extensions/webgpu/ocean.png"/>
+<Playground id="#YX6IB8#200" engine="webgpu" title="Ocean demo" description="Ocean simulation" image="/img/extensions/webgpu/ocean.png" isMain={true} category="WebGPU"/>
 
 This is a port of the great project [FFT-Ocean](https://github.com/gasgiant/FFT-Ocean): all credits to Ivan Pensionerov (https://github.com/gasgiant)!
 

--- a/content/features/featuresDeepDive/materials/shaders/shaderMaterial.md
+++ b/content/features/featuresDeepDive/materials/shaders/shaderMaterial.md
@@ -53,7 +53,7 @@ const myShaderMaterial = new BABYLON.ShaderMaterial("shader", scene, "./COMMON_N
 - If your shader code contains #define values, you can specify the ones you want to activate in the `defines` array.
 - Uniforms assigned to textures in the shader code must be present in the samplers array, all other uniforms must be present in the uniforms array.
 
-<Playground id="#5T8G3I" title="Simplest Shader Material" description="Most basic example of ShaderMaterial" />
+<Playground id="#5T8G3I" title="Simplest Shader Material" description="Most basic example of ShaderMaterial" isMain={true} category="Materials" />
 
 <Playground id="#2TGH43" title="Accessing a shader code file from Github" description="Showing how to refer to shader files stored in a Github repository" />
 
@@ -80,7 +80,7 @@ myShaderMaterial.setVector3("direction", BABYLON.Vector3.Zero());
 
 where the set method's name is dependant on type.
 
-<Playground id="#5T8G3I#13" title="Passing a Color3 uniform to a shader" description="Demonstrating how to pass a Color3 uniform to a shader" />
+<Playground id="#5T8G3I#16" title="Passing and updating a Color3 uniform to a shader" description="Demonstrating how to pass a Color3 uniform to a shader" isMain={true} category="Materials" />
 
 ## Troubleshoot
 

--- a/content/features/featuresDeepDive/physics/v1/forces.md
+++ b/content/features/featuresDeepDive/physics/v1/forces.md
@@ -1,30 +1,30 @@
 ---
 title: Forces
-image: 
+image:
 description: Learn all about applying physical forces in Babylon.js.
 keywords: diving deeper, phyiscs, forces
 further-reading:
-    - title: How To Use The Physics Engines
-      url: /legacy/physics/usingPhysicsEngine
-    - title: How to use Joints
-      url: /legacy/physics/joints
-    - title: How To Use Pivots and Axes
-      url: /legacy/physics/pivotsAxes
-    - title: How To Create Compound Bodies
-      url: /legacy/physics/compoundBodies
-    - title: How To Create Soft Bodies
-      url: /legacy/physics/softBodies
-    - title: How To Use Advanced Features
-      url: /legacy/physics/advancedPhysicsFeatures
-    - title: How To Add Your Own Physics Engine
-      url: /legacy/physics/addPhysicsEngine
+  - title: How To Use The Physics Engines
+    url: /legacy/physics/usingPhysicsEngine
+  - title: How to use Joints
+    url: /legacy/physics/joints
+  - title: How To Use Pivots and Axes
+    url: /legacy/physics/pivotsAxes
+  - title: How To Create Compound Bodies
+    url: /legacy/physics/compoundBodies
+  - title: How To Create Soft Bodies
+    url: /legacy/physics/softBodies
+  - title: How To Use Advanced Features
+    url: /legacy/physics/advancedPhysicsFeatures
+  - title: How To Add Your Own Physics Engine
+    url: /legacy/physics/addPhysicsEngine
 video-overview:
 video-content:
 ---
 
 ## How To Use Forces
 
-This section gives some terminology needed to discuss the use of forces in the three physics' engines 
+This section gives some terminology needed to discuss the use of forces in the three physics' engines
 
 1. Cannon.js;
 2. Oimo.js;
@@ -34,11 +34,9 @@ as well as playground examples to check out the coding. In the playgrounds the p
 
 See [How to Use The Physics' Engines](/legacy/physics/usingPhysicsEngine) for an overall view of setting up and using the three plugins.
 
-
-
 ## Body
 
-Solids in physics are often referred to as `bodies`. In the simulation bodies are made up of two parts, the rendered object and the physics object. The rendered object is a mesh and the physics object, which holds the data about the body, is called a physics imposter. 
+Solids in physics are often referred to as `bodies`. In the simulation bodies are made up of two parts, the rendered object and the physics object. The rendered object is a mesh and the physics object, which holds the data about the body, is called a physics imposter.
 
 **Note:** a box imposter is often preferable when the body is a plane.
 
@@ -54,12 +52,12 @@ new BABYLON.PhysicsImpostor(mesh, BABYLON.PhysicsImpostor.BoxImpostor, { mass: 2
 
 These are gravity, impulses, friction and applied forces.
 
-### Gravity 
+### Gravity
 
-In the simulations gravity is a universal force applied throughout the time of the simulation producing a gravitational acceleration. Setting a Vector3 for gravity is in fact setting the gravitational acceleration. The default value being `(0, -9.807, 0)`. Since it is a universal force it is set in the physics' engine either when it is enabled or later. 
+In the simulations gravity is a universal force applied throughout the time of the simulation producing a gravitational acceleration. Setting a Vector3 for gravity is in fact setting the gravitational acceleration. The default value being `(0, -9.807, 0)`. Since it is a universal force it is set in the physics' engine either when it is enabled or later.
 
 ```javascript
-/*When physics is enabled use default gravity*/ 
+/*When physics is enabled use default gravity*/
 scene.enablePhysics(null, new BABYLON.CannonJSPlugin());
 scene.enablePhysics(null, new BABYLON.OimoJSPlugin());
 
@@ -82,21 +80,21 @@ var physicsEngine = scene.enablePhysics(null, new BABYLON.AmmoJSPlugin());
 var gravity = physicsEngine.gravity;
 
 //Set gravity
-physicsEngine.setGravity(new BABYLON.Vector3(0, -5, 0))
+physicsEngine.setGravity(new BABYLON.Vector3(0, -5, 0));
 ```
 
 <Playground id="#YUNAST#3" title="Gravity Example" description="Simple example of using gravity in a phyics engine."/>
 
 ### Impulses
 
-An impulse is a force applied to a body in an instance which will change the current linear velocity and/or the angular velocity of the body. Impulses acting at the center of mass of the body will not change the angular velocity.  Unless other forces act on it the body will continue with the new velocities.
+An impulse is a force applied to a body in an instance which will change the current linear velocity and/or the angular velocity of the body. Impulses acting at the center of mass of the body will not change the angular velocity. Unless other forces act on it the body will continue with the new velocities.
 
 An impulse is applied to a body's physics imposter.
 
-Applying an impulse requires a vector giving the magnitude and direction of the impulse and the position vector of the contact point of the impulse. The contact point of the impulse is given in world coordinates. 
+Applying an impulse requires a vector giving the magnitude and direction of the impulse and the position vector of the contact point of the impulse. The contact point of the impulse is given in world coordinates.
 
 ```javascript
-imposter.applyImpulse(impluse_vector, contact_vector)
+imposter.applyImpulse(impluse_vector, contact_vector);
 
 let localRefPoint = new BABYLON.Vector3(x, y, z);
 
@@ -107,14 +105,14 @@ imposter.applyImpulse(ImpulseVector, mesh.getAbsolutePosition().add(localRefPoin
 
 The following playground is initially set up to apply an impulse at the center of mass vertically against gravity which eventually return the box to earth. Leaving the friction as 0 and applying horizontal impulses shows the continuity of movement.
 
-<Playground id="#RHBQY9#12" title="Impulses Example 1" description="Simple example of adding impulses to objects." isMain={true} category="Physics"/>
+<Playground id="#RHBQY9#12" title="Impulses Example 1" description="Simple example of adding impulses to objects."/>
 
 ### Friction
 
 Friction is a property of a body and is set in the imposter and provides a continuous force between two bodies while they are in contact. You can set friction when creating an imposter and also get and set it later.
 
 ```javascript
-new BABYLON.PhysicsImpostor(mesh, BABYLON.PhysicsImpostor.BoxImpostor, { mass: 2, friction: 0.4}, scene); //on creation
+new BABYLON.PhysicsImpostor(mesh, BABYLON.PhysicsImpostor.BoxImpostor, { mass: 2, friction: 0.4 }, scene); //on creation
 
 var friction = imposter.friction; // get friction;
 imposter.friction = 0.1; //set friction.
@@ -128,8 +126,7 @@ Re-visiting the following playground and setting friction on **both** bodies and
 
 ### Applied Forces
 
-An applied force will only affect the body over the time period that it is applied which is the duration of the frame interval. For zero friction a sufficiently large force (to overcome inertia) applied in the first frame interval will set the body in motion. While `Cannon.js` and `Ammo.js` have a native apply force method `Oimo.js` does not and so an applying force is replaced (internally in Babylon.js) with the apply impulse method so a smaller value has a greater effect. 
-
+An applied force will only affect the body over the time period that it is applied which is the duration of the frame interval. For zero friction a sufficiently large force (to overcome inertia) applied in the first frame interval will set the body in motion. While `Cannon.js` and `Ammo.js` have a native apply force method `Oimo.js` does not and so an applying force is replaced (internally in Babylon.js) with the apply impulse method so a smaller value has a greater effect.
 
 ```javascript
 //Force Settings
@@ -142,4 +139,4 @@ impostor.applyForce(forceDirection.scale(forceMagnitude), mesh.getAbsolutePositi
 
 The following playground initially set up with zero friction and to apply an impulse at the center of mass horizontally in the X direction.
 
-<Playground id="#RHBQY9#1" title="Applying Forces" description="Simple example of applying forces to objects." isMain={true} category="Physics"/>
+<Playground id="#RHBQY9#1" title="Applying Forces" description="Simple example of applying forces to objects."/>

--- a/content/features/featuresDeepDive/physics/v1/softBodies.md
+++ b/content/features/featuresDeepDive/physics/v1/softBodies.md
@@ -146,7 +146,7 @@ To see both sides of a cloth set `backFaceCulling = false` on the material to be
 
 <Playground id="#480ZBN#3" title="Cloth Over a Softbody" description="Simple example of a cloth over a softbody."/>
 <Playground id="#480ZBN#4" title="Cloth Over a Rigid Box" description="Simple example of a cloth over a rigid box."/>
-<Playground id="#480ZBN#5" title="Cloth Over Rigid Box With Fixed Corners" description="Simple example of a cloth over a rigid box with fixed corners." isMain={true} category="Physics"/>
+<Playground id="#480ZBN#5" title="Cloth Over Rigid Box With Fixed Corners" description="Simple example of a cloth over a rigid box with fixed corners."/>
 
 ### Fixed Points
 

--- a/content/features/featuresDeepDive/physics/v2/constraints.md
+++ b/content/features/featuresDeepDive/physics/v2/constraints.md
@@ -105,4 +105,4 @@ When simulating a long chain of constrained bodies, not all of the constraints m
 
 ## Examples
 
-<Playground id="#7DMWP8" title="Constraints" description="Shows all the different constraints available"/>
+<Playground id="#7DMWP8" title="Constraints" description="Shows all the different constraints available" isMain={true} category="Physics"/>

--- a/content/features/featuresDeepDive/physics/v2/forces.md
+++ b/content/features/featuresDeepDive/physics/v2/forces.md
@@ -105,4 +105,4 @@ setTimeout(() => vortexEvent.disable(), 5000);
 
 *For a more detailed explanation, please take a look at the playground example below.*
 
-<Playground id="#E5URLZ#2" title="Physics helpers" description="Show how to use physics helpers and add various effects with forces"/>
+<Playground id="#E5URLZ#2" title="Physics helpers" description="Show how to use physics helpers and add various effects with forces" isMain={true} category="Physics"/>

--- a/content/features/featuresDeepDive/physics/v2/perfTips.md
+++ b/content/features/featuresDeepDive/physics/v2/perfTips.md
@@ -36,6 +36,6 @@ Whenever possible, don't use the entire mesh as a collision shape, especially wh
 
 [Collision observables](/features/featuresDeepDive/physics/collisionEvents) are functions that run every time a body collides with another. Since this can happen as often as every frame, it's important to avoid complex computations, or else the simulation will have to wait for these observables to finish before continuing.
 
-<Playground id="#PX6E6C" title="Stress test" description="Instanciate many bodies to test the Physics engine performance"/>
+<Playground id="#PX6E6C" title="Stress test" description="Instanciate many bodies to test the Physics engine performance" isMain={true} category="Physics"/>
 
 <Playground id="#W3YL7Z" title="Convex Hull Vs Mesh Test" description="Compare Convex hull and Mesh shapes"/>

--- a/content/features/featuresDeepDive/physics/v2/raycast.md
+++ b/content/features/featuresDeepDive/physics/v2/raycast.md
@@ -32,4 +32,4 @@ Important thing to note here is the `raycastResult` that can (and should!) be re
 
 The result object has some information about the properties of the intersection, such as the intersection point, and the Physics Body that was hit.
 
-<Playground id="#I6AR8X" title="RayPicking Vs Raycast" description="Compare Raypicking with raycast feature of the Physics Engine"/>
+<Playground id="#I6AR8X" title="RayPicking Vs Raycast" description="Compare Raypicking with raycast feature of the Physics Engine" isMain={true} category="Physics"/>

--- a/content/features/featuresDeepDive/physics/v2/rigidBodies.md
+++ b/content/features/featuresDeepDive/physics/v2/rigidBodies.md
@@ -105,7 +105,7 @@ body.applyForce(new BABYLON.Vector3(0, 100, 0), new BABYLON.Vector3(0, 0, 0));
 body.applyForce(new BABYLON.Vector3(100, 0, 0), new BABYLON.Vector3(0, 0, 0), 0); 
 ```
 
-<Playground id="#MZKDQT#1" title="Instances" description="How to use instances with physics"/>
+<Playground id="#MZKDQT#1" title="Instances" description="How to use instances with physics" isMain={true} category="Physics"/>
 
 <Playground id="#BJZ39H" title="Pendulum Instances" description="Pendulum Instances"/>
 

--- a/content/features/featuresDeepDive/physics/v2/usingPhysicsEngine.md
+++ b/content/features/featuresDeepDive/physics/v2/usingPhysicsEngine.md
@@ -98,7 +98,7 @@ var createScene = function () {
 };
 ```
 
-<Playground id="#Z8HTUN#1" title="Simple scene" description="Simple falling sphere created with body and shape"/>
+<Playground id="#Z8HTUN#1" title="Simple scene" description="Simple falling sphere created with body and shape" isMain={true} category="Physics"/>
 
 ## Debugging your scene
 

--- a/content/features/featuresDeepDive/postProcesses/SSAORenderPipeline.md
+++ b/content/features/featuresDeepDive/postProcesses/SSAORenderPipeline.md
@@ -13,7 +13,7 @@ video-content:
 BABYLON.SSAORenderingPipeline is a rendering pipeline (chained post-processes) that will compute the ambient occlusion of a given scene from the screen space.
 You can find an example in our playground:
 
-<Playground id="#N96NXC#106" title="SSAO Rendering Pipeline Example" description="Simple example of using the SSAO rendering pipeline."/>
+<Playground id="#N96NXC#106" title="SSAO Rendering Pipeline Example" description="Simple example of using the SSAO rendering pipeline." isMain={true} category="Post-processing"/>
 
 The post-processes chain is defined by:
 

--- a/content/features/featuresDeepDive/postProcesses/defaultRenderingPipeline.md
+++ b/content/features/featuresDeepDive/postProcesses/defaultRenderingPipeline.md
@@ -18,7 +18,7 @@ video-content:
 
 You can find a complete example of this pipeline in our playground:
 
-<Playground id="#Y3C0HQ#146" title="Default Rendering Pipeline Example" description="Complete example of the default rendering pipeline."/>
+<Playground id="#Y3C0HQ#146" title="Default Rendering Pipeline Example" description="Complete example of the default rendering pipeline." isMain={true} category="Post-processing"/>
 
 ![default rendering pipeline example](/img/how_to/defaultRenderingPipeline/defaultRenderingPipeline.jpg)
 

--- a/content/features/featuresDeepDive/postProcesses/renderTargetTextureMultiPass.md
+++ b/content/features/featuresDeepDive/postProcesses/renderTargetTextureMultiPass.md
@@ -94,7 +94,7 @@ finalPass.onApply = (effect) => {
 };
 ```
 
-Playground example: <Playground id="#TG2B18#60" title="Multiple Passes Example" description="Simple example showing how to run multiple passes with the render target texture."/>. On the left you'll see the base render, on the middle the caustic render, and on the right both combined together.
+Playground example: <Playground id="#TG2B18#60" title="Multiple Passes Example" description="Simple example showing how to run multiple passes with the render target texture." isMain={true} category="Post-processing"/>. On the left you'll see the base render, on the middle the caustic render, and on the right both combined together.
 
 ## Performance and tips
 

--- a/content/features/featuresDeepDive/postProcesses/ssrRenderingPipeline.md
+++ b/content/features/featuresDeepDive/postProcesses/ssrRenderingPipeline.md
@@ -1,16 +1,17 @@
 ---
 title: Screen Space Reflections (SSR) Rendering Pipeline
-image: 
+image:
 description: Learn about the screen space reflection rendering pipeline in Babylon.js.
 keywords: diving deeper, post processes, post process, screen space reflection, reflection, SSR
-further-reading: [
-                "http://casual-effects.blogspot.com/2014/08/screen-space-ray-tracing.html", 
-                "https://sourceforge.net/p/g3d/code/HEAD/tree/G3D10/data-files/shader/screenSpaceRayTrace.glsl", 
-                "https://github.com/kode80/kode80SSR", 
-                "https://sakibsaikia.github.io/graphics/2016/12/26/Screen-Space-Reflection-in-Killing-Floor-2.html", 
-                "https://github.com/godotengine/godot/blob/master/servers/rendering/renderer_rd/shaders/effects/screen_space_reflection.glsl", 
-                "https://doc.babylonjs.com/typedoc/classes/babylon.ssrrenderingpipeline"
-                ]
+further-reading:
+  [
+    "http://casual-effects.blogspot.com/2014/08/screen-space-ray-tracing.html",
+    "https://sourceforge.net/p/g3d/code/HEAD/tree/G3D10/data-files/shader/screenSpaceRayTrace.glsl",
+    "https://github.com/kode80/kode80SSR",
+    "https://sakibsaikia.github.io/graphics/2016/12/26/Screen-Space-Reflection-in-Killing-Floor-2.html",
+    "https://github.com/godotengine/godot/blob/master/servers/rendering/renderer_rd/shaders/effects/screen_space_reflection.glsl",
+    "https://doc.babylonjs.com/typedoc/classes/babylon.ssrrenderingpipeline",
+  ]
 video-overview:
 video-content:
 ---
@@ -20,12 +21,13 @@ This rendering pipeline is new in Babylon.js 5.51.0 and replaces the [Screen Spa
 ## Introduction
 
 Rendering reflections in real time can be done using several methods. Each method has its own advantages and disadvantages. For web technologies, there are two main methods:
-* **Use of a mirror texture**:
-    * Advantages: renders perfect reflections on a plane.
-    * Disadvantages: limited to one reflection direction and complexity increases according to the geometry of the scene.
-* **Use of SSR post-processing** :
-    * Advantages: makes all reflections possible in all directions and the complexity only depends on the screen resolution (like all post-processing).
-    * Disadvantages: limited to what the camera sees.
+
+- **Use of a mirror texture**:
+  - Advantages: renders perfect reflections on a plane.
+  - Disadvantages: limited to one reflection direction and complexity increases according to the geometry of the scene.
+- **Use of SSR post-processing** :
+  - Advantages: makes all reflections possible in all directions and the complexity only depends on the screen resolution (like all post-processing).
+  - Disadvantages: limited to what the camera sees.
 
 Ray tracing is also used in some games to render reflections. However, it is not yet available in web technologies.
 
@@ -37,16 +39,19 @@ Here is a comparison of the rendering with and without the activation of the SSR
 | ![With SSR](/img/how_to/ssrRenderingPipeline/intro_with_ssr_brainstem.jpg!500) | ![Without SSR](/img/how_to/ssrRenderingPipeline/intro_without_ssr_brainstem.jpg!500) |
 
 Here are the playgrounds that generated the above images:
-* <Playground id="#PIZ1GK#1116" title="SSR Rendering Pipeline Example (Hill Valley)" description="Hill Valley scene with screen space reflections"/>
-* <Playground id="#PIZ1GK#1044" title="SSR Rendering Pipeline Example (Balls)" description="Mirror and Balls scene with screen space reflections"/>
-* <Playground id="#PIZ1GK#1045" title="SSR Rendering Pipeline Example (BrainStem)" description="Robot scene with screen space reflections"/>
+
+- <Playground id="#PIZ1GK#1116" title="SSR Rendering Pipeline Example (Hill Valley)" description="Hill Valley scene with screen space reflections" isMain={true} category="Post-processing"/>
+- <Playground id="#PIZ1GK#1044" title="SSR Rendering Pipeline Example (Balls)" description="Mirror and Balls scene with screen space reflections"/>
+- <Playground id="#PIZ1GK#1045" title="SSR Rendering Pipeline Example (BrainStem)" description="Robot scene with screen space reflections"/>
 
 ## Prerequisites
+
 To render reflections using the SSR rendering pipeline, the device must support WebGL 2 or WebGPU. If it does not, the render pipeline will work as a simple pass-through.
 
 For any reflective geometry in your scene, the SSR pipeline needs to know its "reflectivity" properties. To provide this information, your reflective meshes must contain:
-* For a **Standard Material**: a specular color (`material.specularColor`), and optionally a specular texture (`material.specularTexture`). These elements will be used to know how much the object reflects for each pixel. **Important**: by default, the specular color of a standard material is `(1,1,1)`, so the material is totally reflective! If you don't want your material to be reflective, set the specular color to `(0,0,0)`.
-* For a **PBR** material: the `metallic` property and optionally a `metallicTexture` for the metallic/roughness workflow, and the `reflectivityColor` property and optionally a `reflectivityTexture` for the specular/glossiness workflow. The roughness property (in the metallic/roughness workflow) or the micro-surface property (in the specular/glossiness workflow) will also be used to blur the reflection (see below for more details).
+
+- For a **Standard Material**: a specular color (`material.specularColor`), and optionally a specular texture (`material.specularTexture`). These elements will be used to know how much the object reflects for each pixel. **Important**: by default, the specular color of a standard material is `(1,1,1)`, so the material is totally reflective! If you don't want your material to be reflective, set the specular color to `(0,0,0)`.
+- For a **PBR** material: the `metallic` property and optionally a `metallicTexture` for the metallic/roughness workflow, and the `reflectivityColor` property and optionally a `reflectivityTexture` for the specular/glossiness workflow. The roughness property (in the metallic/roughness workflow) or the micro-surface property (in the specular/glossiness workflow) will also be used to blur the reflection (see below for more details).
 
 In the case of PBR, the reflective color is never black, there are always reflections, which means that the SSR effect will be applied to all pixels on the screen! This can be costly in performance for zero benefit, because when the reflective color is low, you usually won't see any difference between applying or not applying the SSR effect (it also depends on the roughness property). This is why the SSR pipeline provides a `reflectivityThreshold` property, which will disable the effect for pixels whose reflective color is at or below a certain threshold. The default value is `0.04`, which is the default reflective color you get when `metallic = 0`.
 
@@ -55,14 +60,15 @@ In the case of PBR, the reflective color is never black, there are always reflec
 ## Creating the SSR rendering pipeline
 
 Just create an instance of `BABYLON.SSRRenderingPipeline` :
+
 ```javascript
 const ssr = new BABYLON.SSRRenderingPipeline(
-    "ssr", // The name of the pipeline
-    scene, // The scene to which the pipeline belongs
-    [scene.activeCamera], // The list of cameras to attach the pipeline to
-    false, // Whether or not to use the geometry buffer renderer (default: false, use the pre-pass renderer)
-    BABYLON.Constants.TEXTURETYPE_UNSIGNED_BYTE // The texture type used by the SSR effect (default: TEXTURETYPE_UNSIGNED_BYTE)
-); 
+  "ssr", // The name of the pipeline
+  scene, // The scene to which the pipeline belongs
+  [scene.activeCamera], // The list of cameras to attach the pipeline to
+  false, // Whether or not to use the geometry buffer renderer (default: false, use the pre-pass renderer)
+  BABYLON.Constants.TEXTURETYPE_UNSIGNED_BYTE, // The texture type used by the SSR effect (default: TEXTURETYPE_UNSIGNED_BYTE)
+);
 ```
 
 You can easily enable/disable the SSR effect by setting the `isEnabled` property of the pipeline.
@@ -72,33 +78,36 @@ You can easily enable/disable the SSR effect by setting the `isEnabled` property
 A basic understanding of the algorithm will help you understand how to configure the SSR rendering pipeline for best results.
 
 The algorithm is based on the following steps:
+
 1. Render the scene in multiple render targets, using either the geometry buffer or the pre-pass renderer. We need to generate the normal, depth and reflectivity buffers.
 1. For each pixel in the screen, if it is reflective:
-    1. Calculate the reflection vector of the camera-to-pixel direction and trace a ray from the pixel's position in that direction. To calculate the reflection vector, we need the normal at this pixel, that's why we need to generate this buffer. Moreover, this calculation is done in the camera space (3D space), so we need to convert the 2D coordinates of the pixel into 3D (thanks to the depth buffer).
-    1. If the ray intersects an object, we get the color of this object from the color texture. 
-    1. If the ray does not intersect anything:
-        1. we use the color from `SSRRenderingPipeline.environmentTexture` as the hit color if a texture is provided.
-        1. we simply use the color of the pixel if no environment texture is provided.
-    1. If blur is not enabled, we blend the hit color with the pixel color to generate the final color. By default, the blending is done using the reflectivity of the object at that pixel (there's a new option in 6.5.1 (`useFresnel`) that will blend using the fresnel coefficient). The calculation of the intersection is done by marching the ray (which means that we advance the ray step by step and calculate a new 3D point at each step) in the screen space, using the depth buffer to know if the ray hit an object or not. In this way, we can calculate the position of the intersected object in camera space (3D) but move forward in 2D space so as not to spend resources in iterations that would project the current point of the ray on the same pixel as the previous iteration.
-    1. If blur is enabled, we simply store the SSR effect and not the final pixel color. We will blur the SSR effect in one more pass (see next step).
+   1. Calculate the reflection vector of the camera-to-pixel direction and trace a ray from the pixel's position in that direction. To calculate the reflection vector, we need the normal at this pixel, that's why we need to generate this buffer. Moreover, this calculation is done in the camera space (3D space), so we need to convert the 2D coordinates of the pixel into 3D (thanks to the depth buffer).
+   1. If the ray intersects an object, we get the color of this object from the color texture.
+   1. If the ray does not intersect anything:
+      1. we use the color from `SSRRenderingPipeline.environmentTexture` as the hit color if a texture is provided.
+      1. we simply use the color of the pixel if no environment texture is provided.
+   1. If blur is not enabled, we blend the hit color with the pixel color to generate the final color. By default, the blending is done using the reflectivity of the object at that pixel (there's a new option in 6.5.1 (`useFresnel`) that will blend using the fresnel coefficient). The calculation of the intersection is done by marching the ray (which means that we advance the ray step by step and calculate a new 3D point at each step) in the screen space, using the depth buffer to know if the ray hit an object or not. In this way, we can calculate the position of the intersected object in camera space (3D) but move forward in 2D space so as not to spend resources in iterations that would project the current point of the ray on the same pixel as the previous iteration.
+   1. If blur is enabled, we simply store the SSR effect and not the final pixel color. We will blur the SSR effect in one more pass (see next step).
 1. If blur is enabled, we blur (in two passes - horizontal and vertical) the result of the SSR pass and merge it with the original scene in a final pass.
 
 Regarding some properties of the SSR pipeline:
-* In step 2, the `reflectivityThreshold` property is used to know whether a pixel is reflective or not.
-* In step 2.1:
-    * The starting point of the ray is shifted to avoid self-collision intersections and erroneous reflections. The `selfCollisionNumSkip` property controls the number of iterations to skip at the start before considering an intersection legitimate. A value of 1 works well in most cases, but it is sometimes necessary to increase it to 2 or 3 to avoid certain rendering artifacts.
-    * If blur is not enabled, the starting point of the ray is jittered to account for the roughness of the surface. The intensity of the jitter is controlled by the `roughnessFactor` property (default: 0.2).
-* At step 2.2:
-    * The ray is moved in 3D space only up to `maxDistance` (default: 1000) units from the pixel position (3D). Note that when frustum clipping is enabled (`clipToFrustum = true`, which is the default), the ray is clipped to the camera frustum, which may reduce the value of `maxDistance` for that ray.
-    * The ray is moved in 2D space up to `maxSteps` (default: 1000) iterations. The number of pixels that are moved in each iteration is given by `step` (default: 1). When the `enableSmoothReflections` property is `true`, an additional calculation is performed to compute a more accurate intersection point. This extra step will only occur if `enableSmoothReflections = true` and `step > 1`.
-    * The `thickness` property is used to give thickness to objects during the intersection calculation. See below for more explanation of the `thickness` parameter.
-* In step 2.5, `roughnessFactor` is used as a global roughness factor applied to all objects. It can help blur reflections even when the roughness of some surfaces is 0.
-* In step 3, `blurDispersionStrength` (default: 0.03) and `blurQuality` (default: 2) are used to control the strength and quality of the blur dispersion effect.
+
+- In step 2, the `reflectivityThreshold` property is used to know whether a pixel is reflective or not.
+- In step 2.1:
+  - The starting point of the ray is shifted to avoid self-collision intersections and erroneous reflections. The `selfCollisionNumSkip` property controls the number of iterations to skip at the start before considering an intersection legitimate. A value of 1 works well in most cases, but it is sometimes necessary to increase it to 2 or 3 to avoid certain rendering artifacts.
+  - If blur is not enabled, the starting point of the ray is jittered to account for the roughness of the surface. The intensity of the jitter is controlled by the `roughnessFactor` property (default: 0.2).
+- At step 2.2:
+  - The ray is moved in 3D space only up to `maxDistance` (default: 1000) units from the pixel position (3D). Note that when frustum clipping is enabled (`clipToFrustum = true`, which is the default), the ray is clipped to the camera frustum, which may reduce the value of `maxDistance` for that ray.
+  - The ray is moved in 2D space up to `maxSteps` (default: 1000) iterations. The number of pixels that are moved in each iteration is given by `step` (default: 1). When the `enableSmoothReflections` property is `true`, an additional calculation is performed to compute a more accurate intersection point. This extra step will only occur if `enableSmoothReflections = true` and `step > 1`.
+  - The `thickness` property is used to give thickness to objects during the intersection calculation. See below for more explanation of the `thickness` parameter.
+- In step 2.5, `roughnessFactor` is used as a global roughness factor applied to all objects. It can help blur reflections even when the roughness of some surfaces is 0.
+- In step 3, `blurDispersionStrength` (default: 0.03) and `blurQuality` (default: 2) are used to control the strength and quality of the blur dispersion effect.
 
 ## Debugging SSR scenes
 
 An important setting in the SSR pipeline is the `debug` property. It can help you understand what is going on in your scene, and we will use it a lot in the following sections.
 Simply set it to `true` to enable a special color rendering of the SSR effect:
+
 ```javascript
 ssr.debug = true;
 ```
@@ -109,10 +118,10 @@ For example
 | ![Without debug](/img/how_to/ssrRenderingPipeline/intro_with_ssr.jpg!500) | ![With debug](/img/how_to/ssrRenderingPipeline/intro_with_ssr_debug.jpg!500) |
 
 The meaning of the colors is as follows:
-    * blue: the ray has reached the maximum distance (we have reached `maxDistance`)
-    * red: the ray ran out of steps (we have reached `maxSteps`)
-    * yellow : the ray has left the screen. By default, frustum clipping is on, so you shouldn't see this color much.
-    * green : the ray has intersected a surface. The brightness of the green color is proportional to the distance between the origin of the ray and the point of intersection: a lighter green means more calculations than a darker green. The brightness is directly proportional to the number of steps the main loop had to execute to find an intersection (`debug.green = num_steps / maxSteps`): if we did not find an intersection within `maxSteps`, a red color is generated instead of a full green.
+_ blue: the ray has reached the maximum distance (we have reached `maxDistance`)
+_ red: the ray ran out of steps (we have reached `maxSteps`)
+_ yellow : the ray has left the screen. By default, frustum clipping is on, so you shouldn't see this color much.
+_ green : the ray has intersected a surface. The brightness of the green color is proportional to the distance between the origin of the ray and the point of intersection: a lighter green means more calculations than a darker green. The brightness is directly proportional to the number of steps the main loop had to execute to find an intersection (`debug.green = num_steps / maxSteps`): if we did not find an intersection within `maxSteps`, a red color is generated instead of a full green.
 
 If possible, you should try to get as few red pixels as possible, as this means that we have executed all the iterations of the loop before stopping without finding an intersection.
 You can trade red pixels for blue pixels by increasing the value of `step`, which will favor speed over quality, so it's a balance to be found depending on your scene and the final result you expect.
@@ -157,8 +166,8 @@ Here is the PG used in these examples: <Playground id="#PIZ1GK#1046" title="Comp
 
 Also, one thing to note about the pre-pass renderer is that you have the option to use 16-bit floating textures for the depth texture, to save memory space for example (the geometry buffer renderer always uses a 32-bit floating texture). This can lead to rendering artifacts, depending on your scene:
 
-| 32 bits float depth texture | 16 bits float depth texture |
-| --- | --- |
+| 32 bits float depth texture                                                                           | 16 bits float depth texture                                                                    |
+| ----------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------- |
 | ![32 bits float depth texture](/img/how_to/ssrRenderingPipeline/geometry_buffer_sphere_debug.jpg!500) | ![16 bits float depth texture](/img/how_to/ssrRenderingPipeline/pre_pass_sphere_debug.jpg!500) |
 
 Note: `ssr.clipToFrustum` has been set to `false` to take these screenshots because the artifacts are more visible with a yellow background than with a blue one!
@@ -166,9 +175,11 @@ Note: `ssr.clipToFrustum` has been set to `false` to take these screenshots beca
 You get these artifacts because there is less precision in the depth buffer and therefore you get more self-collisions between the reflected ray and the actual surface from which the ray is shot (see section 2.1 in [How SSR is working](#how-ssr-works)).
 
 You can solve the problem by keeping the default texture with a depth of 32 bits or by increasing `selfCollisionNumSkip` :
+
 ```javascript
 ssr.selfCollisionNumSkip = 2;
 ```
+
 ![16 bits float depth texture with selfCollisionNumSkip=2](/img/how_to/ssrRenderingPipeline/pre_pass_sphere_skip_2_debug.jpg!500)
 
 Here is the corresponding PG for this screenshot: <Playground id="#PIZ1GK#1047" title="16 bits float depth texture and skip to 2" description="16 bits float depth texture and skip to 2"/>
@@ -182,17 +193,18 @@ In the following sections, we will describe the most important parameters of the
 ### Thickness
 
 In [step 2.2 of the SSR algorithm](#how-ssr-works), we know if the ray has hit an object when:
-* the depth of the current point of the ray is farther away than the depth of the pixel on which this point is projected (this depth is read from the depth buffer). This means that the current ray point is "behind" the object that was rendered in the depth buffer at that point. Note that the depth increases for objects further away from the camera.
-* The depth of the previous point of the ray is closer than the depth of the pixel on which this point is projected. This means that the previous point of the ray is "in front" of the object that was rendered in the depth buffer at that point
+
+- the depth of the current point of the ray is farther away than the depth of the pixel on which this point is projected (this depth is read from the depth buffer). This means that the current ray point is "behind" the object that was rendered in the depth buffer at that point. Note that the depth increases for objects further away from the camera.
+- The depth of the previous point of the ray is closer than the depth of the pixel on which this point is projected. This means that the previous point of the ray is "in front" of the object that was rendered in the depth buffer at that point
 
 Thus, we know that we have crossed the boundary of the object rendered at the location of this pixel. However, the depth buffer stores only one depth value for each pixel, so we don't know the thickness of an object, which is necessary if we want to calculate accurate intersections. By default we use a constant thickness value, which is set to `0.5` by default. You can change this value by setting the `thickness` property of the SSR rendering pipeline, and this value will depend on the extent of your scene.
 
-| Thickness 0 | Thickness 0.5 |
-| --- | --- |
+| Thickness 0                                                                | Thickness 0.5                                                                  |
+| -------------------------------------------------------------------------- | ------------------------------------------------------------------------------ |
 | ![Thickness 0](/img/how_to/ssrRenderingPipeline/balls_thickness_0.jpg!500) | ![Thickness 0.5](/img/how_to/ssrRenderingPipeline/balls_thickness_0_5.jpg!500) |
 
-| Thickness 1 | Thickness 4 |
-| --- | --- |
+| Thickness 1                                                                | Thickness 4                                                                |
+| -------------------------------------------------------------------------- | -------------------------------------------------------------------------- |
 | ![Thickness 1](/img/how_to/ssrRenderingPipeline/balls_thickness_1.jpg!500) | ![Thickness 1](/img/how_to/ssrRenderingPipeline/balls_thickness_4.jpg!500) |
 
 As you can see in the mirror and on the floor, the reflections of the objects expand but only in a linear way, the shape of the sphere is not preserved because we use a constant thickness value.
@@ -201,13 +213,14 @@ As you can see in the mirror and on the floor, the reflections of the objects ex
 
 The SSR pipeline also supports a more accurate method of calculating thickness, which is to use additional depth rendering to generate the depth of the back faces. In this way, we can calculate the thickness as the difference between the depth value read from this back depth buffer and that read from the front depth buffer:
 
-| Thickness 1 | Thickness 0 with automatic thickness computation |
-| --- | --- |
+| Thickness 1                                                                | Thickness 0 with automatic thickness computation                                                                     |
+| -------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------- |
 | ![Thickness 1](/img/how_to/ssrRenderingPipeline/balls_thickness_1.jpg!500) | ![Thickness 0 with automatic thickness computation](/img/how_to/ssrRenderingPipeline/balls_auto_thickness_0.jpg!500) |
 
 Here is the corresponding PG: <Playground id="#PIZ1GK#1044" title="SSR Rendering Pipeline Example (Balls)" description="Mirror and Balls scene with screen space reflections"/>
 
 You enable this mode by setting the `enableAutomaticThicknessComputation` property of the SSR rendering pipeline to `true`:
+
 ```javascript
 ssr.enableAutomaticThicknessComputation = true;
 ```
@@ -224,9 +237,10 @@ You can reduce the GPU requirements of this mode by setting a value greater than
 `maxDistance`, `maxSteps`, `step` and `enableSmoothReflections` work together, and their impact on the final rendering can be understood by reading the [How SSR works](#how-ssr-works) section as well as [Debugging your SSR scenes](#debugging-your-ssr-scenes).
 
 In summary:
-* a ray will not go further than `maxDistance` (in 3D space)
-* a ray will not go further than `maxSteps` * `step` pixels (in 2D space)
-* If `step` is greater than 1, you can enable `enableSmoothReflections` to compute more accurate intersections and thus improve reflections.
+
+- a ray will not go further than `maxDistance` (in 3D space)
+- a ray will not go further than `maxSteps` \* `step` pixels (in 2D space)
+- If `step` is greater than 1, you can enable `enableSmoothReflections` to compute more accurate intersections and thus improve reflections.
 
 `clipToFrustum = true` will clip the ray to the camera frustum and should generally be left `true`, because although it adds some instructions to the shader, it shortens the radius and thus reduces the computation.
 
@@ -235,14 +249,17 @@ In summary:
 ### Reflection intensity
 
 `strength` and `reflectionSpecularFalloffExponent` work together to increase or decrease the SSR effect:
-* The `strength` parameter will modulate the reflectivity color.
-* The `reflectionSpecularFalloffExponent` parameter is applied after the reflectivity color is modulated by the `strength` parameter.
+
+- The `strength` parameter will modulate the reflectivity color.
+- The `reflectionSpecularFalloffExponent` parameter is applied after the reflectivity color is modulated by the `strength` parameter.
 
 The formula is as follows:
+
 ```javascript
-reflectionMultiplier = pow(reflectivity * strength, reflectionSpecularFalloffExponent)
-finalColor = color * (1 - reflectionMultiplier) + reflectionMultiplier * SSR
+reflectionMultiplier = pow(reflectivity * strength, reflectionSpecularFalloffExponent);
+finalColor = color * (1 - reflectionMultiplier) + reflectionMultiplier * SSR;
 ```
+
 Note: `pow` is the exponentiation operator.
 
 It is probably best to keep `strength = 1` (the default) and change `reflectionSpecularFalloffExponent` depending on whether you want to enhance the effect (use values less than 1) or reduce the effect (use values greater than 1).
@@ -254,8 +271,9 @@ You can optionally add a blur pass to SSR reflections (enabled by default). This
 `blurDispersionStrength` is the main parameter (default: 0.03). When it is set to 0, the blur is disabled: You must set a value greater than 0 to enable it. The range of values is approximately between 0 and 0.1, where 0.1 is already a strong blur effect.
 
 As mentioned above, the blur is based on the roughness of the material:
-* for standard materials, the roughness comes from the alpha channel of the specular texture if provided (and is actually `1 - alpha`, since the alpha channel stores gloss, not roughness), and is set to 0 otherwise
-* for PBR materials, it is computed from the `roughness` property and optionally a `reflectivityTexture` for the metallic/roughness workflow, and from the `microSurface` property and optionally a `reflectivityTexture` for the specular/glossiness workflow.
+
+- for standard materials, the roughness comes from the alpha channel of the specular texture if provided (and is actually `1 - alpha`, since the alpha channel stores gloss, not roughness), and is set to 0 otherwise
+- for PBR materials, it is computed from the `roughness` property and optionally a `reflectivityTexture` for the metallic/roughness workflow, and from the `microSurface` property and optionally a `reflectivityTexture` for the specular/glossiness workflow.
 
 If the roughness is 0, the blur will have no effect because the surface is perfectly smooth. If you still want to get some blur even in this case, you can use the `roughnessFactor` property (default: 0.2), which acts as an additional global roughness:
 | `blurDispersionStrength = 0.0`, `roughnessFactor = 0` | `blurDispersionStrength = 0.05`, `roughnessFactor = 0` |
@@ -264,8 +282,8 @@ If the roughness is 0, the blur will have no effect because the surface is perfe
 
 In this scene, all materials are standard materials with no specular texture, so their roughness is 0. The two screenshots are identical because the final roughness is 0 for all materials, even if we give a non-zero value to `blurDispersionStrength`.
 
-| `blurDispersionStrength = 0.05`, `roughnessFactor = 0.1` | `blurDispersionStrength = 0.05`, `roughnessFactor = 0.5` |
-| --- | --- |
+| `blurDispersionStrength = 0.05`, `roughnessFactor = 0.1`                                                  | `blurDispersionStrength = 0.05`, `roughnessFactor = 0.5`                                                  |
+| --------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------- |
 | ![Blur with roughnessFactor = 0.1](/img/how_to/ssrRenderingPipeline/ssr_blur_roughnessfactor_0_1.jpg!500) | ![Blur with roughnessFactor = 0.5](/img/how_to/ssrRenderingPipeline/ssr_blur_roughnessfactor_0_5.jpg!500) |
 
 By setting a non-zero value to `roughnessFactor`, you increase the final roughness and the blur now has a visible effect.
@@ -298,8 +316,9 @@ Using the debug view, we can see that the reflections are calculated on the sphe
 ### Color space
 
 By default, the SSR pipeline expects the input color texture to be in gamma space and will generate its output in gamma space. If for some reason the input is in linear space or you want to generate the output in linear space, you can use these parameters:
-* `inputTextureColorIsInGammaSpace`: set it to `false` to indicate that the input color texture is in linear space.
-* `generateOutputInGammaSpace`: set it to `false` to generate the output in linear space.
+
+- `inputTextureColorIsInGammaSpace`: set it to `false` to indicate that the input color texture is in linear space.
+- `generateOutputInGammaSpace`: set it to `false` to generate the output in linear space.
 
 ### Use fresnel
 
@@ -354,19 +373,21 @@ There is nothing we can do, unfortunately, you will have to be creative to try t
 
 For automatic thickness calculation (`enableAutomaticThicknessComputation = true`) to work, the back sides must exist, so that a thickness can be accurately calculated by subtracting the depth read from the back and front depth textures. If some of your objects have only front faces, you will get nasty artifacts:
 
-| This plane does not have a back face | Some of the objects of the robot don't have back faces |
-| --- | --- |
+| This plane does not have a back face                                                                  | Some of the objects of the robot don't have back faces                                                |
+| ----------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------- |
 | ![Artifacts with plane](/img/how_to/ssrRenderingPipeline/artifacts_automatic_thickness_plane.jpg!500) | ![Artifacts with robot](/img/how_to/ssrRenderingPipeline/artifacts_automatic_thickness_robot.jpg!500) |
 
 The solution is to make sure that all objects have back sides:
-* for the plane it's easy, just set `plane.material.backFaceCulling = false`
-* for the robot, it's not so easy, you have to find the defective meshes and either create back faces for them or set `backFaceCulling = false` for their materials. Another solution would be to simply disable the automatic thickness calculation!
+
+- for the plane it's easy, just set `plane.material.backFaceCulling = false`
+- for the robot, it's not so easy, you have to find the defective meshes and either create back faces for them or set `backFaceCulling = false` for their materials. Another solution would be to simply disable the automatic thickness calculation!
 
 Here is the PG for the plane example: <Playground id="#PIZ1GK#1050" title="SSR Artifacts (automatic thickness)" description="SSR Artifacts with automatic thickness computation"/>
 
 Note that there is a special case for transparent meshes. In the standard rendering pass, transparent meshes do not write to the depth buffer, so it will not be possible to calculate a correct thickness for these subjects.
 It turns out that transparent meshes write to the depth texture when using the geometry/pre-pass renderer, but the backface depth renderer created internally when enabling automatic thickness calculation does not write to the depth texture for transparent materials.
 You will need to enable writing of depth values for transparent meshes by doing:
+
 ```javascript
 ssr.backfaceForceDepthWriteTransparentMeshes = true;
 ```
@@ -390,8 +411,8 @@ Also, the back of the objects cannot be reflected properly, because we only have
 
 Here's what happens to reflections when geometries go out of view:
 <video controls muted loop preload="auto" width="600px">
-    <source src="/img/how_to/ssrRenderingPipeline/artifacts_ssr_geometry_disappear.webm" type="video/webm"/>
-    Your browser does not support the video tag.
+<source src="/img/how_to/ssrRenderingPipeline/artifacts_ssr_geometry_disappear.webm" type="video/webm"/>
+Your browser does not support the video tag.
 </video>
 
 The `attenuateScreenBorders = true` parameter makes the disappearance of reflections less abrupt:
@@ -442,8 +463,9 @@ Because this check requires additional texture lookup to get the normal to the p
 #### Handling missed intersections
 
 When a reflected ray doesn't hit anything (either because there is no geometry to intersect, or because we have reached the maximum distance / maximum steps), we have two choices for the color we should choose:
-* if an environment cube texture has been provided, we read the color from the texture using the direction of the reflected ray
-* If no environment texture has been provided, we use the color of the current pixel as a fallback.
+
+- if an environment cube texture has been provided, we read the color from the texture using the direction of the reflected ray
+- If no environment texture has been provided, we use the color of the current pixel as a fallback.
 
 If you don't provide an environment texture, you will usually see obvious differences between the pixels for which we were able to find a reflected pixel and those for which we were not:
 | No environment texture | Debug view |
@@ -478,6 +500,7 @@ As explained in [How-ssr-is-working](#how-ssr-works), the starting point of the 
 As you can see above, SSR is not a perfect technique (far from it!), and you have to deal with a number of artifacts and limitations. Most of your work will be in trying to hide these artifacts as much as possible, and making sure the effect works as fast as possible within these constraints.
 
 To make the SSR as fast as possible, you should:
+
 1. use the largest possible values for `step`
 1. use the smallest possible values for `maxSteps` and `maxDistance`
 1. disable `enableSmoothReflections` - but, with larger values of `step`, you may want to enable this setting
@@ -485,16 +508,16 @@ To make the SSR as fast as possible, you should:
 1. Use values as large as possible for `blurDownsample`.
 1. Use as large values as possible for `ssrDownsample`. This parameter acts like `blurDownsample` but for the SSR effect itself. Also, it will only have an effect when the blur is on (so when `blurDispersionStrength` is greater than 0).
 
-Here is a playground demonstrating two different settings for the Hill Valley scene: 
+Here is a playground demonstrating two different settings for the Hill Valley scene:
 
 <Playground id="#PIZ1GK#1057" title="SSR (Hill Valley) optimization" description="Hill Valley scene with SSR and optimized settings"/>
 
 For the starting position (GPU is an RTX 3080Ti, canvas size is 1278x1200):
 
-| | Total GPU frame time | GPU time for SSR alone |
-| --- | --- | --- |
-| Quality settings | 6.6ms | 4.15ms |
-| Optimized settings | 1.35ms | 0.2ms |
+|                    | Total GPU frame time | GPU time for SSR alone |
+| ------------------ | -------------------- | ---------------------- |
+| Quality settings   | 6.6ms                | 4.15ms                 |
+| Optimized settings | 1.35ms               | 0.2ms                  |
 
 In the optimized case, the blur + final merge take `0.05ms`, so the full SSR effect takes `0.25ms`! For comparison, the same scene without SSR takes `0.9ms`. So, in reality, the SSR effect takes `1.35 - 0.9 = 0.45ms` and not `0.25ms`. The difference between `0.25ms` and `0.45ms` (`0.2ms`) is the extra time needed to render normal, depth and reflectivity textures. In the end, the optimized settings are `4.4 / 0.45 ~ 10` times faster than the quality settings!
 

--- a/content/features/featuresDeepDive/postProcesses/usePostProcesses.md
+++ b/content/features/featuresDeepDive/postProcesses/usePostProcesses.md
@@ -300,7 +300,7 @@ postProcess.onApply = function (effect) {
 };
 ```
 
-You can find another example here: <Playground id="#DAC1WM" title="Custom Post Process Example" description="Simple example of a custom post process."/>
+You can find another example here: <Playground id="#DAC1WM" title="Custom Post Process Example" description="Simple example of a custom post process." isMain={true} category="Post-processing"/>
 
 To use the output of a previous post process setTextureFromPostProcess can be used.
 Note: This will set sceneSampler to the output of the post process before postProcess0 NOT the output of postProcess0.

--- a/content/features/featuresDeepDive/scene/fastBuildWorld.md
+++ b/content/features/featuresDeepDive/scene/fastBuildWorld.md
@@ -18,11 +18,11 @@ For beginners to Babylon.js these two sections [Fastest Build](/features/feature
 
 The following is a list of the methods of the `scene` object that help in fast building a world, with a link to their API description:
 
--   [createDefaultCameraOrLight](/typedoc/classes/babylon.scene#createdefaultcameraorlight);
--   [createDefaultCamera](/typedoc/classes/babylon.scene#createdefaultcamera);
--   [createDefaultLight](/typedoc/classes/babylon.scene#createdefaultlight);
--   [createDefaultEnvironment](/typedoc/classes/babylon.scene#createdefaultenvironment);
--   [createDefaultSkybox](/typedoc/classes/babylon.scene#createdefaultskybox);
+- [createDefaultCameraOrLight](/typedoc/classes/babylon.scene#createdefaultcameraorlight);
+- [createDefaultCamera](/typedoc/classes/babylon.scene#createdefaultcamera);
+- [createDefaultLight](/typedoc/classes/babylon.scene#createdefaultlight);
+- [createDefaultEnvironment](/typedoc/classes/babylon.scene#createdefaultenvironment);
+- [createDefaultSkybox](/typedoc/classes/babylon.scene#createdefaultskybox);
 
 ## Fastest Build
 
@@ -33,7 +33,7 @@ scene.createDefaultCameraOrLight(true, true, true);
 scene.createDefaultEnvironment();
 ```
 
-<Playground id="#MJNICE" title="The Quickest Way To Build A World" description="Simple example of creating a world with createDefaultEnviornment."/>
+<Playground id="#MJNICE" title="The Quickest Way To Build A World" description="Simple example of creating a world with createDefaultEnviornment." isMain={true} category="Environment"/>
 
 You can see how the camera automatically adjusts by adding a second box and re-positioning it
 
@@ -49,9 +49,9 @@ As can be seen in the _Fastest Build_ section the helper, `createDefaultCameraOr
 
 The `createDefaultCamera` takes three boolean parameters, all set to _false_ by default. They are
 
--   createArcRotateCamera: creates a free camera by default and an arc rotate camera when _true_;
--   replace: when _true_ the created camera will replace the existing active one;
--   attachCameraControls: when _true_ attaches control to the canvas.
+- createArcRotateCamera: creates a free camera by default and an arc rotate camera when _true_;
+- replace: when _true_ the created camera will replace the existing active one;
+- attachCameraControls: when _true_ attaches control to the canvas.
 
 This code will create an arc rotate camera, replace any existing camera and attach the camera control to the canvas
 
@@ -105,7 +105,7 @@ scene.cameras.push(helperCamera);
 
 The `createDefaultLight` takes just one boolean parameters, set to _false_ by default:
 
--   replace: when _true_ the created light will replace all the existing ones; when _false_ and there are no existing lights a hemispherical light is created; when _false_ and lights already exist, no change is made to the scene.
+- replace: when _true_ the created light will replace all the existing ones; when _false_ and there are no existing lights a hemispherical light is created; when _false_ and lights already exist, no change is made to the scene.
 
 When this method is used before the creation of any other lights then it is usually sufficient to use
 
@@ -168,7 +168,7 @@ to prevent the creation of the skybox:
 
 ```javascript
 var helper = scene.createDefaultEnvironment({
-    createSkybox: false,
+  createSkybox: false,
 });
 ```
 
@@ -176,7 +176,7 @@ to enable ground reflection:
 
 ```javascript
 var helper = scene.createDefaultEnvironment({
-    enableGroundMirror: true,
+  enableGroundMirror: true,
 });
 ```
 
@@ -184,7 +184,7 @@ when you see z-fighting with the ground, modify the `groundYBias` to a larger nu
 
 ```javascript
 var helper = scene.createDefaultEnvironment({
-    groundYBias: 0.01,
+  groundYBias: 0.01,
 });
 ```
 
@@ -213,7 +213,7 @@ or how about changing the options parameters
 ```javascript
 var helper = scene.createDefaultEnvironment();
 var options = {
-    skyboxTexture: new BABYLON.CubeTexture("/textures/skybox", scene),
+  skyboxTexture: new BABYLON.CubeTexture("/textures/skybox", scene),
 };
 helper.updateOptions(options);
 ```
@@ -255,8 +255,8 @@ Since the `createDefault...` helpers take into account any models in the scene t
 
 ```javascript
 BABYLON.SceneLoader.Append("https://www.babylonjs.com/Assets/DamagedHelmet/glTF/", "DamagedHelmet.gltf", scene, function (meshes) {
-    scene.createDefaultCameraOrLight(true, true, true);
-    scene.createDefaultEnvironment();
+  scene.createDefaultCameraOrLight(true, true, true);
+  scene.createDefaultEnvironment();
 });
 ```
 

--- a/content/features/featuresDeepDive/scene/interactWithScenes.md
+++ b/content/features/featuresDeepDive/scene/interactWithScenes.md
@@ -79,9 +79,9 @@ scene.onPointerObservable.add((pointerInfo) => {
 
 ## Playground Examples
 
-<Playground id="#0XYMA9#107" title="Scene Observables Template" description="Simple scene observables template." image="/img/playgroundsAndNMEs/divingDeeperInteractions1.jpg" isMain={true} category="Scene"/>
-<Playground id="#7CBW04" title="Simple Drag Example" description="Simple example of a drag behavior." image="/img/playgroundsAndNMEs/divingDeeperInteractions2.jpg" isMain={true} category="Scene"/>
-<Playground id="#XZ0TH6" title="Simple Keyboard Input Example" description="Simple example of keyboard input." image="/img/playgroundsAndNMEs/divingDeeperInteractions3.jpg" isMain={true} category="Scene"/>
-<Playground id="#2SA7J8#7" title="Click+Drag to Multi Select" description="Simple example of how to multi-select objects in a scene using rectangular selection." isMain={true} category="Scene"/>
+<Playground id="#0XYMA9#107" title="Scene Observables Template" description="Simple scene observables template." image="/img/playgroundsAndNMEs/divingDeeperInteractions1.jpg" isMain={true} category="Interactions"/>
+<Playground id="#7CBW04" title="Simple Drag Example" description="Simple example of a drag behavior." image="/img/playgroundsAndNMEs/divingDeeperInteractions2.jpg" isMain={true} category="Interactions"/>
+<Playground id="#XZ0TH6" title="Simple Keyboard Input Example" description="Simple example of keyboard input." image="/img/playgroundsAndNMEs/divingDeeperInteractions3.jpg" isMain={true} category="Interactions"/>
+<Playground id="#2SA7J8#7" title="Click+Drag to Multi Select" description="Simple example of how to multi-select objects in a scene using rectangular selection." isMain={true} category="Interactions"/>
 
 Remember to click in scene (to set focus) before using keyboard

--- a/content/features/featuresDeepDive/scene/multiScenes.md
+++ b/content/features/featuresDeepDive/scene/multiScenes.md
@@ -1,6 +1,6 @@
 ---
 title: Using Multiple Scenes
-image: 
+image:
 description: Learn about using multiple scenes at the same time in Babylon.js.
 keywords: diving deeper, scene, multi-scene
 further-reading:
@@ -8,16 +8,16 @@ video-overview:
 video-content:
 ---
 
-
 ## How to Use Multiple Scenes
 
-To use multiple scenes create them with 
+To use multiple scenes create them with
 
 ```javascript
 var scene0 = new BABYLON.Scene(engine);
 var scene1 = new BABYLON.Scene(engine);
-``` 
-then put the relevant camera, lights and meshes inside each scene and call them in the engine run render loop
+```
+
+then put the relevant camera, lights and meshes inside each scene and call them in `runRenderLoop`
 
 ```javascript
 engine.runRenderLoop(function () {
@@ -25,7 +25,23 @@ engine.runRenderLoop(function () {
   scene1.render();
 });
 ```
-When you want the meshes of both scenes to be visible at the same time then set the 'autoClear' of scene1 (the last rendered scene(s)) to false.
+
+However, this simple code has a potential problem. Remeber that each `scene.render` call will try to clear what has been rendered before, and to avoid one scene erasing what another has rendered, you need to set `scene.autoClear = false` on all the scenes rendered on "top" of others:
+
+```javascript
+var scene0 = new BABYLON.Scene(engine);
+var scene1 = new BABYLON.Scene(engine);
+scene1.autoClear = false; 
+```
+
+```javascript
+engine.runRenderLoop(function () {
+  scene0.render();
+  scene1.render(); // Since scene1's autoClear is false, it will not "erase" what scene0 has rendered.
+});
+```
+
+### Multiple scenes on the Playground
 
 However there is a difference between writing multiple scenes within your own projects and trying them out in the playground.
 
@@ -33,20 +49,20 @@ In your own project it is easy enough to set up create scene functions for each 
 
 ```javascript
 var createScene0 = function () {
-    var scene0 = new BABYLON.Scene(engine);
+  var scene0 = new BABYLON.Scene(engine);
 
-    //Add camera, light and meshes for scene0
+  //Add camera, light and meshes for scene0
 
-	return scene0;
-}
+  return scene0;
+};
 
 var createScene1 = function () {
-    var scene1 = new BABYLON.Scene(engine);
+  var scene1 = new BABYLON.Scene(engine);
 
-    //Add camera, light and meshes for scene1
+  //Add camera, light and meshes for scene1
 
-	return scene1;
-}
+  return scene1;
+};
 
 //Any other code
 var scene0 = createScene0();
@@ -58,108 +74,32 @@ engine.runRenderLoop(function () {
 });
 ```
 
-In the playground the create scene function is wrapped by the code running the playground and so the easiest method is just to create a new scene within the function and add a camera, light and meshes to it. Also the playground has its own engine run render loop which needs to be stopped before running your own version, the trick is to use a setTimeout. Putting these together playground code can look like this example
+The playground has its own engine run render loop which needs to be stopped before running your own version:
 
 ```javascript
 var createScene = function () {
-    var scene = new BABYLON.Scene(engine);
+  var scene = new BABYLON.Scene(engine);
 
-    //Add camera, light and meshes for scene
+  //Add camera, light and meshes for scene
 
-    ////////OTHER SCENE////////////////////
-    var scene1 = new BABYLON.Scene(engine);
+  ////////OTHER SCENE////////////////////
+  var scene1 = new BABYLON.Scene(engine);
 
-    //Add camera, light and meshes for scene
+  //Add camera, light and meshes for scene
 
-    ////////CONTROL ENGINE LOOP///////////
-    setTimeout(function() {
-        engine.stopRenderLoop();
+  ////////CONTROL ENGINE LOOP///////////
+  setTimeout(function () {
+    engine.stopRenderLoop();
 
-        engine.runRenderLoop(function () {
-            scene.render();
-            scene1.render();
-        });
-    }, 500);
-
-	return scene;
-}
-```
-
-
-## Switch Scenes
-You might want a user to be able to switch between scenes, remember that the Babylon GUI is a good way to set triggers for this to be possible. 
-
-An example of one way to do this is
-
-```javascript
-var clicks = 0;
-var showScene = 0;
-var advancedTexture;
-   
-
-var createGUI = function(scene, showScene) {             
-    switch (showScene) {
-        case 0:            
-            advancedTexture = BABYLON.GUI.AdvancedDynamicTexture.CreateFullscreenUI("UI", true, scene0);
-        break
-        case 1:            
-            advancedTexture = BABYLON.GUI.AdvancedDynamicTexture.CreateFullscreenUI("UI", true, scene1);
-        break
-    }
-    var button = BABYLON.GUI.Button.CreateSimpleButton("but", "Scene " + ((clicks + 1) % 2));
-    button.width = 0.2;
-    button.height = "40px";
-    button.color = "white";
-    button.background = "green";
-    button.verticalAlignment = BABYLON.GUI.Control.VERTICAL_ALIGNMENT_TOP
-    advancedTexture.addControl(button);
-
-    
-    button.onPointerUpObservable.add(function () {       
-        clicks++;                   
+    engine.runRenderLoop(function () {
+      scene.render();
+      scene1.render();
     });
-}  
+  }, 500);
 
-createGUI(scene, showScene);
-
-engine.runRenderLoop(function () {
-    if(showScene != (clicks % 2)){
-        showScene = clicks % 2;          
-        switch (showScene) {
-            case 0:                    
-                advancedTexture.dispose();
-                createGUI(scene0, showScene);
-                scene0.render();
-            break
-            case 1:
-                advancedTexture.dispose();
-                createGUI(scene1, showScene);
-                scene1.render();
-            break
-        }
-    }
-}); 
+  return scene;
+};
 ```
 
-<Playground id="#MXCRPS#1" title="Switching Scenes" description="Simple example showing how to switch scenes."/>
-
-## Overlay Multiple Scenes
-
-Suppose you want a first person shooter type project with a 3D foreground representing the user and then a background scene representing what the user is tracking. In this case you want the meshes in both the foreground and background visible. To do this you want the foreground meshes drawn over the background, that is you do not want the render canvas cleared when rendering the foreground. In this case set 'autoClear' to false 
-
-```javascript
-
-//other code
-
-var foregroundScene = new BABYLON.Scene(engine);
-foregroundScene.autoClear = false;
-
-//other code
-
-engine.runRenderLoop(function () {
-  backgroundScene.render();
-  foregroundScene.render();
-});
-``` 
-
-<Playground id="#L0IMUD#1" title="Overlaying Scenes" description="Simple example of overlaying scenes."/>
+An example of switching the currently active scene on the Playground is as follows:
+<Playground id="#P3E9YP" title="Switching Scenes" description="Simple example showing how to switch scenes." isMain={true} category="Scene"/>

--- a/content/features/featuresDeepDive/scene/optimize_your_scene.md
+++ b/content/features/featuresDeepDive/scene/optimize_your_scene.md
@@ -244,7 +244,7 @@ If you switch the `performancePriority` to `BABYLON.ScenePerformancePriority.Agg
 
 ** Please note that the `Intermediate` and `Aggressive` modes will not be backward compatible, which means that we will probably add more features in these modes in the future to support performance first**
 
-Here is an example: <Playground id="#6HWS9M" title="Performance Mode Example" description="Simple example of using Performance Mode."/>
+Here is an example: <Playground id="#6HWS9M" title="Performance Mode Example" description="Simple example of using Performance Mode." isMain={true} category="Scene"/>
 
 ## Instrumentation
 Instrumentation is a key tool when you want to optimize a scene. It will help you figure out where are the bottlenecks so you will be able to optimize what needs to be optimized.

--- a/content/features/featuresDeepDive/webXR/WebXRSelectedFeatures.md
+++ b/content/features/featuresDeepDive/webXR/WebXRSelectedFeatures.md
@@ -656,7 +656,7 @@ featureManager.enableFeature(BABYLON.WebXRFeatureName.HAND_TRACKING, "latest", {
 
 Notice that you can't define the mass. that is because the tracked joints will always have mass `0` to prevent them from constantly "falling down" towards the center of gravity.
 
-<Playground id="#X7Y4H8#73" title="Hand tracking with physics" description="A simple example of a hands-enabled physics playground" image="/img/how_to/xr/handTrackingSpheres.jpg"/>
+<Playground id="#X7Y4H8#73" title="Hand tracking with legacy physics" description="A simple example of a hands-enabled legacy physics playground" image="/img/how_to/xr/handTrackingSpheres.jpg"/>
 
 ## Movement Module
 

--- a/content/features/featuresDeepDive/webXR/introToWebXR.md
+++ b/content/features/featuresDeepDive/webXR/introToWebXR.md
@@ -164,7 +164,7 @@ var createScene = async function () {
 };
 ```
 
-<Playground id="#F41V6N" title="Sphere In WebXR Using Babylon.js" description="Simple example of a sphere in WebXR using Babylon.js" isMain={true} category="VR/AR"/>
+<Playground id="#F41V6N" title="Sphere In WebXR Using Babylon.js" description="Simple example of a sphere in WebXR using Babylon.js" isMain={true} category="WebXR"/>
 
 And that's it!
 

--- a/content/features/featuresDeepDive/webXR/webXRDemos.md
+++ b/content/features/featuresDeepDive/webXR/webXRDemos.md
@@ -33,7 +33,7 @@ const xrHelper = await scene.createDefaultXRExperienceAsync({
 });
 ```
 
-<Playground id="#9K3MRA#1" title="Basic Scene With Teleportation" description="Simple example of a basic scene with teleportation enabled." isMain={true} category="VR/AR"/>
+<Playground id="#9K3MRA#1" title="Basic Scene With Teleportation" description="Simple example of a basic scene with teleportation enabled." isMain={true} category="WebXR"/>
 
 ### Adding a color picker to the basic scene
 
@@ -66,12 +66,12 @@ picker.onValueChangedObservable.add(function(value) {
 panel.addControl(picker);
 ```
 
-<Playground id="#9K3MRA#2" title="WebXR Color Picker" description="Simple WebXR color picker example." isMain={true} category="VR/AR"/>
+<Playground id="#9K3MRA#2" title="WebXR Color Picker" description="Simple WebXR color picker example." isMain={true} category="WebXR"/>
 
 ## Other demos
  
-<Playground id="#PPM311#148" title="Goalkeeper Training" description="Goalkeeper Training" isMain={true} category="VR/AR"/>
-<Playground id="#B922X8#19" title="Physics Playground" description="Physics Playground" isMain={true} category="VR/AR"/>
+<Playground id="#PPM311#148" title="Goalkeeper Training" description="Goalkeeper Training" isMain={true} category="WebXR"/>
+<Playground id="#B922X8#19" title="Legacy Physics Playground" description="Physics Playground" isMain={true} category="WebXR"/>
 
 <Playground id="#F41V6N#139" title="A cylinder object is child of a controller" description="A cylinder object is child of a controller"/>  
 


### PR DESCRIPTION
List of changes:
* Remove legacy Physics API examples and replace them with Havok Examples
* Rename some sections:
    * "Scene" -> "Interactions" (as all PGs there were related with clicking, selecting, dragging, etc)
    * "VR/AR" -> "WebXR" (more modern language and the same as the web standard)
* Add new sections such as "Post-processing" (with the Standard Rendering Pipeline, SSAO, SSR, custom PPs) and "WebGPU"
* Add more examples to many sections, such as "Environment", "Shadows" and "Materials"
* Tweak some examples, such as changing GUI Positions and switching between Scenes