### PR TITLE
add missing option in highlightLayer docs

### DIFF
--- a/content/features/featuresDeepDive/mesh/highlightLayer.md
+++ b/content/features/featuresDeepDive/mesh/highlightLayer.md
@@ -179,6 +179,7 @@ The available members of the option object are:
 - blurHorizontalSize?: number - How big in texel of the blur texture is the horizontal blur.
 - alphaBlendingMode?: number - Alpha blending mode used to apply the blur. Default is combine.
 - camera?: Camera - The camera attached to the layer (only this camera can see the highlights).
+- isStroke?: boolean - Should we display highlight as a solid stroke?
 
 You can pass them during the construction of the highlight layer:
 


### PR DESCRIPTION
Hello community, 

I've always assumed that highlight layer cannot be displayed as a stroke, turned out I was missing that since it was not written in the docs. 

