### PR TITLE
Fixed reversed Img & Title in markdown components H2Image & H3Image

### DIFF
--- a/components/markdownComponents/tableOfContentItem.component.tsx
+++ b/components/markdownComponents/tableOfContentItem.component.tsx
@@ -45,7 +45,6 @@ export const TOCMarkdownComponent: FunctionComponent<ITableOfContentsItem> = (it
             case 1:
                 return (
                     <>
-                        {item.image && <img src={baseUrl + item.image} alt={item.alt || item.title} id={id} />}
                         <Box
                             component="h2"
                             sx={{
@@ -77,12 +76,12 @@ export const TOCMarkdownComponent: FunctionComponent<ITableOfContentsItem> = (it
                                 </IconButton>
                             )}
                         </Box>
+                        {item.image && <img src={baseUrl + item.image} alt={item.alt || item.title} id={id} />}
                     </>
                 );
             case 2:
                 return (
                     <>
-                        {item.image && <img src={baseUrl + item.image} alt={item.alt || item.title} id={id} />}
                         <Box
                             sx={{
                                 position: "relative",
@@ -114,6 +113,7 @@ export const TOCMarkdownComponent: FunctionComponent<ITableOfContentsItem> = (it
                                 </IconButton>
                             )}
                         </Box>
+                        {item.image && <img src={baseUrl + item.image} alt={item.alt || item.title} id={id} />}
                     </>
                 );
             case 3:


### PR DESCRIPTION
```markdown
<H3Image title="Tangents" image="/img/tools/nge/tangentsNode.jpg" alt="Tangents node"/>
```
Tangents `Img` comes before its `Title`, and seems linked to the text above which is about the Potisions Node :warning:

![image](https://github.com/user-attachments/assets/ff2c8a01-c81f-4034-8ec9-cd290ffbc5d8)
___
After this fix :

![image](https://github.com/user-attachments/assets/8c81709c-30b8-4ff7-a7d9-5b2d8dae7c07)
