### PR TITLE
Replace raw code with built-in function

### DIFF
--- a/content/features/featuresDeepDive/Exporters/Save_Babylon.md
+++ b/content/features/featuresDeepDive/Exporters/Save_Babylon.md
@@ -31,15 +31,7 @@ function doDownload(filename, scene) {
 
   const blob = new Blob([strScene], { type: "octet/stream" });
 
-  // turn blob into an object URL; saved as a member, so can be cleaned out later
-  objectUrl = (window.webkitURL || window.URL).createObjectURL(blob);
-
-  const link = window.document.createElement("a");
-  link.href = objectUrl;
-  link.download = filename;
-  const click = document.createEvent("MouseEvents");
-  click.initEvent("click", true, false);
-  link.dispatchEvent(click);
+  BABYLON.Tools.Download(blob, filename);
 }
 ```
 
@@ -67,14 +59,6 @@ function doDownload(filename, mesh) {
 
   const blob = new Blob([strMesh], { type: "octet/stream" });
 
-  // turn blob into an object URL; saved as a member, so can be cleaned out later
-  objectUrl = (window.webkitURL || window.URL).createObjectURL(blob);
-
-  const link = window.document.createElement("a");
-  link.href = objectUrl;
-  link.download = filename;
-  const click = document.createEvent("MouseEvents");
-  click.initEvent("click", true, false);
-  link.dispatchEvent(click);
+  BABYLON.Tools.Download(blob, filename);
 }
 ```


### PR DESCRIPTION
Hi! While studying the documentation and source code, I found that the code was taken from a function that is already [written](https://github.com/BabylonJS/Babylon.js/blob/e2b436066bcc2698ba2c72d5f3d19346223522ed/packages/dev/core/src/Misc/tools.ts#L953) and used, for example, [in Devtools](https://github.com/BabylonJS/Babylon.js/blob/e2b436066bcc2698ba2c72d5f3d19346223522ed/packages/dev/inspector/src/components/actionTabs/tabs/toolsTabComponent.tsx#L305).

Maybe it would be easier and more straightforward to use it?