### PR TITLE
Add docs on loader factories, extensions, and dynamically imported loaders/extensions

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,28 @@
+{
+    // Use IntelliSense to learn about possible attributes.
+    // Hover to view descriptions of existing attributes.
+    // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "type": "msedge",
+            "request": "launch",
+            "name": "Documentation (Edge)",
+            "url": "http://localhost:3000",
+            "preLaunchTask": "Dev"
+        },
+        {
+            "type": "chrome",
+            "request": "launch",
+            "name": "Documentation (Chrome)",
+            "url": "http://localhost:3000",
+            "preLaunchTask": "Dev"
+        }
+    ],
+    "compounds": [
+        {
+            "name": "Default Launch",
+            "configurations": ["Documentation (Edge)"]
+        }
+    ]
+}

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -1,0 +1,31 @@
+{
+    // See https://go.microsoft.com/fwlink/?LinkId=733558
+    // for the documentation about the tasks.json format
+    "version": "2.0.0",
+    "tasks": [
+        {
+            "label": "Dev",
+            "type": "shell",
+            "command": "npm run dev",
+            "isBackground": true,
+            "runOptions": {
+                "instanceLimit": 1
+            },
+            "presentation": {
+                "group": "watch"
+            },
+            "problemMatcher": {
+                "pattern": "$tsc",
+                "background": {
+                    "activeOnStart": true,
+                    "beginsPattern": {
+                        "regexp": ".*Starting...",
+                    },
+                    "endsPattern": {
+                        "regexp": ".*Ready in .*ms",
+                    },
+                },
+            },
+        },
+    ],
+}

--- a/configuration/structure.json
+++ b/configuration/structure.json
@@ -649,6 +649,11 @@
                                             "friendlyName": "Progressively Load .glTF Files",
                                             "children": {},
                                             "content": "features/featuresDeepDive/importers/glTF/progressiveglTFLoad"
+                                        },
+                                        "createExtensions": {
+                                            "friendlyName": "Create Your Own glTF Extensions",
+                                            "children": {},
+                                            "content": "features/featuresDeepDive/importers/glTF/createExtensions"
                                         }
                                     },
                                     "content": "features/featuresDeepDive/importers/glTF"

--- a/content/features/featuresDeepDive/importers.md
+++ b/content/features/featuresDeepDive/importers.md
@@ -16,4 +16,4 @@ Possible file types are gLTF, splat, obj, stl.
 
 To help you with imported assets there is a manager for them.
 
-**Note:** Since meshes you import can have a _rotationQuaternion_ set before applying a rotation set the _rotationQuaternion_ to _null.
+**Note:** Since meshes you import can have a `rotationQuaternion` set before applying a rotation set the `rotationQuaternion` to `null`.

--- a/content/features/featuresDeepDive/importers.md
+++ b/content/features/featuresDeepDive/importers.md
@@ -12,7 +12,7 @@ video-content:
 
 The built in file type is `.babylon` and Babylon.js can load these without a plugin. All other file types require a plugin as described in this section.
 
-Possible file types are gLTF, splat, obj, stl.
+Possible file types are glTF, splat, obj, stl.
 
 To help you with imported assets there is a manager for them.
 

--- a/content/features/featuresDeepDive/importers.md
+++ b/content/features/featuresDeepDive/importers.md
@@ -12,8 +12,8 @@ video-content:
 
 The built in file type is `.babylon` and Babylon.js can load these without a plugin. All other file types require a plugin as described in this section.
 
-Possible file types are gLTF, obj, stl
+Possible file types are gLTF, splat, obj, stl.
 
 To help you with imported assets there is a manager for them.
 
-**Note:** Since meshes you import can have a _rotationQuaternion_ set before applying a rotation set the _rotationQuaternion_ to _null
+**Note:** Since meshes you import can have a _rotationQuaternion_ set before applying a rotation set the _rotationQuaternion_ to _null.

--- a/content/features/featuresDeepDive/importers/assetContainers.md
+++ b/content/features/featuresDeepDive/importers/assetContainers.md
@@ -34,7 +34,7 @@ container.removeAllFromScene();
 
 <Playground id="#5NFRVE#1" title="Asset Container Adding and Removing Assets" description="Simple Example of adding and removing asset container assets into your scene." image="/img/playgroundsAndNMEs/divingDeeperAssetContainer1.jpg"/>
 
-This can be used to add/remove all objects in a scene without the need to exit WebVR. <Playground id="#JA1ND3#48" title="Asset Container Adding and Removing Assets in WebVR" description="Simple Example of adding and removing asset container assets into your WebVR scene." image="/img/playgroundsAndNMEs/divingDeeperAssetContainer2.jpg"/>
+This can be used to add/remove all objects in a scene without the need to exit WebVR. <Playground id="#JA1ND3#1016" title="Asset Container Adding and Removing Assets in WebVR" description="Simple Example of adding and removing asset container assets into your WebVR scene." image="/img/playgroundsAndNMEs/divingDeeperAssetContainer2.jpg"/>
 
 When creating assets manually the moveAllFromScene method can be used to move all assets currently in a scene into an AssetContainer and remove them from the scene for later use.
 
@@ -62,7 +62,7 @@ The return entries object will contain:
 - skeletons: A list of all the skeletons created by the duplication process
 - animationGroups: A list of all the animation groups created by the duplication process
 
-<Playground id="#S7E00P" title="Instantiating Asset Container Assets" description="Simple Example of using asset containers as templates to duplicate assets in a scene." image="/img/playgroundsAndNMEs/divingDeeperAssetContainer3.jpg"/>
+<Playground id="#S7E00P#439" title="Instantiating Asset Container Assets" description="Simple Example of using asset containers as templates to duplicate assets in a scene." image="/img/playgroundsAndNMEs/divingDeeperAssetContainer3.jpg"/>
 
 You can also set two parameters to the call to `instantiateModelsToScene`:
 

--- a/content/features/featuresDeepDive/importers/createImporters.md
+++ b/content/features/featuresDeepDive/importers/createImporters.md
@@ -18,7 +18,7 @@ You can also create your own importer by providing a specific object to the `BAB
 
 A file importer should implement the `ISceneLoaderPluginAsync` interface.
 
-<Alert severity="warning" title="Warning" description="Avoid using ISceneLoaderPlugin as it is legacy and has been replaced by ISceneLoaderPluginAsync" />
+<Alert severity="warning" title="Warning" description="Avoid using ISceneLoaderPlugin as it is deprecated and has been replaced by ISceneLoaderPluginAsync" />
 
 An abbreviated example of a file importer (scene loader plugin) might look something like this:
 

--- a/content/features/featuresDeepDive/importers/glTF.md
+++ b/content/features/featuresDeepDive/importers/glTF.md
@@ -69,12 +69,24 @@ This loader supports only glTF 1.0 and will fail to load glTF 2.0.
 <script src="babylon.glTF1FileLoader.js"></script>
 ```
 
+## NPM
+
+When using the Babylon npm packages in your own build, it is preferable to register the glTF file importer via the top level dynamic loader registration function `registerBuiltInLoaders`. See [Loading Any File Type](/features/featuresDeepDive/importers/loadingFileTypes#npm) for more information.
+
+If you want to import the glTF file importer statically (not recommended), you can do so via:
+
+```javascript
+import "@babylonjs/loaders/glTF/2.0";
+```
+
+You can read more about [NPM support](/setup/frameworkPackages/npmSupport)
+
 ## Loading the Scene
 
-Use one of the static function on the `SceneLoader` to load a glTF asset.
+Use one of scene loader functions to load a glTF asset.
 See [Load from any file type](/features/featuresDeepDive/importers/loadingFileTypes).
 
-See an example here: <Playground id="#WGZLGJ" title="Load a glTF Asset" description="Simple example showing how load a .glTF asset into your scene." image="/img/playgroundsAndNMEs/divingDeeperglTF1.jpg" isMain={true} category="Import"/>
+See an example here: <Playground id="#WGZLGJ#10552" title="Load a glTF Asset" description="Simple example showing how load a .glTF asset into your scene." image="/img/playgroundsAndNMEs/divingDeeperglTF1.jpg" isMain={true} category="Import"/>
 
 ## API (Version 2)
 
@@ -84,7 +96,9 @@ See the available [properties and methods](/typedoc/classes/babylon.gltffileload
 
 ## Extensions
 
-See the available [extensions](/typedoc/modules/babylon.gltf2.loader.extensions) from the API documentation.
+See the built in [extensions](/typedoc/modules/babylon.gltf2.loader.extensions) from the API documentation.
+
+You can also [create your own extensions](/features/featuresDeepDive/importers/glTF/createExtensions).
 
 ## API (Version 1)
 
@@ -105,8 +119,3 @@ Set this property to true in order to work with homogeneous coordinates, availab
 ```javascript
 BABYLON.GLTFFileLoader.HomogeneousCoordinates = true;
 ```
-
-## Extensions
-
-[KHR_binary_glTF](https://github.com/KhronosGroup/glTF/tree/master/extensions/1.0/Khronos/KHR_binary_glTF)  
-[KHR_materials_common](https://github.com/KhronosGroup/glTF/tree/master/extensions/1.0/Khronos/KHR_materials_common)

--- a/content/features/featuresDeepDive/importers/glTF/createExtensions.md
+++ b/content/features/featuresDeepDive/importers/glTF/createExtensions.md
@@ -1,0 +1,90 @@
+---
+title: Create glTF extensions
+image:
+description: Learn about creating new glTF loader extensions.
+keywords: diving deeper, import, importing assets, asset, glTF, extensions
+further-reading:
+video-overview:
+video-content:
+---
+
+## Introduction
+
+The glTF format includes the concept of extensions. Usually glTF loader extensions map 1:1 with a corresponding glTF format extensions. However, it is possible to create custom glTF loader extensions are unrelated to glTF format extensions and simply perform some additional processing on the loaded glTF data.
+
+The glTF loader includes support for many glTF format extensions through built-in glTF loader extensions. It is also possible to create your own glTF loader extensions.
+
+## Extensions
+
+Extensions are defined by implementing the `IGLTFLoaderExtension` interface (from `@babylonjs/loaders/glTF/2.0`). An abbreviated example would look something like this:
+
+```typescript
+import { IGLTFLoaderExtension } from "@babylonjs/loaders/glTF/2.0";
+
+class MyCustomExtension implements IGLTFLoaderExtension {
+    public readonly name = "myCustomExtension";
+    public enabled = true;
+    public order = 100;
+
+    // Implement any of the optional functions, such as:
+    public loadSceneAsync(): Nullable<Promise<void>> {
+        // Modify the default behavior when loading scenes.
+    }
+}
+```
+
+## Extension Factories
+
+When you register a loader extension, you register an extension factory. The factory is a function that takes the glTF loader and returns an extension instance synchronously or asynchronously. This allows you to dynamically import your extension to avoid loading it until it is needed. A simple example might look something like this:
+
+```typescript
+import { registerGLTFExtension } from "@babylonjs/loaders/glTF/2.0";
+
+registerGLTFExtension("myCustomExtension", true, async (loader) => {
+    const { MyCustomExtension } = await import("./MyCustomExtension");
+    return new MyCustomExtension(loader);
+});
+```
+
+<Alert severity="info" title="glTF Format Extensions" description="The second parameter of registerGLTFExtension specifies whether the extension is associated with a glTF format extension. If it is, it will only be used when loading glTFs that use that extension. If it is not, it will be used when loading any glTF." />
+
+## Extension Options
+
+To expose options for your custom glTF loader extension, you should first augment the `GLTFLoaderExtensionOptions` interface to add options for your extension. For example:
+
+```typescript
+type MyCustomExtensionOptions = { option1?: string, option2?: number };
+
+declare module "@babylonjs/loaders" {
+  export interface GLTFLoaderExtensionOptions {
+    myCustomExtension: MyCustomImporterOptions;
+  }
+}
+```
+
+Then, when you register your extension, you can access the options like this:
+
+```typescript
+class MyCustomExtension implements IGLTFLoaderExtension {
+    constructor (loader: GLTFLoader) {
+        const options = loader.parent.extensionOptions["myCustomExtension"];
+    }
+}
+```
+
+Finally, these options can be passed into one of the scene loader functions like this:
+
+```typescript
+await loadAssetContainerAsync("path/to/model", scene, {
+  pluginOptions: {
+    glTF: {
+      extensionOptions: {
+        myCustomExtension: {
+          option1: "hello world",
+          option2: 42,
+        },
+      },
+    },
+  },
+});
+```

--- a/content/features/featuresDeepDive/importers/glTF/createExtensions.md
+++ b/content/features/featuresDeepDive/importers/glTF/createExtensions.md
@@ -3,7 +3,7 @@ title: Create glTF extensions
 image:
 description: Learn about creating new glTF loader extensions.
 keywords: diving deeper, import, importing assets, asset, glTF, extensions
-further-reading:
+further-reading: ["https://babylonjs.medium.com/extending-the-gltf-loader-in-babylon-js-588e48fb692b"]
 video-overview:
 video-content:
 ---

--- a/content/features/featuresDeepDive/importers/incrementalLoading.md
+++ b/content/features/featuresDeepDive/importers/incrementalLoading.md
@@ -16,7 +16,7 @@ These files can be used just like a standard _.babylon_ scene except that they w
 
 You have to put the _.babylonmeshdata_ and _.babylongeometrydata_ files in the same folder as the _.incremental.babylon_ file.
 
-You can find a demo of an incremental scene here: <Playground id="#JA1ND3#943" title="Incremental Loading Example" description="Simple Example of incremental loading assets." image="/img/playgroundsAndNMEs/divingDeeperIncrementalLoading1.jpg"/>
+You can find a demo of an incremental scene here: <Playground id="#JA1ND3#1017" title="Incremental Loading Example" description="Simple Example of incremental loading assets." image="/img/playgroundsAndNMEs/divingDeeperIncrementalLoading1.jpg"/>
 
 ## Detailed Step by step
 
@@ -45,9 +45,8 @@ For users less experienced with command line tools, here's a more detailed step 
 8. And you're ready to load it into Babylon!
 
 ```javascript
-BABYLON.SceneLoader.Append("src/", "my-scene.incremental.babylon", scene, function () {
-  console.log("My incremental file was loaded! WOHOO!");
-});
+await BABYLON.appendSceneAsync("src/my-scene.incremental.babylon", scene);
+console.log("My incremental file was loaded! WOHOO!");
 ```
 
 ## Node.js based incremental file converter

--- a/content/features/featuresDeepDive/importers/loadFromMemory.md
+++ b/content/features/featuresDeepDive/importers/loadFromMemory.md
@@ -39,7 +39,9 @@ const assetUrl = URL.createObjectURL(assetBlob);
 Then finally we load the asset into the scene from the url which points to the memory blob.
 
 ```javascript
-await BABYLON.SceneLoader.AppendAsync(assetUrl, undefined, scene, undefined, ".glb");
+await BABYLON.appendSceneAsync(assetUrl, scene, {
+    pluginExtension: ".glb"
+});
 ```
 
-It's important to note that the Babylon scene loader will use the correct loader based on the file extension of the asset you're trying to load. In this case, since we're loading binary data saved to memory, the scene loader needs to be explicitly told which loader to use. This is why the final argument in the AppendAsync method is ".glb".
+It's important to note that the Babylon scene loader will use the correct loader based on the file extension of the asset you're trying to load. In this case, since we're loading binary data saved to memory, the scene loader needs to be explicitly told which loader to use. This is why the final argument in the `appendSceneAsync` method (the options object) specifies the `pluginExtension` as `".glb"`.

--- a/content/features/featuresDeepDive/importers/loadingFileTypes.md
+++ b/content/features/featuresDeepDive/importers/loadingFileTypes.md
@@ -37,27 +37,55 @@ Currently plugins can be found for:
 - [.stl](/features/featuresDeepDive/importers/stl)
 - .splat
 
+You can also create your own [custom importer](/features/featuresDeepDive/importers/createImporters) for additional file types.
+
+#### CDN
+
 To quickly add support for all loaders the following script can be added to your page:
 
 <Alert severity="warning" title="Warning" description="The CDN should not be used in production environments. The purpose of our CDN is to serve Babylon packages to users learning how to use the platform or running small experiments. Once you've built an application and are ready to share it with the world at large, you should serve all packages from your own CDN."/>
 
-#### Production links
+##### Production links
 
 ```html
 <script src="https://cdn.babylonjs.com/babylon.js"></script>
 <script src="https://cdn.babylonjs.com/loaders/babylonjs.loaders.min.js"></script>
 ```
 
-#### Preview links (useful to test for changes to loaders)
+##### Preview links (useful to test for changes to loaders)
 
 ```html
 <script src="https://preview.babylonjs.com/babylon.js"></script>
 <script src="https://preview.babylonjs.com/loaders/babylonjs.loaders.min.js"></script>
 ```
 
-For NPM usage see: https://www.npmjs.com/package/@babylonjs/loaders
-
 Once the plugin is referenced, scene loader functions can be used to load model files.
+
+#### NPM
+
+When you have a built/bundled app, you can use https://www.npmjs.com/package/@babylonjs/loaders.
+
+The preferred way to bring in the loaders is via:
+
+```typescript
+import { registerBuiltInLoaders } from "@babylonjs/loaders/dynamic";
+...
+registerBuiltInLoaders();
+```
+
+This will register all supported loaders, but internally uses dynamic imports to only download/load a specific importer (e.g. glTF, splat, etc.) when a model of that type is first loaded.
+
+<Alert severity="warning" title="Warning" description="Note that some of the legacy loader functions (e.g. SceneLoader.Append) synchronously return the loader instance. When using dynamically imported loaders, these functions will return null." />
+
+You can also register all loaders statically (e.g. they will all be included in your primary bundle). This is not recommended, but can be done via:
+
+<Alert severity="warning" title="Warning" description="If possible, prefer registerBuiltInLoaders rather than statically importing loaders." />
+
+```typescript
+import "@babylonjs/loaders";
+```
+
+Importers must be registered with one of these approaches before the scene loader functions can be used.
 
 ## loadAssetContainerAsync
 
@@ -156,7 +184,7 @@ const assetContainer = await BABYLON.loadAssetContainerAsync("https://raw.github
         MSFT_lod: {
           maxLODsToLoad: 1,
         },
-      }
+      },
     },
   },
 });

--- a/content/features/featuresDeepDive/importers/loadingFileTypes.md
+++ b/content/features/featuresDeepDive/importers/loadingFileTypes.md
@@ -63,7 +63,7 @@ Once the plugin is referenced, scene loader functions can be used to load model 
 
 #### NPM
 
-When you have a built/bundled app, you can use https://www.npmjs.com/package/@babylonjs/loaders.
+When you have a built/bundled app, you can use [@babylonjs/loaders](https://www.npmjs.com/package/@babylonjs/loaders).
 
 The preferred way to bring in the loaders is via:
 
@@ -84,6 +84,8 @@ You can also register all loaders statically (e.g. they will all be included in 
 ```typescript
 import "@babylonjs/loaders";
 ```
+
+If you are using the UMD package, dynamic loading is not supported. Instead, you should use the static import approach. See [`babylonjs-loaders`](https://www.npmjs.com/package/babylonjs-loaders).
 
 Importers must be registered with one of these approaches before the scene loader functions can be used.
 

--- a/content/features/featuresDeepDive/importers/oBJ.md
+++ b/content/features/featuresDeepDive/importers/oBJ.md
@@ -21,13 +21,9 @@ You can find it [here](https://cdn.babylonjs.com/loaders/babylon.objFileLoader.j
 
 <Alert severity="warning" title="Warning" description="The CDN should not be used in production environments. The purpose of our CDN is to serve Babylon packages to users learning how to use the platform or running small experiments. Once you've built an application and are ready to share it with the world at large, you should serve all packages from your own CDN."/>
 
-If you are using UMD imports via NPM, you need to reference with side-effects:
+When using the Babylon npm packages in your own build, it is preferable to register the OBJ file importer via the top level dynamic loader registration function `registerBuiltInLoaders`. See [Loading Any File Type](/features/featuresDeepDive/importers/loadingFileTypes#npm) for more information.
 
-```javascript
-import "babylonjs-loaders";
-```
-
-If you wish to benefit from the tree-shakeable ES6 package, you need to reference:
+If you want to import the OBJ file importer statically (not recommended), you can do so via:
 
 ```javascript
 import "@babylonjs/loaders/OBJ/objFileLoader";

--- a/content/features/featuresDeepDive/importers/stl.md
+++ b/content/features/featuresDeepDive/importers/stl.md
@@ -21,8 +21,15 @@ To use it you just have to reference it after Babylon.js:
 <script src="babylon.stlFileLoader.js"></script>
 ```
 
-Then you can use one of the static functions on the `SceneLoader` to load.
-See [how to load from any file type](/features/featuresDeepDive/importers/loadingFileTypes)
+When using the Babylon npm packages in your own build, it is preferable to register the STL file importer via the top level dynamic loader registration function `registerBuiltInLoaders`. See [Loading Any File Type](/features/featuresDeepDive/importers/loadingFileTypes#npm) for more information.
+
+If you want to import the STL file importer statically (not recommended), you can do so via:
+
+```javascript
+import "@babylonjs/loaders/STL/stlFileLoader";
+```
+
+You can read more about [NPM support](/setup/frameworkPackages/npmSupport)
 
 By default, the STL loader swaps the Y and Z axes. To disable this behavior,
 set


### PR DESCRIPTION
Lots of updates related to recent changes for loader factories, glTF extension factories, and dynamically imported loaders and extensions.

- Added a section on using `registerBuiltInLoaders` as the way to defer downloading loader plugins / file importers until they are needed, and note that this is the preferred way to support all the built in file types.
- Update the pages on specific loader plugins to recommend using `registerBuiltInLoaders`.
- Update and flesh out the page on creating custom loader plugins / file importers (including dynamic imports for async factories and plugin options).
- Add a new page on creating custom glTF loader extensions (including dynamic imports for async factories and extension options).
- Update all the file loading pages to only reference the new module level loading functions that take options, and not the legacy `SceneLoader` static functions.
- Update all the file loading Playground examples to use the new module level loading functions.

Also included in this PR as adding VSCode tasks and a lunch.json. Ultimately this means you can just hit F5 in VSCode to build and launch the docs page in a browser locally.