### PR TITLE
Update alerts to new alert markdown

### DIFF
--- a/components/markdownComponents/syntaxHighlight.component.tsx
+++ b/components/markdownComponents/syntaxHighlight.component.tsx
@@ -31,7 +31,7 @@ export const SyntaxHighlighting: FunctionComponent<{ className: string; children
 type AlertMarkdownComponentProps = {  severity: 'error' | 'warning' | 'info' | 'success', description: string, title?: string }
 export const AlertMarkdownComponent: FunctionComponent<AlertMarkdownComponentProps> = (props: AlertMarkdownComponentProps) => {
     return (
-        <Alert severity={props.severity}>
+        <Alert severity={props.severity} style={{marginBottom: "1.3rem"}}>
             {props.title || <AlertTitle>{ props.title }</AlertTitle>}
             <p style={{margin: "0"}}>{props.description}</p>
         </Alert>

--- a/content/features/featuresDeepDive/gui/gui.md
+++ b/content/features/featuresDeepDive/gui/gui.md
@@ -23,7 +23,7 @@ It is build on top of the DynamicTexture.
 
 The latest version can be found on our CDN at https://cdn.babylonjs.com/gui/babylon.gui.js.
 
-> ⚠️ WARNING: The CDN should not be used in production environments. The purpose of our CDN is to serve Babylon packages to users learning how to use the platform or running small experiments. Once you've built an application and are ready to share it with the world at large, you should serve all packages from your own CDN.
+<Alert severity="warning" title="Warning" description="The CDN should not be used in production environments. The purpose of our CDN is to serve Babylon packages to users learning how to use the platform or running small experiments. Once you've built an application and are ready to share it with the world at large, you should serve all packages from your own CDN."/>
 
 And the source code is available on the main Babylon.js repo: https://github.com/BabylonJS/Babylon.js/tree/master/packages/dev/gui.
 

--- a/content/features/featuresDeepDive/gui/gui3D.md
+++ b/content/features/featuresDeepDive/gui/gui3D.md
@@ -22,7 +22,7 @@ The Babylon.js 3D GUI library is an extension you can use to generate 3D interac
 
 The latest version can be found on our CDN at https://cdn.babylonjs.com/gui/babylon.gui.js.
 
-> ⚠️ WARNING: The CDN should not be used in production environments. The purpose of our CDN is to serve Babylon packages to users learning how to use the platform or running small experiments. Once you've built an application and are ready to share it with the world at large, you should serve all packages from your own CDN.
+<Alert severity="warning" title="Warning" description="The CDN should not be used in production environments. The purpose of our CDN is to serve Babylon packages to users learning how to use the platform or running small experiments. Once you've built an application and are ready to share it with the world at large, you should serve all packages from your own CDN."/>
 
 And the source code is available on the main Babylon.js repo: https://github.com/BabylonJS/Babylon.js/tree/master/packages/dev/gui.
 

--- a/content/features/featuresDeepDive/importers/loadingFileTypes.md
+++ b/content/features/featuresDeepDive/importers/loadingFileTypes.md
@@ -38,7 +38,7 @@ Currently plugins can be found for:
 
 To quickly add support for all loaders the following script can be added to your page:
 
-> ⚠️ WARNING: The CDN should not be used in production environments. The purpose of our CDN is to serve Babylon packages to users learning how to use the platform or running small experiments. Once you've built an application and are ready to share it with the world at large, you should serve all packages from your own CDN.
+<Alert severity="warning" title="Warning" description="The CDN should not be used in production environments. The purpose of our CDN is to serve Babylon packages to users learning how to use the platform or running small experiments. Once you've built an application and are ready to share it with the world at large, you should serve all packages from your own CDN."/>
 
 #### Production links
 

--- a/content/features/featuresDeepDive/importers/oBJ.md
+++ b/content/features/featuresDeepDive/importers/oBJ.md
@@ -19,7 +19,7 @@ To use it, you just have to reference the loader file:
 
 You can find it [here](https://cdn.babylonjs.com/loaders/babylon.objFileLoader.js)
 
-> ⚠️ WARNING: The CDN should not be used in production environments. The purpose of our CDN is to serve Babylon packages to users learning how to use the platform or running small experiments. Once you've built an application and are ready to share it with the world at large, you should serve all packages from your own CDN.
+<Alert severity="warning" title="Warning" description="The CDN should not be used in production environments. The purpose of our CDN is to serve Babylon packages to users learning how to use the platform or running small experiments. Once you've built an application and are ready to share it with the world at large, you should serve all packages from your own CDN."/>
 
 If you are using UMD imports via NPM, you need to reference with side-effects:
 

--- a/content/features/featuresDeepDive/importers/stl.md
+++ b/content/features/featuresDeepDive/importers/stl.md
@@ -12,7 +12,7 @@ video-content:
 
 You can find the STL loader [here](https://cdn.babylonjs.com/loaders/babylon.stlFileLoader.js)
 
-> ⚠️ WARNING: The CDN should not be used in production environments. The purpose of our CDN is to serve Babylon packages to users learning how to use the platform or running small experiments. Once you've built an application and are ready to share it with the world at large, you should serve all packages from your own CDN.
+<Alert severity="warning" title="Warning" description="The CDN should not be used in production environments. The purpose of our CDN is to serve Babylon packages to users learning how to use the platform or running small experiments. Once you've built an application and are ready to share it with the world at large, you should serve all packages from your own CDN."/>
 
 To use it you just have to reference it after Babylon.js:
 

--- a/content/features/featuresDeepDive/materials/using/proceduralTextures.md
+++ b/content/features/featuresDeepDive/materials/using/proceduralTextures.md
@@ -100,7 +100,7 @@ You can use them in your project:
 - Using npm with `npm install --save @babylonjs/procedural-textures`
 - With a direct reference to: https://cdn.babylonjs.com/proceduralTexturesLibrary/babylonjs.proceduralTextures.min.js
 
-> ⚠️ WARNING: The CDN should not be used in production environments. The purpose of our CDN is to serve Babylon packages to users learning how to use the platform or running small experiments. Once you've built an application and are ready to share it with the world at large, you should serve all packages from your own CDN.
+<Alert severity="warning" title="Warning" description="The CDN should not be used in production environments. The purpose of our CDN is to serve Babylon packages to users learning how to use the platform or running small experiments. Once you've built an application and are ready to share it with the world at large, you should serve all packages from your own CDN."/>
 
 All standard procedural textures can be used in the same ways, but they each have specific (special) properties:
 

--- a/content/features/featuresDeepDive/physics/v1/usingPhysicsEngine.md
+++ b/content/features/featuresDeepDive/physics/v1/usingPhysicsEngine.md
@@ -50,7 +50,7 @@ Once you picked an engine, do not forget to add a reference to the engine code:
 1. Oimo: https://cdn.babylonjs.com/Oimo.js
 1. Ammo: https://cdn.babylonjs.com/ammo.js or directly from https://github.com/kripken/ammo.js/blob/master/builds/ammo.js
 
-> ⚠️ WARNING: The CDN should not be used in production environments. The purpose of our CDN is to serve Babylon packages to users learning how to use the platform or running small experiments. Once you've built an application and are ready to share it with the world at large, you should serve all packages from your own CDN.
+<Alert severity="warning" title="Warning" description="The CDN should not be used in production environments. The purpose of our CDN is to serve Babylon packages to users learning how to use the platform or running small experiments. Once you've built an application and are ready to share it with the world at large, you should serve all packages from your own CDN."/>
 
 ## Basic usage
 

--- a/content/features/featuresDeepDive/physics/v2/usingHavok.md
+++ b/content/features/featuresDeepDive/physics/v2/usingHavok.md
@@ -23,7 +23,7 @@ _To read about the babylon plugin directly, [skip to the next section](#the-baby
 Havok is now available for the web, using a WebAssembly version of the engine. It is available, free to use, under the MIT license.
 The engine is available on both [the npm package](https://www.npmjs.com/package/@babylonjs/havok) `@babylonjs/havok` and on our CDN under the URL `https://cdn.babylonjs.com/havok/HavokPhysics_umd.js` or `https://cdn.babylonjs.com/havok/HavokPhysics_es.js` when using the `module` script.
 
-> ⚠️ WARNING: The CDN should not be used in production environments. The purpose of our CDN is to serve Babylon packages to users learning how to use the platform or running small experiments. Once you've built an application and are ready to share it with the world at large, you should serve all packages from your own CDN.
+<Alert severity="warning" title="Warning" description="The CDN should not be used in production environments. The purpose of our CDN is to serve Babylon packages to users learning how to use the platform or running small experiments. Once you've built an application and are ready to share it with the world at large, you should serve all packages from your own CDN."/>
 
 The NPM package contains the same two flavors as the CDN: an es-modules version and a UMD version for common.js and AMD projects. Your bundler will select the right file for you.
 
@@ -63,7 +63,7 @@ HavokPhysics().then((havok) => {
 The main different between the CDN and the npm package is the way the HavokPhysics object becomes available in your browser.
 Whereas using npm you need to import/require the package, using the CDN you get the object directly from the global scope.
 
-> ⚠️ WARNING: The CDN should not be used in production environments. The purpose of our CDN is to serve Babylon packages to users learning how to use the platform or running small experiments. Once you've built an application and are ready to share it with the world at large, you should serve all packages from your own CDN.
+<Alert severity="warning" title="Warning" description="The CDN should not be used in production environments. The purpose of our CDN is to serve Babylon packages to users learning how to use the platform or running small experiments. Once you've built an application and are ready to share it with the world at large, you should serve all packages from your own CDN."/>
 
 ```html
 <script src="https://cdn.babylonjs.com/havok/HavokPhysics_umd.js"></script>

--- a/content/features/introductionToFeatures/chap1/first_app.md
+++ b/content/features/introductionToFeatures/chap1/first_app.md
@@ -31,7 +31,7 @@ var createScene = function () {
 
 By following this format in you own project you can quickly drop it into your own HTML page using the following as a template.
 
-> ⚠️ WARNING: The CDN should not be used in production environments. The purpose of our CDN is to serve Babylon packages to users learning how to use the platform or running small experiments. Once you've built an application and are ready to share it with the world at large, you should serve all packages from your own CDN.
+<Alert severity="warning" title="Warning" description="The CDN should not be used in production environments. The purpose of our CDN is to serve Babylon packages to users learning how to use the platform or running small experiments. Once you've built an application and are ready to share it with the world at large, you should serve all packages from your own CDN."/>
 
 ```html
 <!DOCTYPE html>

--- a/content/features/introductionToFeatures/chap1/first_viewer.md
+++ b/content/features/introductionToFeatures/chap1/first_viewer.md
@@ -19,7 +19,7 @@ In order to use the Viewer you need to add its code to your HTML page in a *&lt;
 <script src="https://cdn.babylonjs.com/viewer/babylon.viewer.js"></script>
 ```
 
-> ⚠️ WARNING: The CDN should not be used in production environments. The purpose of our CDN is to serve Babylon packages to users learning how to use the platform or running small experiments. Once you've built an application and are ready to share it with the world at large, you should serve all packages from your own CDN.
+<Alert severity="warning" title="Warning" description="The CDN should not be used in production environments. The purpose of our CDN is to serve Babylon packages to users learning how to use the platform or running small experiments. Once you've built an application and are ready to share it with the world at large, you should serve all packages from your own CDN."/>
 
 Once this is added you place the *&lt;babylon&gt;* element in an appropriate container and points its *model* attribute to the file source.
 

--- a/content/features/introductionToFeatures/chap7/light_gui.md
+++ b/content/features/introductionToFeatures/chap7/light_gui.md
@@ -13,7 +13,7 @@ video-content:
 ## Day to Night
 One useful way to add a graphical user interface to a scene is the Babylon.js GUI. When working in virtual reality this GUI is necessary as it is designed to be within and part of the Babylon.js scene canvas rather than the HTML document. This GUI is pre-loaded into the playground but is an additional script to load in your own projects with
 
-> ⚠️ WARNING: The CDN should not be used in production environments. The purpose of our CDN is to serve Babylon packages to users learning how to use the platform or running small experiments. Once you've built an application and are ready to share it with the world at large, you should serve all packages from your own CDN.
+<Alert severity="warning" title="Warning" description="The CDN should not be used in production environments. The purpose of our CDN is to serve Babylon packages to users learning how to use the platform or running small experiments. Once you've built an application and are ready to share it with the world at large, you should serve all packages from your own CDN."/>
 
 ```html
 <script>https://cdn.babylonjs.com/gui/babylon.gui.min.js</script>

--- a/content/setup/frameworkPackages/CDN.md
+++ b/content/setup/frameworkPackages/CDN.md
@@ -8,7 +8,7 @@ video-overview:
 video-content:
 ---
 
-> ⚠️ WARNING: The CDN should not be used in production environments. The purpose of our CDN is to serve Babylon packages to users learning how to use the platform or running small experiments. Once you've built an application and are ready to share it with the world at large, you should serve all packages from your own CDN.
+<Alert severity="warning" title="Warning" description="The CDN should not be used in production environments. The purpose of our CDN is to serve Babylon packages to users learning how to use the platform or running small experiments. Once you've built an application and are ready to share it with the world at large, you should serve all packages from your own CDN."/>
 
 ## Direct Usage
 

--- a/content/setup/frameworkPackages/frameworkVers.md
+++ b/content/setup/frameworkPackages/frameworkVers.md
@@ -20,7 +20,7 @@ Both versions are considered to be stable and can be used in production. In cert
 
 Both versions have their own CDN endpoint. The preview version is available on [preview.babylonjs.com](https://preview.babylonjs.com) and the stable version is available on [cdn.babylonjs.com](https://cdn.babylonjs.com).
 
-> ⚠️ WARNING: The CDN should not be used in production environments. The purpose of our CDN is to serve Babylon packages to users learning how to use the platform or running small experiments. Once you've built an application and are ready to share it with the world at large, you should serve all packages from your own CDN.
+<Alert severity="warning" title="Warning" description="The CDN should not be used in production environments. The purpose of our CDN is to serve Babylon packages to users learning how to use the platform or running small experiments. Once you've built an application and are ready to share it with the world at large, you should serve all packages from your own CDN."/>
 
 We keep the same version for all of our public repositories. Every time we release a new version, all of our public framework packages (which can be found on npmjs.com: [https://www.npmjs.com/~babylonjs](https://www.npmjs.com/~babylonjs)) will receive a new version update as well, even when they sometimes don't change. As a rule of thumb stick with the same version for all of your dependencies. This is especially important when it comes to the major version - when using babylon's core 5.X, make sure to use all other dependencies in version 5.X.
 
@@ -53,7 +53,7 @@ When developing please make sure to pick the one that fits your architecture. We
 
 ## CDN Current Versions
 
-> ⚠️ WARNING: The CDN should not be used in production environments. The purpose of our CDN is to serve Babylon packages to users learning how to use the platform or running small experiments. Once you've built an application and are ready to share it with the world at large, you should serve all packages from your own CDN.
+<Alert severity="warning" title="Warning" description="The CDN should not be used in production environments. The purpose of our CDN is to serve Babylon packages to users learning how to use the platform or running small experiments. Once you've built an application and are ready to share it with the world at large, you should serve all packages from your own CDN."/>
 
 ### Direct Usage of Packages
 
@@ -90,7 +90,7 @@ These packages can be imported directly from the CDN, as needed, using
 
 ### View Packages
 
-> ⚠️ WARNING: The CDN should not be used in production environments. Please use self-hosting for production.
+<Alert severity="warning" title="Warning" description="The CDN should not be used in production environments. The purpose of our CDN is to serve Babylon packages to users learning how to use the platform or running small experiments. Once you've built an application and are ready to share it with the world at large, you should serve all packages from your own CDN."/>
 
 **Babylon.js Core**  
 Minimum Version - [https://cdn.babylonjs.com/babylon.js](https://cdn.babylonjs.com/babylon.js)  

--- a/content/setup/starterHTML.md
+++ b/content/setup/starterHTML.md
@@ -11,7 +11,7 @@ video-content:
 
 ## Minimal HTML Template
 
-> ⚠️ WARNING: The CDN should not be used in production environments. The purpose of our CDN is to serve Babylon packages to users learning how to use the platform or running small experiments. Once you've built an application and are ready to share it with the world at large, you should serve all packages from your own CDN.
+<Alert severity="warning" title="Warning" description="The CDN should not be used in production environments. The purpose of our CDN is to serve Babylon packages to users learning how to use the platform or running small experiments. Once you've built an application and are ready to share it with the world at large, you should serve all packages from your own CDN."/>
 
 ```html
 <!DOCTYPE html>

--- a/content/setup/templates/basicTemplates/basicHTML.md
+++ b/content/setup/templates/basicTemplates/basicHTML.md
@@ -8,7 +8,7 @@ video-overview:
 video-content:
 ---
 
-> ⚠️ WARNING: The CDN should not be used in production environments. The purpose of our CDN is to serve Babylon packages to users learning how to use the platform or running small experiments. Once you've built an application and are ready to share it with the world at large, you should serve all packages from your own CDN.
+<Alert severity="warning" title="Warning" description="The CDN should not be used in production environments. The purpose of our CDN is to serve Babylon packages to users learning how to use the platform or running small experiments. Once you've built an application and are ready to share it with the world at large, you should serve all packages from your own CDN."/>
 
 ```html
 <!DOCTYPE html>

--- a/content/toolsAndResources/assetLibraries/materialsLibrary/cellShadingMat.md
+++ b/content/toolsAndResources/assetLibraries/materialsLibrary/cellShadingMat.md
@@ -14,7 +14,7 @@ video-content:
 
 Cell material can be found here: [https://cdn.babylonjs.com/materialsLibrary/babylon.cellMaterial.js](https://cdn.babylonjs.com/materialsLibrary/babylon.cellMaterial.js)
 
-> ⚠️ WARNING: The CDN should not be used in production environments. The purpose of our CDN is to serve Babylon packages to users learning how to use the platform or running small experiments. Once you've built an application and are ready to share it with the world at large, you should serve all packages from your own CDN.
+<Alert severity="warning" title="Warning" description="The CDN should not be used in production environments. The purpose of our CDN is to serve Babylon packages to users learning how to use the platform or running small experiments. Once you've built an application and are ready to share it with the world at large, you should serve all packages from your own CDN."/>
 
 A demo can be found here: PG: <Playground id="#36VUUE" title="Cell Material" description="Example of cell material"/>
 

--- a/content/toolsAndResources/assetLibraries/materialsLibrary/fireMat.md
+++ b/content/toolsAndResources/assetLibraries/materialsLibrary/fireMat.md
@@ -14,7 +14,7 @@ video-content:
 
 Fire material can be found here: [https://cdn.babylonjs.com/materialsLibrary/babylon.fireMaterial.js](https://cdn.babylonjs.com/materialsLibrary/babylon.fireMaterial.js)
 
-> ⚠️ WARNING: The CDN should not be used in production environments. The purpose of our CDN is to serve Babylon packages to users learning how to use the platform or running small experiments. Once you've built an application and are ready to share it with the world at large, you should serve all packages from your own CDN.
+<Alert severity="warning" title="Warning" description="The CDN should not be used in production environments. The purpose of our CDN is to serve Babylon packages to users learning how to use the platform or running small experiments. Once you've built an application and are ready to share it with the world at large, you should serve all packages from your own CDN."/>
 
 A demo can be found here: PG: <Playground id="#NES8QN" title="Fire Material" description="Example of fire material"/>
 

--- a/content/toolsAndResources/assetLibraries/materialsLibrary/furMat.md
+++ b/content/toolsAndResources/assetLibraries/materialsLibrary/furMat.md
@@ -12,7 +12,7 @@ video-content:
 
 Fur material can be found here: [https://cdn.babylonjs.com/materialsLibrary/babylon.furMaterial.js](https://cdn.babylonjs.com/materialsLibrary/babylon.furMaterial.js)
 
-> ⚠️ WARNING: The CDN should not be used in production environments. The purpose of our CDN is to serve Babylon packages to users learning how to use the platform or running small experiments. Once you've built an application and are ready to share it with the world at large, you should serve all packages from your own CDN.
+<Alert severity="warning" title="Warning" description="The CDN should not be used in production environments. The purpose of our CDN is to serve Babylon packages to users learning how to use the platform or running small experiments. Once you've built an application and are ready to share it with the world at large, you should serve all packages from your own CDN."/>
 
 ## Using the High Level mode
 

--- a/content/toolsAndResources/assetLibraries/materialsLibrary/gradientMat.md
+++ b/content/toolsAndResources/assetLibraries/materialsLibrary/gradientMat.md
@@ -15,7 +15,7 @@ You can get the gradient material:
 * Using npm with npm install --save babylonjs babylonjs-materials
 * With a direct reference to: https://cdn.babylonjs.com/materialsLibrary/babylonjs.materials.min.js
 
-> ⚠️ WARNING: The CDN should not be used in production environments. The purpose of our CDN is to serve Babylon packages to users learning how to use the platform or running small experiments. Once you've built an application and are ready to share it with the world at large, you should serve all packages from your own CDN.
+<Alert severity="warning" title="Warning" description="The CDN should not be used in production environments. The purpose of our CDN is to serve Babylon packages to users learning how to use the platform or running small experiments. Once you've built an application and are ready to share it with the world at large, you should serve all packages from your own CDN."/>
 
 ## Using the gradient material
 

--- a/content/toolsAndResources/assetLibraries/materialsLibrary/gridMat.md
+++ b/content/toolsAndResources/assetLibraries/materialsLibrary/gridMat.md
@@ -20,7 +20,7 @@ A full playground example can be found here: PG: <Playground id="#1UFGZH#12" tit
 
 As the grid material is a babylonJS extension, it is not included in the main _babylon.js_ file. In order to use the material, please download and reference the extension from the cdn using [babylon.gridMaterial.js](https://cdn.babylonjs.com/materialsLibrary/babylon.gridMaterial.js) or its minified version [babylon.gridMaterial.min.js](https://cdn.babylonjs.com/materialsLibrary/babylon.gridMaterial.min.js).
 
-> ⚠️ WARNING: The CDN should not be used in production environments. The purpose of our CDN is to serve Babylon packages to users learning how to use the platform or running small experiments. Once you've built an application and are ready to share it with the world at large, you should serve all packages from your own CDN.
+<Alert severity="warning" title="Warning" description="The CDN should not be used in production environments. The purpose of our CDN is to serve Babylon packages to users learning how to use the platform or running small experiments. Once you've built an application and are ready to share it with the world at large, you should serve all packages from your own CDN."/>
 
 The default grid behaviour does not require any setup and displays a black and white grid on your meshes:
 

--- a/content/toolsAndResources/assetLibraries/materialsLibrary/lavaMat.md
+++ b/content/toolsAndResources/assetLibraries/materialsLibrary/lavaMat.md
@@ -14,7 +14,7 @@ PG: <Playground id="#1BLVWO#25" title="Lava Material" description="An example of
 
 Lava material can be found here: [https://cdn.babylonjs.com/materialsLibrary/babylon.lavaMaterial.js](https://cdn.babylonjs.com/materialsLibrary/babylon.lavaMaterial.js)
 
-> ⚠️ WARNING: The CDN should not be used in production environments. The purpose of our CDN is to serve Babylon packages to users learning how to use the platform or running small experiments. Once you've built an application and are ready to share it with the world at large, you should serve all packages from your own CDN.
+<Alert severity="warning" title="Warning" description="The CDN should not be used in production environments. The purpose of our CDN is to serve Babylon packages to users learning how to use the platform or running small experiments. Once you've built an application and are ready to share it with the world at large, you should serve all packages from your own CDN."/>
 
 ## Using the lava material
 

--- a/content/toolsAndResources/assetLibraries/materialsLibrary/shadowOnlyMat.md
+++ b/content/toolsAndResources/assetLibraries/materialsLibrary/shadowOnlyMat.md
@@ -16,7 +16,7 @@ The goal of the ShadowOnlyMaterial is to display only shadows casted by a light 
 
 ShadowOnly material can be found here: [https://cdn.babylonjs.com/materialsLibrary/babylon.shadowOnlyMaterial.js](https://cdn.babylonjs.com/materialsLibrary/babylon.shadowOnlyMaterial.js)
 
-> ⚠️ WARNING: The CDN should not be used in production environments. The purpose of our CDN is to serve Babylon packages to users learning how to use the platform or running small experiments. Once you've built an application and are ready to share it with the world at large, you should serve all packages from your own CDN.
+<Alert severity="warning" title="Warning" description="The CDN should not be used in production environments. The purpose of our CDN is to serve Babylon packages to users learning how to use the platform or running small experiments. Once you've built an application and are ready to share it with the world at large, you should serve all packages from your own CDN."/>
 
 A demo can be found here: PG: <Playground id="#1KF7V1" title="Shadow Only Material" description="Example of shadow only material"/>
 

--- a/content/toolsAndResources/assetLibraries/materialsLibrary/waterMat.md
+++ b/content/toolsAndResources/assetLibraries/materialsLibrary/waterMat.md
@@ -14,7 +14,7 @@ video-content:
 
 Water material can be found here: [https://cdn.babylonjs.com/materialsLibrary/babylon.waterMaterial.js](https://cdn.babylonjs.com/materialsLibrary/babylon.waterMaterial.js)
 
-> ⚠️ WARNING: The CDN should not be used in production environments. The purpose of our CDN is to serve Babylon packages to users learning how to use the platform or running small experiments. Once you've built an application and are ready to share it with the world at large, you should serve all packages from your own CDN.
+<Alert severity="warning" title="Warning" description="The CDN should not be used in production environments. The purpose of our CDN is to serve Babylon packages to users learning how to use the platform or running small experiments. Once you've built an application and are ready to share it with the world at large, you should serve all packages from your own CDN."/>
 
 A demo can be found here: PG: <Playground id="#1SLLOJ#20" title="Water Material" description="Example of water material"/>
 

--- a/content/toolsAndResources/assetLibraries/postProcessLibrary/asciiArtPP.md
+++ b/content/toolsAndResources/assetLibraries/postProcessLibrary/asciiArtPP.md
@@ -20,7 +20,7 @@ Ascii Art Post Process Scripts can be found here:
 - Normal: https://cdn.babylonjs.com/postProcessesLibrary/babylon.asciiArtPostProcess.js
 - Minified: https://cdn.babylonjs.com/postProcessesLibrary/babylon.asciiArtPostProcess.min.js
 
-> ⚠️ WARNING: The CDN should not be used in production environments. The purpose of our CDN is to serve Babylon packages to users learning how to use the platform or running small experiments. Once you've built an application and are ready to share it with the world at large, you should serve all packages from your own CDN.
+<Alert severity="warning" title="Warning" description="The CDN should not be used in production environments. The purpose of our CDN is to serve Babylon packages to users learning how to use the platform or running small experiments. Once you've built an application and are ready to share it with the world at large, you should serve all packages from your own CDN."/>
 
 Please, first reference this script in your page:
 

--- a/content/toolsAndResources/assetLibraries/postProcessLibrary/digitalRainPP.md
+++ b/content/toolsAndResources/assetLibraries/postProcessLibrary/digitalRainPP.md
@@ -21,7 +21,7 @@ Digital Rain Post Process Scripts can be found here:
 - Normal: https://cdn.babylonjs.com/postProcessesLibrary/babylon.digitalRainPostProcess.js
 - Minified: https://cdn.babylonjs.com/postProcessesLibrary/babylon.digitalRainPostProcess.min.js
 
-> ⚠️ WARNING: The CDN should not be used in production environments. The purpose of our CDN is to serve Babylon packages to users learning how to use the platform or running small experiments. Once you've built an application and are ready to share it with the world at large, you should serve all packages from your own CDN.
+<Alert severity="warning" title="Warning" description="The CDN should not be used in production environments. The purpose of our CDN is to serve Babylon packages to users learning how to use the platform or running small experiments. Once you've built an application and are ready to share it with the world at large, you should serve all packages from your own CDN."/>
 
 Please, first reference this script in your page:
 

--- a/content/toolsAndResources/assetLibraries/proceduralTexturesLibrary/brick.md
+++ b/content/toolsAndResources/assetLibraries/proceduralTexturesLibrary/brick.md
@@ -18,7 +18,7 @@ Brick procedural texture can be found here:
 - Normal: [Normal](https://cdn.babylonjs.com/proceduralTexturesLibrary/babylon.brickProceduralTexture.js)
 - Minified : [Minified](https://cdn.babylonjs.com/proceduralTexturesLibrary/babylon.brickProceduralTexture.min.js)
 
-> ⚠️ WARNING: The CDN should not be used in production environments. The purpose of our CDN is to serve Babylon packages to users learning how to use the platform or running small experiments. Once you've built an application and are ready to share it with the world at large, you should serve all packages from your own CDN.
+<Alert severity="warning" title="Warning" description="The CDN should not be used in production environments. The purpose of our CDN is to serve Babylon packages to users learning how to use the platform or running small experiments. Once you've built an application and are ready to share it with the world at large, you should serve all packages from your own CDN."/>
 
 A demo can be found here: <Playground id="#1CL0BO#18" title="Brick Procedural Texture" description="Brick Procedural Texture"/>
 

--- a/content/toolsAndResources/assetLibraries/proceduralTexturesLibrary/cloud.md
+++ b/content/toolsAndResources/assetLibraries/proceduralTexturesLibrary/cloud.md
@@ -18,7 +18,7 @@ Cloud procedural texture can be found here:
 - Normal: [Normal](https://cdn.babylonjs.com/proceduralTexturesLibrary/babylon.cloudProceduralTexture.js)
 - Minified: [Minified](https://cdn.babylonjs.com/proceduralTexturesLibrary/babylon.cloudProceduralTexture.min.js)
 
-> ⚠️ WARNING: The CDN should not be used in production environments. The purpose of our CDN is to serve Babylon packages to users learning how to use the platform or running small experiments. Once you've built an application and are ready to share it with the world at large, you should serve all packages from your own CDN.
+<Alert severity="warning" title="Warning" description="The CDN should not be used in production environments. The purpose of our CDN is to serve Babylon packages to users learning how to use the platform or running small experiments. Once you've built an application and are ready to share it with the world at large, you should serve all packages from your own CDN."/>
 
 A demo can be found here: <Playground id="#NQDNM#0" title="Cloud Procedural Texture Demo" description="Cloud Procedural Texture Demo"/>
 

--- a/content/toolsAndResources/assetLibraries/proceduralTexturesLibrary/fire.md
+++ b/content/toolsAndResources/assetLibraries/proceduralTexturesLibrary/fire.md
@@ -19,7 +19,7 @@ Fire procedural texture can be found here:
 - Normal: [Normal](https://cdn.babylonjs.com/proceduralTexturesLibrary/babylon.fireProceduralTexture.js)
 - Minified: [Minified](https://cdn.babylonjs.com/proceduralTexturesLibrary/babylon.fireProceduralTexture.min.js)
 
-> ⚠️ WARNING: The CDN should not be used in production environments. The purpose of our CDN is to serve Babylon packages to users learning how to use the platform or running small experiments. Once you've built an application and are ready to share it with the world at large, you should serve all packages from your own CDN.
+<Alert severity="warning" title="Warning" description="The CDN should not be used in production environments. The purpose of our CDN is to serve Babylon packages to users learning how to use the platform or running small experiments. Once you've built an application and are ready to share it with the world at large, you should serve all packages from your own CDN."/>
 
 A demo can be found here:  <Playground id="#KM3TC" title="Fire Procedural Texture" description="Fire Procedural Texture"/>
 

--- a/content/toolsAndResources/assetLibraries/proceduralTexturesLibrary/grass.md
+++ b/content/toolsAndResources/assetLibraries/proceduralTexturesLibrary/grass.md
@@ -19,7 +19,7 @@ Grass procedural texture can be found here:
 - Normal: [Normal](https://cdn.babylonjs.com/proceduralTexturesLibrary/babylon.grassProceduralTexture.js)
 - Minified: [Minified](https://cdn.babylonjs.com/proceduralTexturesLibrary/babylon.grassProceduralTexture.min.js)
 
-> ⚠️ WARNING: The CDN should not be used in production environments. The purpose of our CDN is to serve Babylon packages to users learning how to use the platform or running small experiments. Once you've built an application and are ready to share it with the world at large, you should serve all packages from your own CDN.
+<Alert severity="warning" title="Warning" description="The CDN should not be used in production environments. The purpose of our CDN is to serve Babylon packages to users learning how to use the platform or running small experiments. Once you've built an application and are ready to share it with the world at large, you should serve all packages from your own CDN."/>
 
 A demo can be found here:  https://www.babylonjs-playground.com/#KM3TC#1
 

--- a/content/toolsAndResources/assetLibraries/proceduralTexturesLibrary/marble.md
+++ b/content/toolsAndResources/assetLibraries/proceduralTexturesLibrary/marble.md
@@ -19,7 +19,7 @@ Marble procedural texture can be found here:
 - Normal: [Normal](https://cdn.babylonjs.com/proceduralTexturesLibrary/babylon.marbleProceduralTexture.js)
 - Minified : [Minified](https://cdn.babylonjs.com/proceduralTexturesLibrary/babylon.marbleProceduralTexture.min.js)
 
-> ⚠️ WARNING: The CDN should not be used in production environments. The purpose of our CDN is to serve Babylon packages to users learning how to use the platform or running small experiments. Once you've built an application and are ready to share it with the world at large, you should serve all packages from your own CDN.
+<Alert severity="warning" title="Warning" description="The CDN should not be used in production environments. The purpose of our CDN is to serve Babylon packages to users learning how to use the platform or running small experiments. Once you've built an application and are ready to share it with the world at large, you should serve all packages from your own CDN."/>
 
 A demo can be found here:  <Playground id="#HS1SK#4" title="Marble Procedural Texture Demo" description="Marble Procedural Texture Demo"/>
 

--- a/content/toolsAndResources/assetLibraries/proceduralTexturesLibrary/road.md
+++ b/content/toolsAndResources/assetLibraries/proceduralTexturesLibrary/road.md
@@ -19,7 +19,7 @@ Road procedural texture can be found here:
 - Normal: [Normal](https://cdn.babylonjs.com/proceduralTexturesLibrary/babylon.roadProceduralTexture.js)
 - Minified: [Minified](https://cdn.babylonjs.com/proceduralTexturesLibrary/babylon.roadProceduralTexture.min.js)
 
-> ⚠️ WARNING: The CDN should not be used in production environments. The purpose of our CDN is to serve Babylon packages to users learning how to use the platform or running small experiments. Once you've built an application and are ready to share it with the world at large, you should serve all packages from your own CDN.
+<Alert severity="warning" title="Warning" description="The CDN should not be used in production environments. The purpose of our CDN is to serve Babylon packages to users learning how to use the platform or running small experiments. Once you've built an application and are ready to share it with the world at large, you should serve all packages from your own CDN."/>
 
 A demo can be found here: <Playground id="#FBW4N#0" title="Road Procedural Texture Demo" description="Road Procedural Texture Demo"/>
 

--- a/content/toolsAndResources/assetLibraries/proceduralTexturesLibrary/wood.md
+++ b/content/toolsAndResources/assetLibraries/proceduralTexturesLibrary/wood.md
@@ -18,7 +18,7 @@ Wood procedural texture can be found here:
 - Normal: [Normal](https://cdn.babylonjs.com/proceduralTexturesLibrary/babylon.woodProceduralTexture.js)
 - Minified : [Minified](https://cdn.babylonjs.com/proceduralTexturesLibrary/babylon.woodProceduralTexture.min.js)
 
-> ⚠️ WARNING: The CDN should not be used in production environments. The purpose of our CDN is to serve Babylon packages to users learning how to use the platform or running small experiments. Once you've built an application and are ready to share it with the world at large, you should serve all packages from your own CDN.
+<Alert severity="warning" title="Warning" description="The CDN should not be used in production environments. The purpose of our CDN is to serve Babylon packages to users learning how to use the platform or running small experiments. Once you've built an application and are ready to share it with the world at large, you should serve all packages from your own CDN."/>
 
 A demo can be found here: <Playground id="#K41IJ#3" title="Wood Procedural Texture Demo" description="Wood Procedural Texture Demo"/>
 


### PR DESCRIPTION
:rocket: I have went ahead and replaced all occurrences of

```
⚠️ WARNING: The CDN should not be used in production environments. The purpose of our CDN is to serve Babylon packages to users learning how to use the platform or running small experiments. Once you've built an application and are ready to share it with the world at large, you should serve all packages from your own CDN.
```

with

```
<Alert severity="warning" title="Warning" description="The CDN should not be used in production environments. The purpose of our CDN is to serve Babylon packages to users learning how to use the platform or running small experiments. Once you've built an application and are ready to share it with the world at large, you should serve all packages from your own CDN."/>
```


:rocket: Changed in `content/setup/frameworkPackages/frameworkVers.md` the verbiage from:

> The CDN should not be used in production environments. Please use self-hosting for production.

to:

> The CDN should not be used in production environments. The purpose of our CDN is to serve Babylon packages to users learning how to use the platform or running small experiments. Once you've built an application and are ready to share it with the world at large, you should serve all packages from your own CDN.


:rocket: I also added a marginBottom of 1.3rem to the alert to match the `<p>` tag.

WITHOUT marginBottom:
![image](https://github.com/BabylonJS/Documentation/assets/14898141/cbc20a5f-3465-46c8-a1dc-f03bacd14bc7)

WITH marginBottom:
![image](https://github.com/BabylonJS/Documentation/assets/14898141/343f3297-6741-49da-b9bc-9b54169e5901)


:question: I do wonder, should the alert be its _own_ component file instead of in the syntaxHighlight one? (i'm new to contributing so not sure where things should really live just yet :) ) I'm happy to make that change or leave it. Whatever works.
