### PR TITLE
support NGE in the Docs

### DIFF
--- a/components/markdownComponents/example.component.tsx
+++ b/components/markdownComponents/example.component.tsx
@@ -114,3 +114,7 @@ export const PlaygroundMarkdownComponent: FunctionComponent<IExampleLink> = (pro
 export const NMEMarkdownComponent: FunctionComponent<IExampleLink> = (props) => {
     return <ExampleMarkdownComponent {...props} type="nme"></ExampleMarkdownComponent>;
 };
+
+export const NGEMarkdownComponent: FunctionComponent<IExampleLink> = (props) => {
+    return <ExampleMarkdownComponent {...props} type="nge"></ExampleMarkdownComponent>;
+};

--- a/components/markdownComponents/markdownComponents.tsx
+++ b/components/markdownComponents/markdownComponents.tsx
@@ -1,5 +1,5 @@
 import { Table, Thead, Tbody, Tr, Th, Td } from "react-super-responsive-table";
-import { PlaygroundMarkdownComponent, NMEMarkdownComponent } from "./example.component";
+import { PlaygroundMarkdownComponent, NMEMarkdownComponent, NGEMarkdownComponent } from "./example.component";
 import { ImageMarkdownComponent } from "./image.component";
 import { YoutubeComponent, MediaFileComponent } from "./media.component";
 import { SyntaxHighlighting } from "./syntaxHighlight.component";
@@ -11,6 +11,8 @@ export const markdownComponents = {
     Playground: PlaygroundMarkdownComponent,
     nme: NMEMarkdownComponent,
     NME: NMEMarkdownComponent,
+    nge: NGEMarkdownComponent,
+    NGE: NGEMarkdownComponent,
     pre: (props) => <div {...props} />,
     code: SyntaxHighlighting,
     table: Table,

--- a/lib/content.interfaces.ts
+++ b/lib/content.interfaces.ts
@@ -12,7 +12,7 @@ export interface IMenuItem {
 }
 
 export interface IExampleLink {
-    type?: "pg" | "nme";
+    type?: "pg" | "nme" | "nge";
     id?: string; // both are accepted
     playgroundId?: string; // both are accepted. This one has priority
     title?: string;

--- a/lib/frontendUtils/frontendTools.ts
+++ b/lib/frontendUtils/frontendTools.ts
@@ -5,7 +5,15 @@ export const getExampleLink = (example: Partial<IExampleLink>, full: boolean = t
     const id = idToUse ? (idToUse[0] === "#" ? idToUse : `#${idToUse}`) : "";
     // webgpu parameter. Stay safe and validate
     const params = (example.engine && example.engine==='webgpu') ? `?${example.engine}` : '';
-    return (example.type === "nme" ? "https://nme.babylonjs.com/" : "https://playground.babylonjs.com/" + (full ? "full.html" : "")) + params + id;
+    switch (example.type) {
+        case "nge":
+            return `https://nge.babylonjs.com/${id}`;
+        case "nme":
+            return `https://nme.babylonjs.com/${id}`;
+        case "pg":
+        default:
+            return `https://playground.babylonjs.com/${full ? "full.html" : ""}${params}${id}`;
+    }
 };
 
 export const getExampleImageUrl = (example: Partial<IExampleLink>) => {


### PR DESCRIPTION
Just like NME, it is now possible to add NGE examples in a playground page using the following syntax:

```html
<NGE id="#MSH13Z" title="The default NGE" description="The default NGE saved as a snippet. Meaningless, but powerful!"/>
````