### PR TITLE
Docs Fix: static call GetAvailableFeatures()

### DIFF
--- a/content/features/featuresDeepDive/webXR/webXRFeaturesManager.md
+++ b/content/features/featuresDeepDive/webXR/webXRFeaturesManager.md
@@ -33,7 +33,7 @@ Note that even before creating the features manager you could call its static me
 To check what feature is available, use the features manager's static `GetAvailableFeatures` function, which will return an array of strings corresponding to specific features:
 
 ``` javascript
-const availableFeatures = featuresManager.GetAvailableFeatures();
+const availableFeatures = WebXRFeaturesManager.GetAvailableFeatures(); // in plain JS, use BABYLON.WebXRFeaturesManager
 
 // availableFeatures = ["xr-hit-test", "xr-pointer-selection", ...]
 ```
@@ -41,7 +41,7 @@ const availableFeatures = featuresManager.GetAvailableFeatures();
 To find if a specific feature is available use this code:
 
 ``` javascript
-const availableFeatures = featuresManager.GetAvailableFeatures();
+const availableFeatures = WebXRFeaturesManager.GetAvailableFeatures();
 // using indexOf, but you can use any other method - includes, find, findIndex, in, etc'
 if (availableFeatures.indexOf(WebXRFeatureName.POINTER_SELECTION) !== -1) {
     // Pointer selection is available


### PR DESCRIPTION
Hi! I just quickly fixed this documentation in one minute. I think I fixed an issue: The documentation said `GetAvailableFeatures() ` was an instance method, but it's a static method, so we need to call it from the class. Sorry if this was already fixed, I admit I didn't check that.