### PR TITLE
Add first draft documenting OpenPBR support in Babylon.js

### DIFF
--- a/configuration/structure.json
+++ b/configuration/structure.json
@@ -813,6 +813,11 @@
                                             "children": {},
                                             "content": "features/featuresDeepDive/materials/using/masterPBR"
                                         },
+                                        "OpenPBR": {
+                                            "friendlyName": "OpenPBR",
+                                            "children": {},
+                                            "content": "features/featuresDeepDive/materials/using/OpenPBR"
+                                        },
                                         "proceduralTextures": {
                                             "friendlyName": "Procedural Textures",
                                             "children": {},

--- a/content/features/featuresDeepDive/materials/using/OpenPBR.md
+++ b/content/features/featuresDeepDive/materials/using/OpenPBR.md
@@ -10,7 +10,7 @@ video-content:
 
 ## Introduction
 
-OpenPBR is an open standard developed by Autodesk and Adobe, that defines an artist friendly material model and with a focus on interoperability. Materials authored using it should have a consistent look on platforms that support OpenPBR.
+[OpenPBR](https://github.com/AcademySoftwareFoundation/OpenPBR?tab=readme-ov-file) is an open standard developed by Autodesk and Adobe, that defines an artist friendly material model and with a focus on interoperability. Materials authored using it should have a consistent look on platforms that support OpenPBR.
 
 The implementation of OpenPBR support in Babylon.js has started and its status is listed below.
 

--- a/content/features/featuresDeepDive/materials/using/OpenPBR.md
+++ b/content/features/featuresDeepDive/materials/using/OpenPBR.md
@@ -27,7 +27,7 @@ The parameters controlling the behaviour of the different parts of the material 
 
 ### Base
 
-Most of the Base group is already expected to work in Babylon.js. One notable missing element is the new [energy conserving Oren-Nayar](https://arxiv.org/abs/2410.18026) introduced for OpenPBR.
+Most of the Base group is already expected to work in Babylon.js. One notable missing element is the new [energy conserving Oren-Nayar diffuse model](https://arxiv.org/abs/2410.18026) introduced for OpenPBR.
 
 | Parameter                | Support in Babylon.js |
 | ------------------------ | --------------------- |

--- a/content/features/featuresDeepDive/materials/using/OpenPBR.md
+++ b/content/features/featuresDeepDive/materials/using/OpenPBR.md
@@ -31,10 +31,10 @@ Most of the Base group is already expected to work in Babylon.js. One notable mi
 
 | Parameter                | Support in Babylon.js |
 | ------------------------ | --------------------- |
-| `base_weight`            | Newly implemented |
-| `base_color`             | Corresponds to the `albedoColor` input |
-| `base_metalness`         | Strictly equivalent to the `metallic` input |
-| `base_diffuse_roughness` | The diffuse parameter is missing, and the implemented diffuse is a different model. |
+| `base_weight`            | Present as `PBRBaseMaterial._baseWeightTexture` and `_baseWeight` |
+| `base_color`             | Present as `PBRBaseMaterial._albedoTexture` and `_albedoColor` |
+| `base_metalness`         | Present as `PBRBaseMaterial._metallicTexture` and `_metallic` |
+| `base_diffuse_roughness` | Missing. |
 
 
 ### Specular
@@ -43,11 +43,11 @@ In OpenPBR, the specular lobe uses the F82-tint model and a new anisotropy param
 
 | Parameter                       | Support in Babylon.js |
 | ------------------------------- | --------------------- |
-| `specular_weight`               | FIXME                 |
-| `specular_color`                | FIXME                 |
-| `specular_roughness`            | Strictly equivalent to the `roughness` input |
-| `specular_roughness_anisotropy` | FIXME                 |
-| `specular_ior`                  | FIXME                 |
+| `specular_weight`               | Missing               |
+| `specular_color`                | To be evaluated       |
+| `specular_roughness`            | Present as `PBRBaseMaterial._microSurfaceTexture` and `_roughness` |
+| `specular_roughness_anisotropy` | To be evaluated       |
+| `specular_ior`                  | To be evaluated       |
 
 
 ### Transmission
@@ -56,13 +56,13 @@ In OpenPBR, Transmission represents the volume part in which scattering is limit
 
 | Parameter                             | Support in Babylon.js |
 | ------------------------------------- | --------------------- |
-| `transmission_weight`                 | FIXME                 |
-| `transmission_color`                  | FIXME                 |
-| `transmission_depth`                  | FIXME                 |
-| `transmission_scatter`                | FIXME                 |
-| `transmission_scatter_anisotropy`     | FIXME                 |
-| `transmission_dispersion_scale`       | FIXME                 |
-| `transmission_dispersion_abbe_number` | FIXME                 |
+| `transmission_weight`                 | To be evaluated       |
+| `transmission_color`                  | To be evaluated       |
+| `transmission_depth`                  | To be evaluated       |
+| `transmission_scatter`                | To be evaluated       |
+| `transmission_scatter_anisotropy`     | To be evaluated       |
+| `transmission_dispersion_scale`       | To be evaluated       |
+| `transmission_dispersion_abbe_number` | To be evaluated       |
 
 
 ### Subsurface
@@ -71,23 +71,23 @@ In OpenPBR, Subsurface represents the volume part in which scattering is strong.
 
 | Parameter                       | Support in Babylon.js |
 | ------------------------------- | --------------------- |
-| `subsurface_weight`             | FIXME                 |
-| `subsurface_color`              | FIXME                 |
-| `subsurface_radius`             | FIXME                 |
-| `subsurface_radius_scale`       | FIXME                 |
-| `subsurface_scatter_anisotropy` | FIXME                 |
+| `subsurface_weight`             | To be evaluated       |
+| `subsurface_color`              | To be evaluated       |
+| `subsurface_radius`             | To be evaluated       |
+| `subsurface_radius_scale`       | To be evaluated       |
+| `subsurface_scatter_anisotropy` | To be evaluated       |
 
 
 ### Coat
 
 | Parameter                   | Support in Babylon.js |
 | --------------------------- | --------------------- |
-| `coat_weight`               | FIXME                 |
-| `coat_color`                | FIXME                 |
-| `coat_roughness`            | FIXME                 |
-| `coat_roughness_anisotropy` | FIXME                 |
-| `coat_ior`                  | FIXME                 |
-| `coat_darkening`            | FIXME                 |
+| `coat_weight`               | Present as `PBRClearCoatConfiguration.intensity` |
+| `coat_color`                | Present as `PBRClearCoatConfiguration.tintColor` |
+| `coat_roughness`            | Present as `PBRClearCoatConfiguration.roughness` |
+| `coat_roughness_anisotropy` | Missing               |
+| `coat_ior`                  | Present as `PBRClearCoatConfiguration.indexOfRefraction` |
+| `coat_darkening`            | Missing               |
 
 
 ### Fuzz
@@ -96,9 +96,9 @@ What OpenPBR refers to as "Fuzz" is what some models call "Sheen", but expressiv
 
 | Parameter        | Support in Babylon.js |
 | ---------------- | --------------------- |
-| `fuzz_weight`    | FIXME                 |
-| `fuzz_color`     | FIXME                 |
-| `fuzz_roughness` | FIXME                 |
+| `fuzz_weight`    | To be evaluated       |
+| `fuzz_color`     | To be evaluated       |
+| `fuzz_roughness` | To be evaluated       |
 
 
 ### Emission
@@ -107,19 +107,19 @@ In OpenPBR, the emissive properties of a material are given in physical units. T
 
 | Parameter            | Support in Babylon.js |
 | -------------------- | --------------------- |
-| `emission_luminance` | FIXME                 |
-| `emission_color`     | FIXME                 |
+| `emission_luminance` | To be evaluated       |
+| `emission_color`     | To be evaluated       |
 
 
 ### Thin-film
 
-In OpenPBR, iridescence uses a thin-film model.
+In OpenPBR, iridescence uses a thin-film model. Iridescence is already supported in Babylon.js and exposes similar parameters, but the model might be different.
 
 | Parameter             | Support in Babylon.js |
 | --------------------- | --------------------- |
-| `thin_film_weight`    | FIXME                 |
-| `thin_film_thickness` | FIXME                 |
-| `thin_film_ior`       | FIXME                 |
+| `thin_film_weight`    | Present as `PBRIridescenceConfiguration.intensity` |
+| `thin_film_thickness` | Exposed as `PBRIridescenceConfiguration.thicknessTexture` with `minimumThickness` and `maximumThickness` |
+| `thin_film_ior`       | Present as `PBRIridescenceConfiguration.indexOfRefraction` |
 
 
 ### Geometry
@@ -128,9 +128,9 @@ OpenPBR only describes the material, but it expects to be given certain informat
 
 | Parameter               | Support in Babylon.js |
 | ----------------------- | --------------------- |
-| `geometry_opacity`      | FIXME                 |
-| `geometry_thin_walled`  | FIXME                 |
-| `geometry_normal`       | FIXME                 |
-| `geometry_tangent`      | FIXME                 |
-| `geometry_coat_normal`  | FIXME                 |
-| `geometry_coat_tangent` | FIXME                 |
+| `geometry_opacity`      | To be evaluated       |
+| `geometry_thin_walled`  | To be evaluated       |
+| `geometry_normal`       | To be evaluated       |
+| `geometry_tangent`      | To be evaluated       |
+| `geometry_coat_normal`  | To be evaluated       |
+| `geometry_coat_tangent` | To be evaluated       |

--- a/content/features/featuresDeepDive/materials/using/OpenPBR.md
+++ b/content/features/featuresDeepDive/materials/using/OpenPBR.md
@@ -14,6 +14,7 @@ video-content:
 
 The implementation of OpenPBR support in Babylon.js has started and its status is listed below.
 
+
 ## OpenPBR model description
 
 OpenPBR is a so-called über shader. Unlike node based or closure based models like MaterialX or MDL, which allow to describe arbitrarily complex shaders, OpenPBR has a fixed material structure. This saves valuable time because the structure is already designed (by gauging the most valuable material features to cover the majority of production needs), but is less flexible and will not cover all possible cases.
@@ -32,108 +33,108 @@ The parameters controlling the behaviour of the different parts of the material 
 
 Most of the Base group is already expected to work in Babylon.js. One notable missing element is the new [energy conserving Oren-Nayar](https://arxiv.org/abs/2410.18026) introduced for OpenPBR.
 
- Parameter                | Support in Babylon.js
---------------------------+-----------------------
- `base_weight`            | Newly implemented
- `base_color`             | Corresponds to the `albedoColor` input
- `base_metalness`         | Strictly equivalent to the `metallic` input
- `base_diffuse_roughness` | The diffuse parameter is missing, and the implemented diffuse is a different model.
+| Parameter                | Support in Babylon.js |
+| ------------------------ | --------------------- |
+| `base_weight`            | Newly implemented |
+| `base_color`             | Corresponds to the `albedoColor` input |
+| `base_metalness`         | Strictly equivalent to the `metallic` input |
+| `base_diffuse_roughness` | The diffuse parameter is missing, and the implemented diffuse is a different model. |
 
 
 ### Specular
 
 In OpenPBR, the specular lobe uses the F82-tint model and a new anisotropy parametrisation.
 
- Parameter                       | Support in Babylon.js
----------------------------------+-----------------------
- `specular_weight`               | FIXME
- `specular_color`                | FIXME
- `specular_roughness`            | Strictly equivalent to the `roughness` input
- `specular_roughness_anisotropy` | FIXME
- `specular_ior`                  | FIXME
+| Parameter                       | Support in Babylon.js |
+| ------------------------------- | --------------------- |
+| `specular_weight`               | FIXME                 |
+| `specular_color`                | FIXME                 |
+| `specular_roughness`            | Strictly equivalent to the `roughness` input |
+| `specular_roughness_anisotropy` | FIXME                 |
+| `specular_ior`                  | FIXME                 |
 
 
 ### Transmission
 
 In OpenPBR, Transmission represents the volume part in which scattering is limited or absent.
 
- Parameter                             | Support in Babylon.js
----------------------------------------+-----------------------
- `transmission_weight`                 | FIXME
- `transmission_color`                  | FIXME
- `transmission_depth`                  | FIXME
- `transmission_scatter`                | FIXME
- `transmission_scatter_anisotropy`     | FIXME
- `transmission_dispersion_scale`       | FIXME
- `transmission_dispersion_abbe_number` | FIXME
+| Parameter                             | Support in Babylon.js |
+| ------------------------------------- | --------------------- |
+| `transmission_weight`                 | FIXME                 |
+| `transmission_color`                  | FIXME                 |
+| `transmission_depth`                  | FIXME                 |
+| `transmission_scatter`                | FIXME                 |
+| `transmission_scatter_anisotropy`     | FIXME                 |
+| `transmission_dispersion_scale`       | FIXME                 |
+| `transmission_dispersion_abbe_number` | FIXME                 |
 
 
 ### Subsurface
 
 In OpenPBR, Subsurface represents the volume part in which scattering is strong.
 
- Parameter                       | Support in Babylon.js
----------------------------------+-----------------------
- `subsurface_weight`             | FIXME
- `subsurface_color`              | FIXME
- `subsurface_radius`             | FIXME
- `subsurface_radius_scale`       | FIXME
- `subsurface_scatter_anisotropy` | FIXME
+| Parameter                       | Support in Babylon.js |
+| ------------------------------- | --------------------- |
+| `subsurface_weight`             | FIXME                 |
+| `subsurface_color`              | FIXME                 |
+| `subsurface_radius`             | FIXME                 |
+| `subsurface_radius_scale`       | FIXME                 |
+| `subsurface_scatter_anisotropy` | FIXME                 |
 
 
 ### Coat
 
- Parameter                   | Support in Babylon.js
------------------------------+-----------------------
- `coat_weight`               | FIXME
- `coat_color`                | FIXME
- `coat_roughness`            | FIXME
- `coat_roughness_anisotropy` | FIXME
- `coat_ior`                  | FIXME
- `coat_darkening`            | FIXME
+| Parameter                   | Support in Babylon.js |
+| --------------------------- | --------------------- |
+| `coat_weight`               | FIXME                 |
+| `coat_color`                | FIXME                 |
+| `coat_roughness`            | FIXME                 |
+| `coat_roughness_anisotropy` | FIXME                 |
+| `coat_ior`                  | FIXME                 |
+| `coat_darkening`            | FIXME                 |
 
 
 ### Fuzz
 
 What OpenPBR refers to as "Fuzz" is what some models call "Sheen", but expressive enough to cover cases like clothes or dust.
 
- Parameter        | Support in Babylon.js
-------------------+-----------------------
- `fuzz_weight`    | FIXME
- `fuzz_color`     | FIXME
- `fuzz_roughness` | FIXME
+| Parameter        | Support in Babylon.js |
+| ---------------- | --------------------- |
+| `fuzz_weight`    | FIXME                 |
+| `fuzz_color`     | FIXME                 |
+| `fuzz_roughness` | FIXME                 |
 
 
 ### Emission
 
 In OpenPBR, the emissive properties of a material are given in physical units. This requires the renderer to handle physical light units to get a correct result.
 
- Parameter            | Support in Babylon.js
-----------------------+-----------------------
- `emission_luminance` | FIXME
- `emission_color`     | FIXME
+| Parameter            | Support in Babylon.js |
+| -------------------- | --------------------- |
+| `emission_luminance` | FIXME                 |
+| `emission_color`     | FIXME                 |
 
 
 ### Thin-film
 
 In OpenPBR, iridescence uses a thin-film model.
 
- Parameter             | Support in Babylon.js
------------------------+-----------------------
- `thin_film_weight`    | FIXME
- `thin_film_thickness` | FIXME
- `thin_film_ior`       | FIXME
+| Parameter             | Support in Babylon.js |
+| --------------------- | --------------------- |
+| `thin_film_weight`    | FIXME                 |
+| `thin_film_thickness` | FIXME                 |
+| `thin_film_ior`       | FIXME                 |
 
 
 ### Geometry
 
 OpenPBR only describes the material, but it expects to be given certain information about the geometry.
 
- Parameter               | Support in Babylon.js
--------------------------+-----------------------
- `geometry_opacity`      | FIXME
- `geometry_thin_walled`  | FIXME
- `geometry_normal`       | FIXME
- `geometry_tangent`      | FIXME
- `geometry_coat_normal`  | FIXME
- `geometry_coat_tangent` | FIXME
+| Parameter               | Support in Babylon.js |
+| ----------------------- | --------------------- |
+| `geometry_opacity`      | FIXME                 |
+| `geometry_thin_walled`  | FIXME                 |
+| `geometry_normal`       | FIXME                 |
+| `geometry_tangent`      | FIXME                 |
+| `geometry_coat_normal`  | FIXME                 |
+| `geometry_coat_tangent` | FIXME                 |

--- a/content/features/featuresDeepDive/materials/using/OpenPBR.md
+++ b/content/features/featuresDeepDive/materials/using/OpenPBR.md
@@ -19,10 +19,6 @@ The implementation of OpenPBR support in Babylon.js has started and its status i
 
 OpenPBR is a so-called über shader. Unlike node based or closure based models like MaterialX or MDL, which allow to describe arbitrarily complex shaders, OpenPBR has a fixed material structure. This saves valuable time because the structure is already designed (by gauging the most valuable material features to cover the majority of production needs), but is less flexible and will not cover all possible cases.
 
-In OpenPBR, a surface material is considered to be made of "slabs", that can be mixed or layered. The slabs that compose the OpenPBR are organised as shown in this diagram from the official documentation:
-
-FIXME: diagram
-
 
 ## OpenPBR support in Babylon.js
 

--- a/content/features/featuresDeepDive/materials/using/OpenPBR.md
+++ b/content/features/featuresDeepDive/materials/using/OpenPBR.md
@@ -1,0 +1,139 @@
+---
+title: OpenPBR
+image:
+description: Read about the support of OpenPBR in Babylon.js and learn about its features.
+keywords: diving deeper, materials, PBR, Physically Based Rendering, OpenPBR
+further-reading:
+video-overview:
+video-content:
+---
+
+## Introduction
+
+OpenPBR is an open standard developed by Autodesk and Adobe, that defines an artist friendly material model and with a focus on interoperability. Materials authored using it should have a consistent look on platforms that support OpenPBR.
+
+The implementation of OpenPBR support in Babylon.js has started and its status is listed below.
+
+## OpenPBR model description
+
+OpenPBR is a so-called über shader. Unlike node based or closure based models like MaterialX or MDL, which allow to describe arbitrarily complex shaders, OpenPBR has a fixed material structure. This saves valuable time because the structure is already designed (by gauging the most valuable material features to cover the majority of production needs), but is less flexible and will not cover all possible cases.
+
+In OpenPBR, a surface material is considered to be made of "slabs", that can be mixed or layered. The slabs that compose the OpenPBR are organised as shown in this diagram from the official documentation:
+
+FIXME: diagram
+
+
+## OpenPBR support in Babylon.js
+
+The parameters controlling the behaviour of the different parts of the material are organised in groups: Base, Specular, Transmission, Subsurface, Coat, Fuzz, Emission, Thin-film, Geometry.
+
+
+### Base
+
+Most of the Base group is already expected to work in Babylon.js. One notable missing element is the new [energy conserving Oren-Nayar](https://arxiv.org/abs/2410.18026) introduced for OpenPBR.
+
+ Parameter                | Support in Babylon.js
+--------------------------+-----------------------
+ `base_weight`            | Newly implemented
+ `base_color`             | Corresponds to the `albedoColor` input
+ `base_metalness`         | Strictly equivalent to the `metallic` input
+ `base_diffuse_roughness` | The diffuse parameter is missing, and the implemented diffuse is a different model.
+
+
+### Specular
+
+In OpenPBR, the specular lobe uses the F82-tint model and a new anisotropy parametrisation.
+
+ Parameter                       | Support in Babylon.js
+---------------------------------+-----------------------
+ `specular_weight`               | FIXME
+ `specular_color`                | FIXME
+ `specular_roughness`            | Strictly equivalent to the `roughness` input
+ `specular_roughness_anisotropy` | FIXME
+ `specular_ior`                  | FIXME
+
+
+### Transmission
+
+In OpenPBR, Transmission represents the volume part in which scattering is limited or absent.
+
+ Parameter                             | Support in Babylon.js
+---------------------------------------+-----------------------
+ `transmission_weight`                 | FIXME
+ `transmission_color`                  | FIXME
+ `transmission_depth`                  | FIXME
+ `transmission_scatter`                | FIXME
+ `transmission_scatter_anisotropy`     | FIXME
+ `transmission_dispersion_scale`       | FIXME
+ `transmission_dispersion_abbe_number` | FIXME
+
+
+### Subsurface
+
+In OpenPBR, Subsurface represents the volume part in which scattering is strong.
+
+ Parameter                       | Support in Babylon.js
+---------------------------------+-----------------------
+ `subsurface_weight`             | FIXME
+ `subsurface_color`              | FIXME
+ `subsurface_radius`             | FIXME
+ `subsurface_radius_scale`       | FIXME
+ `subsurface_scatter_anisotropy` | FIXME
+
+
+### Coat
+
+ Parameter                   | Support in Babylon.js
+-----------------------------+-----------------------
+ `coat_weight`               | FIXME
+ `coat_color`                | FIXME
+ `coat_roughness`            | FIXME
+ `coat_roughness_anisotropy` | FIXME
+ `coat_ior`                  | FIXME
+ `coat_darkening`            | FIXME
+
+
+### Fuzz
+
+What OpenPBR refers to as "Fuzz" is what some models call "Sheen", but expressive enough to cover cases like clothes or dust.
+
+ Parameter        | Support in Babylon.js
+------------------+-----------------------
+ `fuzz_weight`    | FIXME
+ `fuzz_color`     | FIXME
+ `fuzz_roughness` | FIXME
+
+
+### Emission
+
+In OpenPBR, the emissive properties of a material are given in physical units. This requires the renderer to handle physical light units to get a correct result.
+
+ Parameter            | Support in Babylon.js
+----------------------+-----------------------
+ `emission_luminance` | FIXME
+ `emission_color`     | FIXME
+
+
+### Thin-film
+
+In OpenPBR, iridescence uses a thin-film model.
+
+ Parameter             | Support in Babylon.js
+-----------------------+-----------------------
+ `thin_film_weight`    | FIXME
+ `thin_film_thickness` | FIXME
+ `thin_film_ior`       | FIXME
+
+
+### Geometry
+
+OpenPBR only describes the material, but it expects to be given certain information about the geometry.
+
+ Parameter               | Support in Babylon.js
+-------------------------+-----------------------
+ `geometry_opacity`      | FIXME
+ `geometry_thin_walled`  | FIXME
+ `geometry_normal`       | FIXME
+ `geometry_tangent`      | FIXME
+ `geometry_coat_normal`  | FIXME
+ `geometry_coat_tangent` | FIXME


### PR DESCRIPTION
This PR adds to the documentation a page about OpenPBR, serving 3 purposes:
- Document the use of OpenPBR in Babylon.js
- Document the state of the implementation of OpenPBR support
- Document the remaining task for full support of OpenPBR