### PR TITLE
Updated the WGSL specifications used in Image Blur

### DIFF
--- a/content/features/featuresDeepDive/materials/shaders/computeShader.md
+++ b/content/features/featuresDeepDive/materials/shaders/computeShader.md
@@ -103,7 +103,7 @@ This PG creates 3 compute shaders:
 
 ### Image Blur
 
-<Playground id="#3URR7V#185" engine="webgpu" title="Blur compute shader" description="This example shows how to blur an image using a WebGPU compute shader" image="/img/extensions/webgpu/blur.png"/>
+<Playground id="#3URR7V#273" engine="webgpu" title="Blur compute shader" description="This example shows how to blur an image using a WebGPU compute shader" image="/img/extensions/webgpu/blur.png"/>
 
 This is a direct port of the WebGPU sample [imageBlur](http://austin-eng.com/webgpu-samples/samples/imageBlur).
 


### PR DESCRIPTION
I noticed that the WGSL specifications used in the sample were outdated, so I updated them.

See below for details.
https://forum.babylonjs.com/t/the-specifications-of-the-compute-shader-used-in-image-blur-are-outdated/44594