### PR TITLE
Update migrateFromV1.md for extra startsAsleep param in PhysicsBody

### DIFF
--- a/content/features/featuresDeepDive/physics/v2/migrateFromV1.md
+++ b/content/features/featuresDeepDive/physics/v2/migrateFromV1.md
@@ -44,7 +44,7 @@ Would become:
 ```javascript
 const sphere = BABYLON.MeshBuilder.CreateSphere("sphere", { diameter: 2, segments: 32 }, scene);
 const sphereShape = new BABYLON.PhysicsShapeSphere(new BABYLON.Vector3(0, 0, 0), 1, scene);
-const sphereBody = new BABYLON.PhysicsBody(sphere, BABYLON.PhysicsMotionType.DYNAMIC, scene);
+const sphereBody = new BABYLON.PhysicsBody(sphere, BABYLON.PhysicsMotionType.DYNAMIC, false, scene);
 sphereShape.material = { friction: 0.2, restitution: 0.3 };
 sphereBody.shape = sphereShape;
 sphereBody.setMassProperties({ mass: 1 });
@@ -54,7 +54,7 @@ The advantage of this approach is that, if you have another mesh you want to use
 
 ```javascript
 const complexModel = await BABYLON.SceneLoader.ImportMeshAsync(...);
-const body = new BABYLON.PhysicsBody(complexModel, BABYLON.PhysicsMotionType.DYNAMIC, scene);
+const body = new BABYLON.PhysicsBody(complexModel, BABYLON.PhysicsMotionType.DYNAMIC, false, scene);
 body.shape = sphereShape;
 body.setMassProperties({mass: complexModelMass});
 ```


### PR DESCRIPTION
https://doc.babylonjs.com/typedoc/classes/BABYLON.PhysicsBody

When I followed this tutorial I ended up with "cannot find property setShape of undefined' error, where undefined is the havok physicsPlugin due to it being not found in the provided scene. The tutorial puts Scene as the param where a bool startsAsleep is, causing scene to be undefined. Not having a scene param was also a silent fail, which I'm not sure if is intended or not