### PR TITLE
Update documentationPage.module.scss

### DIFF
--- a/pages/documentationPage.module.scss
+++ b/pages/documentationPage.module.scss
@@ -67,6 +67,8 @@
     flex: 1;
     overflow: auto;
     max-width: 100%;
+    margin-top: 2rem;
+
     * {
         max-width: 920px;
     }


### PR DESCRIPTION
Fixed how the content would overlap the playground at the top of the page, blocking access to controls on some examples.

Before:

<img width="928" alt="Screenshot 2024-06-05 at 7 52 00 PM" src="https://github.com/BabylonJS/Documentation/assets/168613177/7f072dc7-9430-4159-b6c8-36e8f6b5ddb8">

After:

<img width="928" alt="Screenshot 2024-06-05 at 7 52 51 PM" src="https://github.com/BabylonJS/Documentation/assets/168613177/de4415e8-4de9-43da-a974-9ba719c42853">

