### PR TITLE
Enhancement #790: Expand Image

### DIFF
--- a/components/markdownComponents/image.component.tsx
+++ b/components/markdownComponents/image.component.tsx
@@ -20,17 +20,19 @@ const styles = makeStyles((theme: Theme) =>
             }
         },
         imageContainerExpandable: {
-            "& $image": {
-                boxShadow: theme.shadows[3]
-            },
-            "&:hover": {
+            [theme.breakpoints.up("sm")]: {
                 "& $image": {
-                    opacity: "0.3"
+                    boxShadow: theme.shadows[3]
                 },
-                "& $expandIconContainer": {
-                    opacity: 1
-                }
-            },
+                "&:hover": {
+                    "& $image": {
+                        opacity: "0.3"
+                    },
+                    "& $expandIconContainer": {
+                        opacity: 1
+                    }
+                },
+            }
         },
         image: {
             borderRadius: theme.shape.borderRadius,

--- a/components/markdownComponents/image.component.tsx
+++ b/components/markdownComponents/image.component.tsx
@@ -1,10 +1,11 @@
 import Image from "next/image";
 import { FunctionComponent, useEffect, useRef, useState } from "react";
-import { Button, Theme, Modal, Card, Tooltip, Fade, Hidden } from "@mui/material";
+import { Button, Theme, Modal, Card, Fade, Hidden, IconButton } from "@mui/material";
 import { createStyles, makeStyles } from "@mui/styles";
 import { IImageEmbed } from "../../lib/content.interfaces";
 import { throttle } from "../../lib/frontendUtils/frontendTools";
 import ZoomOutMapIcon from '@mui/icons-material/ZoomOutMap';
+import CloseIcon from '@mui/icons-material/Close';
 
 const styles = makeStyles((theme: Theme) =>
     createStyles({
@@ -66,23 +67,30 @@ const styles = makeStyles((theme: Theme) =>
         },
         modalImageContainer: {
             display: "flex",
-            flexDirection: "column",
             alignItems: "center",
             justifyContent: "center",
             width: "100%",
-            height: "100%",
-            padding: "1rem",
+            height: "90%",
+            padding: "0 0.5rem 0.5rem 0.5rem"
+        },
+        modalCard: {
+            display: "flex",
+            flexDirection: "column",
+            width: "100%",
+            height: "100%"
         },
         modal: {
             display: "flex",
             alignItems: "center",
             justifyContent: "center",
-            [theme.breakpoints.up("sm")]: {
-                margin: "2.5rem 6rem"
-            },
             [theme.breakpoints.up("md")]: {
                 margin: "5rem 12rem"
             }
+        },
+        modalCloseContainer: {
+            display: "flex",
+            alignItems: "end",
+            justifyContent: "end"
         }
     }),
 );
@@ -219,8 +227,15 @@ export const ImageMarkdownComponent: FunctionComponent<IImageEmbed> = (props) =>
                 aria-describedby="server-modal-description"
             >
                 <Fade in={isOpen}>
-                    <Card className={classes.modalImageContainer}>
-                        <img className={classes.modalImage} {...props} src={src} />
+                    <Card className={classes.modalCard}>
+                        <div className={classes.modalCloseContainer}>
+                            <IconButton onClick={() => setIsOpen(false)}>
+                                <CloseIcon />
+                            </IconButton>
+                        </div>
+                        <div className={classes.modalImageContainer}>
+                            <img className={classes.modalImage} {...props} src={src} />
+                        </div>
                     </Card>
                 </Fade>
             </Modal>

--- a/components/markdownComponents/image.component.tsx
+++ b/components/markdownComponents/image.component.tsx
@@ -1,6 +1,6 @@
 import Image from "next/image";
 import { FunctionComponent, useEffect, useRef, useState } from "react";
-import { IconButton, Theme, Modal, Card, Tooltip } from "@mui/material";
+import { IconButton, Theme, Modal, Card, Tooltip, Fade } from "@mui/material";
 import { createStyles, makeStyles } from "@mui/styles";
 import { IImageEmbed } from "../../lib/content.interfaces";
 import { throttle } from "../../lib/frontendUtils/frontendTools";
@@ -192,16 +192,17 @@ export const ImageMarkdownComponent: FunctionComponent<IImageEmbed> = (props) =>
     return (
         <>
             <Modal
-                // disablePortal
                 className={classes.modal}
                 open={isOpen}
                 onClose={() => setIsOpen(false)}
                 aria-labelledby="server-modal-title"
                 aria-describedby="server-modal-description"
             >
-                <Card className={classes.modalImageContainer}>
-                    <img className={classes.modalImage} {...props} src={src} />
-                </Card>
+                <Fade in={isOpen}>
+                    <Card className={classes.modalImageContainer}>
+                        <img className={classes.modalImage} {...props} src={src} />
+                    </Card>
+                </Fade>
             </Modal>
             <span ref={containerRef} style={{ display: "block", height: containerScale.h !== 0 ? containerScale.h : "auto", width: containerScale.w !== 0 ? containerScale.w : "100%" }} className={classes.imageWrapper}>
                 {getImage()}

--- a/components/markdownComponents/image.component.tsx
+++ b/components/markdownComponents/image.component.tsx
@@ -20,6 +20,9 @@ const styles = makeStyles((theme: Theme) =>
             }
         },
         imageContainerExpandable: {
+            "& $image": {
+                boxShadow: theme.shadows[3]
+            },
             "&:hover": {
                 "& $image": {
                     opacity: "0.3"
@@ -30,13 +33,14 @@ const styles = makeStyles((theme: Theme) =>
             },
         },
         image: {
+            borderRadius: theme.shape.borderRadius,
             flexGrow: "1",
             transition: ".5s ease",
-            backfaceVisibility: "hidden",
-            borderRadius: theme.shape.borderRadius,
-            boxShadow: theme.shadows[3]
+            backfaceVisibility: "hidden"
         },
-        expandIcon: {},
+        expandIcon: {
+            minWidth: "6.6rem"
+        },
         expandIconContainer: {
             position: "absolute",
             top: "50%",

--- a/components/markdownComponents/image.component.tsx
+++ b/components/markdownComponents/image.component.tsx
@@ -1,6 +1,6 @@
 import Image from "next/image";
 import { FunctionComponent, useEffect, useRef, useState } from "react";
-import { IconButton, Theme, Modal, Backdrop } from "@mui/material";
+import { IconButton, Theme, Modal, Card, CardActions, CardContent, CardMedia } from "@mui/material";
 import { createStyles, makeStyles } from "@mui/styles";
 import { IImageEmbed } from "../../lib/content.interfaces";
 import { throttle } from "../../lib/frontendUtils/frontendTools";
@@ -190,7 +190,7 @@ export const ImageMarkdownComponent: FunctionComponent<IImageEmbed> = (props) =>
                 aria-labelledby="server-modal-title"
                 aria-describedby="server-modal-description"
             >
-                <div>
+                <Card>
                     <Image
                         unoptimized={true}
                         className={classes.modalImage}
@@ -200,7 +200,7 @@ export const ImageMarkdownComponent: FunctionComponent<IImageEmbed> = (props) =>
                         alt={props.alt}
                         src={src}
                     ></Image>
-                </div>
+                </Card>
             </Modal>
             <span ref={containerRef} style={{ display: "block", height: containerScale.h !== 0 ? containerScale.h : "auto", width: containerScale.w !== 0 ? containerScale.w : "100%" }} className={classes.imageWrapper}>
                 {getImage()}

--- a/components/markdownComponents/image.component.tsx
+++ b/components/markdownComponents/image.component.tsx
@@ -22,7 +22,8 @@ const styles = makeStyles((theme: Theme) =>
         image: {
             flex: 1,
             width: "100%",
-            boxShadow: theme.shadows[3]
+            boxShadow: theme.shadows[3],
+            borderRadius: theme.shape.borderRadius * 1
         },
         expandIcon: {
             backgroundColor: theme.palette.primary.light,

--- a/components/markdownComponents/image.component.tsx
+++ b/components/markdownComponents/image.component.tsx
@@ -22,8 +22,6 @@ const styles = makeStyles((theme: Theme) =>
         image: {
             flex: 1,
             width: "100%",
-            boxShadow: theme.shadows[3],
-            borderRadius: theme.shape.borderRadius * 1,
         },
         expandIcon: {
             backgroundColor: theme.palette.primary.light,
@@ -209,11 +207,10 @@ export const ImageMarkdownComponent: FunctionComponent<IImageEmbed> = (props) =>
                     </Card>
                 </Fade>
             </Modal>
-            <span ref={containerRef} style={{ display: "block", height: containerScale.h !== 0 ? containerScale.h : "auto", width: containerScale.w !== 0 ? containerScale.w : "100%" }} className={classes.imageWrapper}>
-                {getImage()}
+            <span ref={containerRef} style={{ height: containerScale.h !== 0 ? containerScale.h : "auto", width: containerScale.w !== 0 ? containerScale.w : "100%" }} className={classes.imageWrapper}>
                 {queryParams.expandable && (
                     <Hidden smDown>
-                        <span className={classes.expandIconContainer}>
+                        <span className={classes.expandIconContainer} style={{zIndex: 999}}>
                                 <Tooltip title="Expand Image">
                                     <IconButton
                                         className={classes.expandIcon}
@@ -226,6 +223,7 @@ export const ImageMarkdownComponent: FunctionComponent<IImageEmbed> = (props) =>
                         </span>
                     </Hidden>
                 )}
+                {getImage()}
             </span>
             {props.caption && <span className={classes.caption}>{props.caption}</span>}
         </>

--- a/components/markdownComponents/image.component.tsx
+++ b/components/markdownComponents/image.component.tsx
@@ -1,6 +1,6 @@
 import Image from "next/image";
 import { FunctionComponent, useEffect, useRef, useState } from "react";
-import { IconButton, Theme, Modal, Card, Tooltip, Fade, Hidden } from "@mui/material";
+import { Button, Theme, Modal, Card, Tooltip, Fade, Hidden } from "@mui/material";
 import { createStyles, makeStyles } from "@mui/styles";
 import { IImageEmbed } from "../../lib/content.interfaces";
 import { throttle } from "../../lib/frontendUtils/frontendTools";
@@ -8,33 +8,44 @@ import ZoomOutMapIcon from '@mui/icons-material/ZoomOutMap';
 
 const styles = makeStyles((theme: Theme) =>
     createStyles({
-        imageWrapper: {
+        imageContainer: {
             position: "relative",
+            display: "flex",
             flexDirection: "column",
             maxWidth: "100%",
             height: "auto",
             margin: theme.spacing(2, 0),
-            display: "inline-block",
             [theme.breakpoints.up("sm")]: {
                 maxWidth: 800,
+            }
+        },
+        imageContainerExpandable: {
+            "&:hover": {
+                "& $image": {
+                    opacity: "0.3"
+                },
+                "& $expandIconContainer": {
+                    opacity: 1
+                }
             },
         },
         image: {
-            flex: 1,
-            width: "100%",
+            flexGrow: "1",
+            transition: ".5s ease",
+            backfaceVisibility: "hidden",
+            borderRadius: theme.shape.borderRadius,
+            boxShadow: theme.shadows[3]
         },
-        expandIcon: {
-            backgroundColor: theme.palette.primary.light,
-            "&:hover": {
-                backgroundColor: theme.palette.primary.main
-            }
-        },
+        expandIcon: {},
         expandIconContainer: {
-            display: "flex",
-            position: "relative",
-            width: "100%",
-            justifyContent: "end",
-            padding: "0.25rem"
+            position: "absolute",
+            top: "50%",
+            left: "50%",
+            transform: "translate(-50%, -50%)",
+            textAlign: "center",
+            transition: ".5s ease",
+            backfaceVisibility: "hidden",
+            opacity: 0,
         },
         caption: {
             fontSize: 12,
@@ -207,23 +218,26 @@ export const ImageMarkdownComponent: FunctionComponent<IImageEmbed> = (props) =>
                     </Card>
                 </Fade>
             </Modal>
-            <span ref={containerRef} style={{ height: containerScale.h !== 0 ? containerScale.h : "auto", width: containerScale.w !== 0 ? containerScale.w : "100%" }} className={classes.imageWrapper}>
+            <span ref={containerRef} className={[
+                classes.imageContainer,
+                queryParams.expandable ? classes.imageContainerExpandable : ""
+            ].join(" ")} style={{ height: containerScale.h !== 0 ? containerScale.h : "auto", width: containerScale.w !== 0 ? containerScale.w : "100%" }}>
+                {getImage()}
                 {queryParams.expandable && (
                     <Hidden smDown>
-                        <span className={classes.expandIconContainer} style={{zIndex: 999}}>
-                                <Tooltip title="Expand Image">
-                                    <IconButton
-                                        className={classes.expandIcon}
-                                        size="small"
-                                        onClick={() => setIsOpen(true)}
-                                    >
-                                        <ZoomOutMapIcon sx={{fontSize: "1rem"}} />
-                                    </IconButton>
-                                </Tooltip>
+                        <span className={classes.expandIconContainer}>
+                            <Button
+                                className={classes.expandIcon}
+                                size="small"
+                                variant="outlined"
+                                onClick={() => setIsOpen(true)}
+                            >
+                                <span style={{marginRight: "0.5rem"}}>Expand</span>
+                                <ZoomOutMapIcon sx={{fontSize: "1rem"}} />
+                            </Button>
                         </span>
                     </Hidden>
                 )}
-                {getImage()}
             </span>
             {props.caption && <span className={classes.caption}>{props.caption}</span>}
         </>

--- a/components/markdownComponents/image.component.tsx
+++ b/components/markdownComponents/image.component.tsx
@@ -22,6 +22,7 @@ const styles = makeStyles((theme: Theme) =>
         image: {
             flex: 1,
             width: "100%",
+            boxShadow: theme.shadows[3]
         },
         expandIcon: {
             backgroundColor: theme.palette.primary.light,

--- a/components/markdownComponents/image.component.tsx
+++ b/components/markdownComponents/image.component.tsx
@@ -1,6 +1,6 @@
 import Image from "next/image";
 import { FunctionComponent, useEffect, useRef, useState } from "react";
-import { IconButton, Theme, Modal, Card, Tooltip, Fade } from "@mui/material";
+import { IconButton, Theme, Modal, Card, Tooltip, Fade, Hidden } from "@mui/material";
 import { createStyles, makeStyles } from "@mui/styles";
 import { IImageEmbed } from "../../lib/content.interfaces";
 import { throttle } from "../../lib/frontendUtils/frontendTools";
@@ -23,7 +23,7 @@ const styles = makeStyles((theme: Theme) =>
             flex: 1,
             width: "100%",
             boxShadow: theme.shadows[3],
-            borderRadius: theme.shape.borderRadius * 1
+            borderRadius: theme.shape.borderRadius * 1,
         },
         expandIcon: {
             backgroundColor: theme.palette.primary.light,
@@ -33,6 +33,7 @@ const styles = makeStyles((theme: Theme) =>
         },
         expandIconContainer: {
             display: "flex",
+            position: "relative",
             width: "100%",
             justifyContent: "end",
             padding: "0.25rem"
@@ -47,7 +48,6 @@ const styles = makeStyles((theme: Theme) =>
             width: "100%",
             height: "auto",
             maxHeight: "100%",
-            boxShadow: theme.shadows[3]
         },
         modalImageContainer: {
             display: "flex",
@@ -56,12 +56,15 @@ const styles = makeStyles((theme: Theme) =>
             justifyContent: "center",
             width: "100%",
             height: "100%",
-            padding: "0.5rem",
+            padding: "1rem",
         },
         modal: {
             display: "flex",
             alignItems: "center",
             justifyContent: "center",
+            [theme.breakpoints.up("sm")]: {
+                margin: "2.5rem 6rem"
+            },
             [theme.breakpoints.up("md")]: {
                 margin: "5rem 12rem"
             }
@@ -75,12 +78,12 @@ const styles = makeStyles((theme: Theme) =>
 export const ImageMarkdownComponent: FunctionComponent<IImageEmbed> = (props) => {
     const getQueryParams = (rawSrc: string) => {
         let src = rawSrc;
-        let expandable = false;
+        let expandable = true;
         if(src.includes("?")) {
             let split = src.split("?");
             src = split[0];
             const params = new URLSearchParams(split[1]);
-            expandable = params.get('expandable') === "true"
+            expandable = params.get('expandable') === "true" || params.get('expandable') === undefined
         }
         return {
             src,
@@ -209,17 +212,19 @@ export const ImageMarkdownComponent: FunctionComponent<IImageEmbed> = (props) =>
             <span ref={containerRef} style={{ display: "block", height: containerScale.h !== 0 ? containerScale.h : "auto", width: containerScale.w !== 0 ? containerScale.w : "100%" }} className={classes.imageWrapper}>
                 {getImage()}
                 {queryParams.expandable && (
-                    <span className={classes.expandIconContainer}>
-                        <Tooltip title="Expand Image">
-                            <IconButton
-                                className={classes.expandIcon}
-                                size="small"
-                                onClick={() => setIsOpen(true)}
-                            >
-                                <ZoomOutMapIcon sx={{fontSize: "1rem"}} />
-                            </IconButton>
-                        </Tooltip>
-                    </span>
+                    <Hidden smDown>
+                        <span className={classes.expandIconContainer}>
+                                <Tooltip title="Expand Image">
+                                    <IconButton
+                                        className={classes.expandIcon}
+                                        size="small"
+                                        onClick={() => setIsOpen(true)}
+                                    >
+                                        <ZoomOutMapIcon sx={{fontSize: "1rem"}} />
+                                    </IconButton>
+                                </Tooltip>
+                        </span>
+                    </Hidden>
                 )}
             </span>
             {props.caption && <span className={classes.caption}>{props.caption}</span>}

--- a/components/markdownComponents/image.component.tsx
+++ b/components/markdownComponents/image.component.tsx
@@ -1,6 +1,6 @@
 import Image from "next/image";
 import { FunctionComponent, useEffect, useRef, useState } from "react";
-import { IconButton, Theme, Modal, Card, CardHeader } from "@mui/material";
+import { IconButton, Theme, Modal, Card, Tooltip } from "@mui/material";
 import { createStyles, makeStyles } from "@mui/styles";
 import { IImageEmbed } from "../../lib/content.interfaces";
 import { throttle } from "../../lib/frontendUtils/frontendTools";
@@ -24,7 +24,10 @@ const styles = makeStyles((theme: Theme) =>
             width: "100%",
         },
         expandIcon: {
-            backgroundColor: theme.palette.primary.contrastText
+            backgroundColor: theme.palette.primary.light,
+            "&:hover": {
+                backgroundColor: theme.palette.primary.main
+            }
         },
         expandIconContainer: {
             display: "flex",
@@ -186,7 +189,6 @@ export const ImageMarkdownComponent: FunctionComponent<IImageEmbed> = (props) =>
         }
     };
     const [isOpen, setIsOpen] = useState(false)
-    console.log(props.alt)
     return (
         <>
             <Modal
@@ -205,13 +207,15 @@ export const ImageMarkdownComponent: FunctionComponent<IImageEmbed> = (props) =>
                 {getImage()}
                 {queryParams.expandable && (
                     <span className={classes.expandIconContainer}>
-                        <IconButton
-                            className={classes.expandIcon}
-                            size="small"
-                            onClick={() => setIsOpen(true)}
-                        >
-                            <ZoomOutMapIcon color="action" />
-                        </IconButton>
+                        <Tooltip title="Expand Image">
+                            <IconButton
+                                className={classes.expandIcon}
+                                size="small"
+                                onClick={() => setIsOpen(true)}
+                            >
+                                <ZoomOutMapIcon sx={{fontSize: "1rem"}} />
+                            </IconButton>
+                        </Tooltip>
                     </span>
                 )}
             </span>

--- a/content/features/introductionToFeatures/chap1/first_scene.md
+++ b/content/features/introductionToFeatures/chap1/first_scene.md
@@ -19,7 +19,7 @@ Wireframe View Showing Mesh Triangles
 
 A large number of meshes can be created directly within Babylon.js using code, or, as you will shortly see, imported as models from meshes created with other software. Let us start simply with a box.
 
-Examples on these pages can be viewed in the playground, the place to try out Babylon.js live on the web, by clicking on their titles. To edit the code open them with ![open pg](/img/getstarted/openpg.png)
+Examples on these pages can be viewed in the playground, the place to try out Babylon.js live on the web, by clicking on their titles. To edit the code open them with ![open pg](/img/getstarted/openpg.png?expandable=false)
 
 ## Say Hello to Your First World
 

--- a/content/journey/learningTheDocs.md
+++ b/content/journey/learningTheDocs.md
@@ -30,23 +30,23 @@ The documentation page layout has several features that you'll want to know abou
 
 To start, the left most panel is the navigation pane. This pane is how you navigate to where you'd like to go.
 
-![Navigation Pane](/img/home/home1.jpg?expandable=true)
+![Navigation Pane](/img/home/home1.jpg)
 
 Next is the content pane. It's in the middle, and you guessed it, it contains the main content and information.
 
-![Content Pane](/img/home/home2.jpg?expandable=true)
+![Content Pane](/img/home/home2.jpg)
 
 Some pages have a lot of information that's organized into sub sections. The table of contents pane makes it easy to navigate lengthier pages.
 
-![Table of Contents](/img/home/home4.jpg?expandable=true)
+![Table of Contents](/img/home/home4.jpg)
 
 The panel on the right is the examples pane. It provides quick access to every playground (live examples) on the current page.
 
-![Examples Pane](/img/home/home3.jpg?expandable=true)
+![Examples Pane](/img/home/home3.jpg)
 
 Lastly, if you select any one of the examples in the examples pane, it will load that example inside of the playground pane at the top of the page content.
 
-![Examples Pane](/img/home/home5.jpg?expandable=true)
+![Examples Pane](/img/home/home5.jpg)
 
 ## A note on versioning
 

--- a/content/journey/learningTheDocs.md
+++ b/content/journey/learningTheDocs.md
@@ -30,23 +30,23 @@ The documentation page layout has several features that you'll want to know abou
 
 To start, the left most panel is the navigation pane. This pane is how you navigate to where you'd like to go.
 
-![Navigation Pane](/img/home/home1.jpg)
+![Navigation Pane](/img/home/home1.jpg?expandable=true)
 
 Next is the content pane. It's in the middle, and you guessed it, it contains the main content and information.
 
-![Content Pane](/img/home/home2.jpg)
+![Content Pane](/img/home/home2.jpg?expandable=true)
 
 Some pages have a lot of information that's organized into sub sections. The table of contents pane makes it easy to navigate lengthier pages.
 
-![Table of Contents](/img/home/home4.jpg)
+![Table of Contents](/img/home/home4.jpg?expandable=true)
 
 The panel on the right is the examples pane. It provides quick access to every playground (live examples) on the current page.
 
-![Examples Pane](/img/home/home3.jpg)
+![Examples Pane](/img/home/home3.jpg?expandable=true)
 
 Lastly, if you select any one of the examples in the examples pane, it will load that example inside of the playground pane at the top of the page content.
 
-![Examples Pane](/img/home/home5.jpg)
+![Examples Pane](/img/home/home5.jpg?expandable=true)
 
 ## A note on versioning
 

--- a/content/journey/theFirstStep.md
+++ b/content/journey/theFirstStep.md
@@ -18,7 +18,7 @@ This doc will take you on a VERY brief journey of creating and hosting your very
 
 The single most important tool available to you as you learn and develop with Babylon, is the Babylon.js Playground.
 
-![playground](/img/home/playground.jpg)
+![playground](/img/home/playground.jpg?expandable=true)
 
 The playground is your toybox, your tinker environment, your laboratory. This simple website allows you to write Babylon code on the left, and see instant updates on the right. It's really that simple.
 
@@ -98,7 +98,7 @@ Pretty cool! You've now created your first Babylon.js texture and assigned it to
 
 Ok it's time for another addition to the scene. After all of your ground-related code, give yourself a little space by hitting enter and on a new line press CTRL+SPACE. This will spawn a list of playground templates. These templates are handy pieces of code that you will likely reuse over and over again through your Babylon learning journey. Go ahead and select the template that says "Import a Mesh w/Callback".
 
-![templates](/img/home/playgroundTemplates.jpg)
+![templates](/img/home/playgroundTemplates.jpg?expandable=true)
 
 You should see the following lines of code pop right into the playground:
 
@@ -171,11 +171,11 @@ You'll need to log in (or sign up if you're new to GitHub...it's free).
 
 Next, we'll create a new repository.
 
-![newRepo](/img/home/newRepo.jpg)
+![newRepo](/img/home/newRepo.jpg?expandable=true)
 
 Give your new repo a cool name and make sure to check the "Add a README file."
 
-![newRepoDetails](/img/home/newRepoDetails.jpg)
+![newRepoDetails](/img/home/newRepoDetails.jpg?expandable=true)
 
 Congratulations! You've just set up a new GitHub repository! Yay!
 
@@ -183,29 +183,29 @@ Now let's add the downloaded Babylon Playground files to this repository.
 
 Click on "Add file" and then "Upload files"
 
-![uploadFiles](/img/home/uploadFiles.jpg)
+![uploadFiles](/img/home/uploadFiles.jpg?expandable=true)
 
 Locate the file that you downloaded from the Babylon.js playground and drag it onto this page. Then press the "Commit changes" button.
 
-![uploadCommit](/img/home/uploadCommit.jpg)
+![uploadCommit](/img/home/uploadCommit.jpg?expandable=true)
 
 One last step and then your Babylon Experience will be hosted with a live url for anyone to see.
 
 Hit the "Settings" button on the main repo page.
 
-![settings](/img/home/settings.jpg)
+![settings](/img/home/settings.jpg?expandable=true)
 
 Navigate to the "Pages" menu item, set the "Branch" to "main", and hit the save button.
 
-![pages](/img/home/pages.jpg)
+![pages](/img/home/pages.jpg?expandable=true)
 
 After your settings are saved you'll see the url to to reach your website! You can share that url with anyone that you'd like!
 
-![url](/img/home/url.jpg)
+![url](/img/home/url.jpg?expandable=true)
 
 Your project also needs one more file to complete the setup which defines the title and description of your website. It is a file named _config.yml and if it is not already in your repository, you can simply create one easily. Simply use the `Add File` drop down and select `Create New File`.
 
-![create text file](/img/home/addNewTextFile.jpg)
+![create text file](/img/home/addNewTextFile.jpg?expandable=true)
 
 This will open a text editor for you to create the file. At the top, type `_config.yml` in the input field as the name of the file to save in your repository. Then type the following in the body of the file:
 
@@ -216,11 +216,11 @@ description: Website description.
 
 ```
 
-![create config file](/img/home/createTextFile.jpg)
+![create config file](/img/home/createTextFile.jpg?expandable=true)
 
 Once you are done editing the config file, click the `Commit changes...` button to commit the file to the repository. This will bring up a window that asks you to create a commit message and extended description. Entering a message and description will show up in your repository's history, so it is good to be descriptive here. Once you have those entered, select the `Commit directly to the main branch` option and then `Commit changes`.
 
-![commit text file to repository](/img/home/commitTextFile.jpg)
+![commit text file to repository](/img/home/commitTextFile.jpg?expandable=true)
 
 
 

--- a/content/journey/theFirstStep.md
+++ b/content/journey/theFirstStep.md
@@ -18,7 +18,7 @@ This doc will take you on a VERY brief journey of creating and hosting your very
 
 The single most important tool available to you as you learn and develop with Babylon, is the Babylon.js Playground.
 
-![playground](/img/home/playground.jpg?expandable=true)
+![playground](/img/home/playground.jpg)
 
 The playground is your toybox, your tinker environment, your laboratory. This simple website allows you to write Babylon code on the left, and see instant updates on the right. It's really that simple.
 
@@ -53,7 +53,7 @@ sphere.position.y = 1;
 
 Go ahead and highlight those lines of code and hit DELETE! You've just made your first change! Feel good? But wait, nothing happened in the scene? That's because we have to re-run the scene with our changes. You can do that by either pressing ALT+ENTER on your keyboard or pressing the 'run' button in the UI.
 
-![run](/img/home/run.jpg)
+![run](/img/home/run.jpg?expandable=false)
 
 BOOM! The sphere is gone!
 
@@ -98,7 +98,7 @@ Pretty cool! You've now created your first Babylon.js texture and assigned it to
 
 Ok it's time for another addition to the scene. After all of your ground-related code, give yourself a little space by hitting enter and on a new line press CTRL+SPACE. This will spawn a list of playground templates. These templates are handy pieces of code that you will likely reuse over and over again through your Babylon learning journey. Go ahead and select the template that says "Import a Mesh w/Callback".
 
-![templates](/img/home/playgroundTemplates.jpg?expandable=true)
+![templates](/img/home/playgroundTemplates.jpg)
 
 You should see the following lines of code pop right into the playground:
 
@@ -147,7 +147,7 @@ Run the scene and click+drag or touch+drag on the Babylon scene.
 
 WooHoo! You've added interaction to the scene! Great job! Go ahead and save your playground by pressing CTRL+S or hitting the save button.
 
-![save](/img/home/save.jpg)
+![save](/img/home/save.jpg?expandable=false)
 
 ### The .html File
 
@@ -155,7 +155,7 @@ At this point, let's say we're happy with our creation, and we want to put the B
 
 Getting your Babylon scene ready to host is as simple as pressing a button. Either press SHIFT+CTRL+S or press the Download button to download an .html file of your Babylon scene to your system.
 
-![download](/img/home/download.jpg)
+![download](/img/home/download.jpg?expandable=false)
 
 That's it! You've got everything you need for the world to see your first Babylon experience! Now all we need to do is host it somewhere for the world to see it!
 
@@ -171,11 +171,11 @@ You'll need to log in (or sign up if you're new to GitHub...it's free).
 
 Next, we'll create a new repository.
 
-![newRepo](/img/home/newRepo.jpg?expandable=true)
+![newRepo](/img/home/newRepo.jpg)
 
 Give your new repo a cool name and make sure to check the "Add a README file."
 
-![newRepoDetails](/img/home/newRepoDetails.jpg?expandable=true)
+![newRepoDetails](/img/home/newRepoDetails.jpg)
 
 Congratulations! You've just set up a new GitHub repository! Yay!
 
@@ -183,29 +183,29 @@ Now let's add the downloaded Babylon Playground files to this repository.
 
 Click on "Add file" and then "Upload files"
 
-![uploadFiles](/img/home/uploadFiles.jpg?expandable=true)
+![uploadFiles](/img/home/uploadFiles.jpg)
 
 Locate the file that you downloaded from the Babylon.js playground and drag it onto this page. Then press the "Commit changes" button.
 
-![uploadCommit](/img/home/uploadCommit.jpg?expandable=true)
+![uploadCommit](/img/home/uploadCommit.jpg)
 
 One last step and then your Babylon Experience will be hosted with a live url for anyone to see.
 
 Hit the "Settings" button on the main repo page.
 
-![settings](/img/home/settings.jpg?expandable=true)
+![settings](/img/home/settings.jpg)
 
 Navigate to the "Pages" menu item, set the "Branch" to "main", and hit the save button.
 
-![pages](/img/home/pages.jpg?expandable=true)
+![pages](/img/home/pages.jpg)
 
 After your settings are saved you'll see the url to to reach your website! You can share that url with anyone that you'd like!
 
-![url](/img/home/url.jpg?expandable=true)
+![url](/img/home/url.jpg?expandable=false)
 
 Your project also needs one more file to complete the setup which defines the title and description of your website. It is a file named _config.yml and if it is not already in your repository, you can simply create one easily. Simply use the `Add File` drop down and select `Create New File`.
 
-![create text file](/img/home/addNewTextFile.jpg?expandable=true)
+![create text file](/img/home/addNewTextFile.jpg)
 
 This will open a text editor for you to create the file. At the top, type `_config.yml` in the input field as the name of the file to save in your repository. Then type the following in the body of the file:
 
@@ -216,11 +216,11 @@ description: Website description.
 
 ```
 
-![create config file](/img/home/createTextFile.jpg?expandable=true)
+![create config file](/img/home/createTextFile.jpg)
 
 Once you are done editing the config file, click the `Commit changes...` button to commit the file to the repository. This will bring up a window that asks you to create a commit message and extended description. Entering a message and description will show up in your repository's history, so it is good to be descriptive here. Once you have those entered, select the `Commit directly to the main branch` option and then `Commit changes`.
 
-![commit text file to repository](/img/home/commitTextFile.jpg?expandable=true)
+![commit text file to repository](/img/home/commitTextFile.jpg)
 
 
 

--- a/content/landing_pages/home.md
+++ b/content/landing_pages/home.md
@@ -16,4 +16,4 @@ We know that each person comes to Babylon.js with their own individual backgroun
 
 However, before you go any further, we strongly encourage (and humbly ask) EVERYONE to [Start Your Babylon.js Journey Here.](journey/theFirstStep)
 
-![Babylon](/img/home/babylonjs_identity_color.png?expandable=true)
+![Babylon](/img/home/babylonjs_identity_color.png)

--- a/content/landing_pages/home.md
+++ b/content/landing_pages/home.md
@@ -16,4 +16,4 @@ We know that each person comes to Babylon.js with their own individual backgroun
 
 However, before you go any further, we strongly encourage (and humbly ask) EVERYONE to [Start Your Babylon.js Journey Here.](journey/theFirstStep)
 
-![Babylon](/img/home/babylonjs_identity_color.png)
+![Babylon](/img/home/babylonjs_identity_color.png?expandable=false)

--- a/content/landing_pages/home.md
+++ b/content/landing_pages/home.md
@@ -16,4 +16,4 @@ We know that each person comes to Babylon.js with their own individual backgroun
 
 However, before you go any further, we strongly encourage (and humbly ask) EVERYONE to [Start Your Babylon.js Journey Here.](journey/theFirstStep)
 
-![Babylon](/img/home/babylonjs_identity_color.png)
+![Babylon](/img/home/babylonjs_identity_color.png?expandable=true)


### PR DESCRIPTION
## Issue
#790 

## Description
Added a hover effect to images in the doc that allows you to expand an image in a model. I'm sure the design could be refined at some point, but it gets the job done. It is enabled by default but if in the URL your used the queryparam `expandable=false` it will disable this feature.

⚠️ I did add a round border and a box shadow to the expandable images to give it a lil extra pizaz.

### Disabled
![image](https://github.com/BabylonJS/Documentation/assets/14898141/1c955241-1d21-46fc-9cfe-6d689d560348)

### Hoverable
![image](https://github.com/BabylonJS/Documentation/assets/14898141/3d0226dc-f06a-4855-87ee-8143dd9dacba)

### Hovering
![image](https://github.com/BabylonJS/Documentation/assets/14898141/a03dc83f-1224-45a1-92ad-89cbce2dedf1)

### Expanded
![image](https://github.com/BabylonJS/Documentation/assets/14898141/925654c0-d5e7-4658-9750-7fc80340fc64)


