### PR TITLE
TexturePacker: Use new BabylonJS exporters instead of generic

### DIFF
--- a/content/features/featuresDeepDive/sprites/packed_manager.md
+++ b/content/features/featuresDeepDive/sprites/packed_manager.md
@@ -17,7 +17,12 @@ A packed spritesheet will look something like this
 
 with sprite cells of different sizes arranged to optimize the file size.
 
-The corresponding JSON file will have the format which is based on that produced using the _TexturePacker_ app with output file framework set to JSON Hash format and Trim to None and Allow Rotation to Off. A frame is another way of talking about a cell.
+The corresponding JSON file will have the format which is based on that produced using the [TexturePacker](https://www.codeandweb.com/texturepacker) app with the following settings:
+
+- Data format: *Babylon.js (JSON Hash for SpritePackedManager)* 
+- Trim: None
+- Allow Rotation: Off
+
 
 ```javascript
 {   "frames": {
@@ -62,7 +67,7 @@ The corresponding JSON file will have the format which is based on that produced
 }
 ```
 
-**Note:** *SpriteMap* uses the JSON Array format for packed spritesheets. JSON files are not interchangeable between *SpritePackedManager* and *SpritMap*.
+**Note:** *SpriteMap* uses the *Babylon.js (JSON Array for SpriteMap)* format for packed spritesheets. JSON files are not interchangeable between *SpritePackedManager* and *SpritMap*.
 
 The minimal format required by *SpritePackedManager* is below. Although currently it only uses the frame property it may be able to use others in the future. 
 

--- a/content/features/featuresDeepDive/sprites/sprite_map.md
+++ b/content/features/featuresDeepDive/sprites/sprite_map.md
@@ -17,7 +17,7 @@ A  sprite map is displayed on a standard plane mesh in 3D space. and has the abi
 
 Since the plane is split into a grid of tiles of the same size the cells of the packed spritesheet should be of the same size.
 
-It uses the full JSON Array format of _TexturePacker_ and benefits from using the properties, rotation, extrude and padding.  *Soon the trim support will be functional as well*
+It uses the *Babylon.js (JSON Array for SpriteMap)* format of [TexturePacker](https://www.codeandweb.com/texturepacker) and benefits from using the properties, rotation, extrude and padding.  *Soon the trim support will be functional as well*
 
 **Note:** *SpritePackedManager* uses the JSON Hash format for packed spritesheets. JSON files are not interchangeable between *SpritePackedManager* and *SpritMap*.
 


### PR DESCRIPTION
With the latest release of TexturePacker, we now offer direct support for Babylon.js, eliminating the need to rely on generic formats.

 This makes it easier for users to find the appropriate exporter while allowing us to implement improvements and modifications without risking compatibility with other frameworks.

Additionally, in an upcoming release, we plan to refine our exporters further. They will only include full information for Sprite Packed Manager when necessary, while exporting frames in a more optimized, "reduced" format by default.

This change to the docs should encourage users to use the new exporters.

<img width="521" alt="Screenshot 2025-03-06 at 14 29 08" src="https://github.com/user-attachments/assets/35183460-2aa6-439b-bb24-60185bc22dc1" />
