### PR TITLE
Update documentation with permanent solution for ./ in index.html

### DIFF
--- a/content/guidedLearning/usingVite.md
+++ b/content/guidedLearning/usingVite.md
@@ -208,7 +208,7 @@ Here's how:
 - If it's not already open as a tab, right-click on your project's folder (not the main one) and choose `Open in Integrated Terminal`. Or just click on your second Terminal tab if you still have it.
 - Run this command: `npm run build`
 - Your exported code bundle is now in a folder called `dist`. Check if it works by running: `npm run preview`
-- **IMPORTANT:** Once you verify this test works, open `dist/index.html` and look for any file paths that point to root with `/`. Add a period in front of all of those root paths (meaning `/assets` would become `./assets`) and save the file.
+- **IMPORTANT:** Once you verify this test works, open `dist/index.html` and look for any file paths that point to root with `/`. Add a period in front of all of those root paths (meaning `/assets` would become `./assets`) and save the file. For a more permanent solution, you can modify the package.json file in your project directory. Change the line: "build": "tsc && vite build" to: "build": "tsc && vite build --base=./". This will ensure that the base path is correctly set during the build process, eliminating the need to manually edit file paths in dist/index.html after each build.
 
 ![Final dist folder](/img/how_to/using-vite/11.png)
 


### PR DESCRIPTION
Added a section to the Vite.js configuration documentation to provide a more permanent solution for setting the base path during the build process. Instead of manually editing file paths in dist/index.html after each build, users can now modify the build script in package.json by adding --base=./ to the vite build command. This change simplifies the build process and reduces potential errors (404).