### PR TITLE
Change namespace to Debug.AxesViewer()

### DIFF
--- a/content/toolsAndResources/utilities/World_Axes.md
+++ b/content/toolsAndResources/utilities/World_Axes.md
@@ -14,7 +14,7 @@ video-content:
 It is often useful to be able to quickly display world and local axes to see position and rotation for example. For world axes use
 
 ```javascript
-const axes = new BABYLON.AxesViewer(scene, length_of_axes)
+const axes = new BABYLON.Debug.AxesViewer(scene, length_of_axes)
 ```
 
 To make any of the x, y and z axes local to a mesh (or other appropriate object) use


### PR DESCRIPTION
See: https://forum.babylonjs.com/t/axesviewer-does-not-exist-in-typescript-playground/42911/4