### PR TITLE
typesetting error in "The Animation Method" page

### DIFF
--- a/content/features/featuresDeepDive/animation/animation_method.md
+++ b/content/features/featuresDeepDive/animation/animation_method.md
@@ -33,7 +33,7 @@ const myAnim = new BABYLON.Animation(name, property, frames_per_second, property
 
     BABYLON.Animation.ANIMATIONLOOPMODE_CYCLE - Restart the animation from initial value  
     BABYLON.Animation.ANIMATIONLOOPMODE_CONSTANT - Pause the animation at the final value  
-    BABYLON.Animation.ANIMATIONLOOPMODE_RELATIVE - Repeat the animation incrementing using key value gradients. In this way, for example, a \_clip* showing a character's legs in a walking motion can be looped to show the character progressing across the scene.
+    BABYLON.Animation.ANIMATIONLOOPMODE_RELATIVE - Repeat the animation incrementing using key value gradients. In this way, for example, a \_clip* showing a character's legs in a walking motion can be looped to show the character progressing across the scene
     BABYLON.Animation.ANIMATIONLOOPMODE_YOYO - The animation will reverses its direction when it reaches the end instead of restarting from the beginning
 
 ## Set Key Frames


### PR DESCRIPTION
missing a CR/LF (or < br / >) before  BABYLON.Animation.ANIMATIONLOOPMODE_YOYO

![image](https://github.com/BabylonJS/Documentation/assets/6300574/a137621d-cf18-40b6-a195-8e7792ba7638)
