### PR TITLE
fix image reference if baseUrl is defined

### DIFF
--- a/components/bucketContent.component.tsx
+++ b/components/bucketContent.component.tsx
@@ -102,14 +102,14 @@ const DivContainer = styled("div")(({ theme }) => ({
 }));
 
 export const BucketContent: FunctionComponent<IBucketContentProps> = ({ childPages, title = "Coming next", externalLinks }) => {
+    const baseUrl = useContext(BaseUrlContext);
     const bucketItems: IBucketItem[] = Object.keys(childPages || []).map((child) => {
         const childData = childPages[child].metadata;
         const title = (childData.title || child).replace(/_/g, " ");
         const link = "/" + childPages[child].id.join("/");
-        const imageUrl = getImageUrl(childData.imageUrl);
+        const imageUrl = getImageUrl(childData.imageUrl, baseUrl);
         return { title, link, imageUrl, description: childData.description };
     });
-    const baseUrl = useContext(BaseUrlContext);
     return (
         <>
             {(!!bucketItems.length || (externalLinks && !!externalLinks.length)) && (

--- a/components/bucketContent.component.tsx
+++ b/components/bucketContent.component.tsx
@@ -88,7 +88,7 @@ const SingleBucketItem: FunctionComponent<IBucketItem> = ({ link, title, imageUr
                     </CardContent>
                 </DetailsDiv>
                 <ImageContainer>
-                    <Image alt={title} src={baseUrl + imageUrl} fill={true}></Image>
+                    <Image alt={title} src={imageUrl} fill={true}></Image>
                 </ImageContainer>
             </Card>
         </StyledLink>

--- a/components/contentComponents/example.component.tsx
+++ b/components/contentComponents/example.component.tsx
@@ -90,7 +90,7 @@ export const ExampleComponent: FunctionComponent<{ example: IExampleLink; onExam
                 <Image
                     onError={(e) => {
                         // fallback to default image
-                        (e.target as HTMLImageElement).src = getImageUrl();
+                        (e.target as HTMLImageElement).src = getImageUrl(undefined, baseUrl);
                         (e.target as HTMLImageElement).alt = "Babylon.js logo";
                         (e.target as HTMLImageElement).srcset = "";
                     }}

--- a/components/layout.component.tsx
+++ b/components/layout.component.tsx
@@ -35,17 +35,17 @@ export const Layout: FunctionComponent<PropsWithChildren<IPageProps>> = ({ id, p
         }
     };
     const router = useRouter();
+    const baseDomain = useContext(BaseUrlContext);
     const { title, description, keywords, imageUrl, robots } = disableMetadataAugmentation
         ? metadata
         : {
               title: `${metadata.title} | Babylon.js Documentation`,
               description: metadata.description,
               keywords: `${metadata.keywords},${defaultKeywords}`,
-              imageUrl: getImageUrl(metadata.imageUrl),
+              imageUrl: getImageUrl(metadata.imageUrl, baseDomain),
               robots: metadata.robots || "index, follow",
           };
 
-    const baseDomain = useContext(BaseUrlContext);
     const MenuStructure = <SideMenu items={menuStructure} selected={`/${id.join("/")}`}></SideMenu>;
     const indexOfQuery = router.asPath.indexOf("?");
     const url = baseDomain + (id.indexOf("search") !== -1 || id.indexOf("playground") !== -1 ? router.asPath : indexOfQuery !== -1 ? router.asPath.substring(0, indexOfQuery) : router.asPath);

--- a/lib/frontendUtils/frontendTools.ts
+++ b/lib/frontendUtils/frontendTools.ts
@@ -4,7 +4,7 @@ export const getExampleLink = (example: Partial<IExampleLink>, full: boolean = t
     const idToUse = example.playgroundId || example.id;
     const id = idToUse ? (idToUse[0] === "#" ? idToUse : `#${idToUse}`) : "";
     // webgpu parameter. Stay safe and validate
-    const params = (example.engine && example.engine==='webgpu') ? `?${example.engine}` : '';
+    const params = example.engine && example.engine === "webgpu" ? `?${example.engine}` : "";
     switch (example.type) {
         case "nge":
             return `https://nge.babylonjs.com/${id}`;
@@ -21,8 +21,9 @@ export const getExampleImageUrl = (example: Partial<IExampleLink>) => {
     return `/img/playgroundsAndNMEs/${example.type}${idToUse.replace(/#/g, "-")}.png`;
 };
 
-export const getImageUrl = (imageUrl?: string) => {
-    return imageUrl || "/img/defaultImage.png";
+export const getImageUrl = (imageUrl?: string, baseUrl?: string) => {
+    const imgUrl = imageUrl || "/img/defaultImage.png";
+    return imgUrl.startsWith("http") ? imgUrl : baseUrl ? baseUrl + imgUrl : imgUrl;
 };
 
 export const getUrlById = (id: string[]) => {


### PR DESCRIPTION
This will prevent a lot of 404 requests to the (missing) default image when using the snapshots.