### PR TITLE
Fix pg for filtering in collisionEvents.md

### DIFF
--- a/content/features/featuresDeepDive/physics/v2/collisionEvents.md
+++ b/content/features/featuresDeepDive/physics/v2/collisionEvents.md
@@ -97,4 +97,4 @@ Note, the engine will also perform the same test with shapeA and shapeB swapped;
 
 - Logging the collision events that happen to a body: <Playground id="#Z8HTUN#613" title="Collision events" description="Logging the collision events that happen to a body"/>
 
-- Collision filtering <Playground id="#H4UR4Z" title="Collision filtering" description="Filtering collisions that happen to a body"/>
+- Collision filtering <Playground id="#H4UR4Z#1" title="Collision filtering" description="Filtering collisions that happen to a body"/>


### PR DESCRIPTION
- The mask should use a binary "or" instead of "and"
- Apply the filter to sphere2 and sphere1 instead of sphere1 every time