### PR TITLE
Update theFirstStep.md

### DIFF
--- a/content/journey/theFirstStep.md
+++ b/content/journey/theFirstStep.md
@@ -85,7 +85,7 @@ Find this line:
 groundMaterial.diffuseColor = BABYLON.Color3.Red();
 ```
 
-Replace it with these two lines and run the scene again:
+Add these two new lines underneath it and run the scene again:
 
 ```javascript
 let groundTexture = new BABYLON.Texture(Assets.textures.checkerboard_basecolor_png.path, scene);


### PR DESCRIPTION
While following the steps, removing the diffuse color line results in a different outcome than the red/black checkerboard expected. Changing instruction to add the new lines instead of replace.

What I expected as a new learner: 
<img width="291" alt="Screenshot 2024-06-03 at 8 50 44 PM" src="https://github.com/BabylonJS/Documentation/assets/15054255/f19a47d4-c1fd-4b9b-bdf7-36564fc51541">

What I saw after following the instructions as presented: 
<img width="587" alt="Screenshot 2024-06-03 at 8 51 51 PM" src="https://github.com/BabylonJS/Documentation/assets/15054255/b2925e53-048d-4b56-9033-a461f0b81165">
