### PR TITLE
Update mmdLoader example PG

### DIFF
--- a/content/communityExtensions/mmdLoader.md
+++ b/content/communityExtensions/mmdLoader.md
@@ -31,7 +31,7 @@ babylon-mmd is a library focused on loading PMX models and VMD motion files into
 ## Example
 
 ![Playground example of a MMD](/img/extensions/mmdLoader/PGScreenshot.png)
-<Playground id="#028YR6#16" title="Complete MMD Example" description="Example of a MMD model with a VMD motion file and audio." />
+<Playground id="#028YR6#18" title="Complete MMD Example" description="Example of a MMD model with a VMD motion file and audio." />
 
 *Music: [メランコリ・ナイト](https://youtu.be/y__uZETTuL8) by higma*
 


### PR DESCRIPTION
Changes mmdLoader playground to use specific version of mmdLoader extension, so breaking changes to the extension don't break the example in our docs.