### PR TITLE
Removing non-working demo

### DIFF
--- a/content/communityExtensions/amp360Video.md
+++ b/content/communityExtensions/amp360Video.md
@@ -18,7 +18,7 @@ The [Azure media player](http://amp.azure.net/libs/amp/latest/docs/index.html) 3
 
 The plugin natively supports VR headsets (Windows Mixed Reality, etc.).
 
-[Online Demo of the plugin](https://www.babylonjs.com/Demos/Amp360Video/)
+<!-- [Online Demo of the plugin](https://www.babylonjs.com/Demos/Amp360Video/) -->
 
 ## How to Run Locally
 

--- a/content/communityExtensions/amp360Video.md
+++ b/content/communityExtensions/amp360Video.md
@@ -18,7 +18,7 @@ The [Azure media player](http://amp.azure.net/libs/amp/latest/docs/index.html) 3
 
 The plugin natively supports VR headsets (Windows Mixed Reality, etc.).
 
-<!-- [Online Demo of the plugin](https://www.babylonjs.com/Demos/Amp360Video/) -->
+{/* [Online Demo of the plugin](https://www.babylonjs.com/Demos/Amp360Video/) */}
 
 ## How to Run Locally
 


### PR DESCRIPTION
Until we find an open-source video we can host and use here, the demo is not working.  Related to https://github.com/BabylonJS/Website/issues/715 , but not closing it.