### PR TITLE
Update glTF loader loading codecs locally section

### DIFF
--- a/content/features/featuresDeepDive/importers/glTF.md
+++ b/content/features/featuresDeepDive/importers/glTF.md
@@ -159,7 +159,7 @@ Though deprecated, Babylon maintains a dedicated glTF loader plugin for glTF 1.0
 
 ### Properties
 
-#### IncrementalLoading
+##### IncrementalLoading
 
 Set this property to false to disable incremental loading which delays the loader from calling the success callback until after loading the meshes and shaders. Textures always loads asynchronously. For example, the success callback can compute the bounding information of the loaded meshes when incremental loading is disabled. Defaults to true.
 
@@ -167,7 +167,7 @@ Set this property to false to disable incremental loading which delays the loade
 BABYLON.GLTFFileLoader.IncrementalLoading = false;
 ```
 
-#### HomogeneousCoordinates
+##### HomogeneousCoordinates
 
 Set this property to true in order to work with homogeneous coordinates, available with some converters and exporters. Defaults to false.
 

--- a/content/features/featuresDeepDive/importers/glTF.md
+++ b/content/features/featuresDeepDive/importers/glTF.md
@@ -59,7 +59,7 @@ This behavior can lead to issues like GDPR compliance concerns or CSP violations
 
 How you do this depends on your setup. In general, there are two approaches.
 
-##### 1. Via URL Configuration
+#### Via URL Configuration
 
 1. Obtain the decoder files. You can either:
    - Download them directly from the Babylon CDN at `https://cdn.babylonjs.com/[FILENAME]`, or
@@ -90,7 +90,7 @@ KhronosTextureContainer2.URLConfig = {
 };
 ```
 
-##### 2. Via Resource Injection
+#### Via Resource Injection
 
 Alternatively, you can inject the decoder modules directly (or workers preloaded with them) instead of relying on Babylon to fetch them.
 Follow the steps in the [ESM/NPM Support docs](https://doc.babylonjs.com/setup/frameworkPackages/es6Support/#ktx2-decoder-packages) to set this up with the KTX2 and Draco decoders. (_Note: Meshopt compression does not yet support injection._)
@@ -159,7 +159,7 @@ Though deprecated, Babylon maintains a dedicated glTF loader plugin for glTF 1.0
 
 ### Properties
 
-##### IncrementalLoading
+#### IncrementalLoading
 
 Set this property to false to disable incremental loading which delays the loader from calling the success callback until after loading the meshes and shaders. Textures always loads asynchronously. For example, the success callback can compute the bounding information of the loaded meshes when incremental loading is disabled. Defaults to true.
 
@@ -167,7 +167,7 @@ Set this property to false to disable incremental loading which delays the loade
 BABYLON.GLTFFileLoader.IncrementalLoading = false;
 ```
 
-##### HomogeneousCoordinates
+#### HomogeneousCoordinates
 
 Set this property to true in order to work with homogeneous coordinates, available with some converters and exporters. Defaults to false.
 

--- a/content/features/featuresDeepDive/importers/glTF.md
+++ b/content/features/featuresDeepDive/importers/glTF.md
@@ -110,7 +110,7 @@ You can also [create your own extensions](/features/featuresDeepDive/importers/g
 
 ## Options
 
-Each of the scene loader functions accepts an options object, where you can customize the behavior of the glTF loader plugin. See the [full list of available glTF options](typedoc/classes/BABYLON.GLTFLoaderOptions) from the API documentation.
+Each of the scene loader functions accepts an options object, where you can customize the behavior of the glTF loader plugin. See the [full list of available glTF options](/typedoc/classes/BABYLON.GLTFLoaderOptions) from the API documentation.
 
 ### Disabling Extensions
 

--- a/content/features/featuresDeepDive/importers/glTF.md
+++ b/content/features/featuresDeepDive/importers/glTF.md
@@ -40,19 +40,60 @@ import "@babylonjs/loaders/glTF/2.0";
 
 You can read more about [NPM support](/setup/frameworkPackages/npmSupport).
 
-### Loading codecs locally
+### Loading Codecs Locally
 
-By default, the glTF loader will request additional files for [draco compression](https://google.github.io/draco/) from _cdn.babylonjs.com_. In case you want to deliver these files locally (e.g. for GDPR compliance), you can set the [DracoDecoder.DefaultConfiguration](https://doc.babylonjs.com/typedoc/classes/BABYLON.DracoDecoder) object to use local files:
+If your glTF files use any of the following features, you'll need to take a few extra steps for production use.
+
+| Feature                               | glTF extension             | Babylon interface        |
+| ------------------------------------- | -------------------------- | ------------------------ |
+| Draco compression                     | KHR_mesh_draco_compression | DracoDecoder             |
+| Meshopt compression                   | EXT_meshopt_compression    | MeshoptCompression       |
+| .ktx2, or Basis Universal Compression | KHR_texture_basisu         | KhronosTextureContainer2 |
+
+<br/>
+Babylon performs extra work at load time to decompress the data that uses these extensions. By default, it will:
+- Download the required decoder files from the Babylon CDN.
+- Use web workers (if available) to execute the code.
+
+This behavior can lead to issues like GDPR compliance concerns or CSP violations, so we recommend hosting these resources yourself.
+
+How you do this depends on your setup. In general, there are two approaches.
+
+##### 1. Via URL Configuration
+
+1. Obtain the decoder files. You can either:
+   - Download them directly from the Babylon CDN at `https://cdn.babylonjs.com/[FILENAME]`, or
+   - (Draco only) Copy them from @babylonjs/core/assets/Draco/\[FILENAME\] during your build process.
+2. Host these files from your own app (for example, in a /public folder).
+3. Configure the URLs so Babylon loads them from your server instead of the CDN.
 
 ```typescript
 DracoDecoder.DefaultConfiguration = {
-  wasmUrl: "/babylon-draco-files/draco_wasm_wrapper_gltf.js",
-  wasmBinaryUrl: "/babylon-draco-files/draco_decoder_gltf.wasm",
-  fallbackUrl: "/babylon-draco-files/draco_decoder_gltf.js",
+  wasmUrl: localPath + "/draco_wasm_wrapper_gltf.js",
+  wasmBinaryUrl: localPath + "/draco_decoder_gltf.wasm",
+  fallbackUrl: localPath + "/draco_decoder_gltf.js",
+};
+
+MeshoptCompression.Configuration.decoder = {
+  url: localPath + "/meshopt_decoder.js",
+};
+
+KhronosTextureContainer2.URLConfig = {
+  jsDecoderModule: localPath + "/babylon.ktx2Decoder.js",
+  wasmUASTCToASTC: localPath + "/ktx2Transcoders/1/uastc_astc.wasm",
+  wasmUASTCToBC7: localPath + "/ktx2Transcoders/1/uastc_bc7.wasm",
+  wasmUASTCToRGBA_UNORM: localPath + "/ktx2Transcoders/1/uastc_rgba8_unorm_v2.wasm",
+  wasmUASTCToRGBA_SRGB: localPath + "/ktx2Transcoders/1/uastc_rgba8_srgb_v2.wasm",
+  jsMSCTranscoder: localPath + "/ktx2Transcoders/1/msc_basis_transcoder.js",
+  wasmMSCTranscoder: localPath + "/ktx2Transcoders/1/msc_basis_transcoder.wasm",
+  wasmZSTDDecoder: localPath + "/zstddec.wasm",
 };
 ```
 
-Be sure to download the files first (from `https://cdn.babylonjs.com/[FILENAME]`) and put them in a local path (`public/babylon-draco-files`, in this case).
+##### 2. Via Resource Injection
+
+Alternatively, you can inject the decoder modules directly (or workers preloaded with them) instead of relying on Babylon to fetch them.
+Follow the steps in the [ESM/NPM Support docs](https://doc.babylonjs.com/setup/frameworkPackages/es6Support/#ktx2-decoder-packages) to set this up with the KTX2 and Draco decoders. (_Note: Meshopt compression does not yet support injection._)
 
 ## Loading the Scene
 


### PR DESCRIPTION
This PR emphasizes the need to setup local resources for glTF extensions surrounding compression, and lists the available ways to do so.

Some nits:
- A bad link
- Demote Version 1 properties titles so they don't appear in table of contents