### PR TITLE
Remove gulp-related build instructions from the contribution pages

### DIFF
--- a/content/contribute/toBabylon.md
+++ b/content/contribute/toBabylon.md
@@ -14,10 +14,10 @@ Babylon.js is maintained on Github, a web-based hosting service for version cont
 
 ## Pre-Requisites
 
-- Installation of Node.js, NPM, Git, Typescript, Gulp and have a Github Account;
+- Installation of Node.js, NPM, Git, Typescript, and have a Github Account;
 - A fork and clone of Babylon.js;
 - Reading the [contribution guidelines](https://github.com/BabylonJS/Babylon.js/blob/master/contributing.md);
 - An IDE such as VSCode;
 - An ability to code in Typescript. Babylon.js is written in Typescript then compiled and distributed in JavaScript.
 
-At the time of writing the version of Gulp needed was 4.0.0. The current [What's New](//doc.babylonjs.com/whats-new) should indicate if there have been any changes of version. You can also look in the Babylon.js repository for `package.json` in `Tools/Publisher` which will give the version number for Gulp and Typescript.
+You can find the required Typescript version by checking  `package.json` in the [Babylon.js repository](https://github.com/BabylonJS/Babylon.js/blob/master/package.json).


### PR DESCRIPTION
Incomplete work from earlier this year. I'll try to update the other docs shortly, but feel free to add suggestions.

Should resolve #770 (after the remaining pages have been updated).