### PR TITLE
Updating PG search to handle PG 2 manifest

### DIFF
--- a/components/contentComponents/playgroundSearchResult.tsx
+++ b/components/contentComponents/playgroundSearchResult.tsx
@@ -28,6 +28,7 @@ export interface IPlaygroundSearchResult {
 
 const MaxLineLength = 200;
 const NumberOfLinesToShow = 10;
+const CodeNotFound = -1;
 
 export const PlaygroundSearchResult: FunctionComponent<{ searchResult: IPlaygroundSearchResult; type: SearchType; term?: string; setActiveExample: (example: IExampleLink) => void }> = ({ searchResult, type, term, setActiveExample }) => {
     const theme = useTheme();
@@ -102,7 +103,7 @@ export const PlaygroundSearchResult: FunctionComponent<{ searchResult: IPlaygrou
 
                 // When not searching for code, just show the beginning of the first file
                 if (type !== "code") {
-                    TrimLinesAndShow(filesCode.length ? filesCode[0][1].split("\n") : [], 0, -1);
+                    TrimLinesAndShow(filesCode.length ? filesCode[0][1].split("\n") : [], 0, CodeNotFound);
                     return;
                 }
 
@@ -123,7 +124,7 @@ export const PlaygroundSearchResult: FunctionComponent<{ searchResult: IPlaygrou
                     for (foundLine = 0; foundLine < codeLines.length; ++foundLine) {
                         if (codeLines[foundLine].toLowerCase().indexOf(lowerTerm) !== -1) {
                             codeFound = true;
-                            startingLine = Math.max(foundLine - 5, 0);
+                            startingLine = Math.max(foundLine - Math.round(NumberOfLinesToShow / 2), 0);
                             foundFile = filename;
                             break;
                         }
@@ -143,7 +144,7 @@ export const PlaygroundSearchResult: FunctionComponent<{ searchResult: IPlaygrou
                 } else {
                     // Couldn't find the exact code in the snippet, but search thought it was relevant,
                     // so we still show the beginning of the first file
-                    TrimLinesAndShow(filesCode.length ? filesCode[0][1].split("\n") : [], 0, -1);
+                    TrimLinesAndShow(filesCode.length ? filesCode[0][1].split("\n") : [], 0, CodeNotFound);
                 }
             });
         });

--- a/components/contentComponents/playgroundSearchResult.tsx
+++ b/components/contentComponents/playgroundSearchResult.tsx
@@ -110,7 +110,10 @@ export const PlaygroundSearchResult: FunctionComponent<{ searchResult: IPlaygrou
                 }
                 
                 if (codeFound) {
-                    setName(`${searchResult.name ? searchResult.name : searchResult.id} - ${foundFile}`);
+                    if (foundFile !== "default") {
+                        setName(name + ` - ${foundFile}`);
+                    }
+
                     setCodeToShow({
                         code: codeLines.slice(startingLine, startingLine + 10).join("\n"),
                         startingLine,

--- a/components/contentComponents/playgroundSearchResult.tsx
+++ b/components/contentComponents/playgroundSearchResult.tsx
@@ -58,12 +58,15 @@ export const PlaygroundSearchResult: FunctionComponent<{ searchResult: IPlaygrou
 
                 let v2Manifest = { files: { default: "" } };
                 try {
+                    // With the PG V2, instead of just having code as with PG V1, we have a list of file names
+                    // and the code associated with it, which are also JSON stringified
                     v2Manifest = JSON.parse(parsed.code);
                 } catch (e) {
-                    // This was not a V2 PG manifest, use as is
+                    // If parsing the JSON failed, it means it's a PG V1 snippet, so we just read the code directly
                     v2Manifest.files.default = parsed.code;
                 }
 
+                // Put the files and their code into a list for easier access
                 for (const [filename, code] of Object.entries(v2Manifest.files)) {
                     if (code && typeof code === 'string') {
                         filesCode.push([filename, code]);
@@ -120,7 +123,8 @@ export const PlaygroundSearchResult: FunctionComponent<{ searchResult: IPlaygrou
                         foundLine,
                     });
                 } else {
-                    // Couldn't find the exact code, still show the first 10 lines of the first file
+                    // Couldn't find the exact code in the snippet, but search thought it was relevant,
+                    // so we still show the first 10 lines of the first file
                     setCodeToShow({
                         code: filesCode.length ? filesCode[0][1].split("\n").slice(0, 10).join("\n") : "",
                         startingLine: 0,

--- a/components/contentComponents/playgroundSearchResult.tsx
+++ b/components/contentComponents/playgroundSearchResult.tsx
@@ -58,11 +58,15 @@ export const PlaygroundSearchResult: FunctionComponent<{ searchResult: IPlaygrou
 
                 let v2Manifest = { files: { default: "" } };
                 try {
-                    // With the PG V2, instead of just having code as with PG V1, we have a list of file names
-                    // and the code associated with it, which are also JSON stringified
-                    v2Manifest = JSON.parse(parsed.code);
+                    // Starting with PG V2, the manifest contains now a version and a list of files
+                    // instead of just having code as with PG V1
+                    if (parsed.version) {
+                        v2Manifest = JSON.parse(parsed.code);
+                    } else { // PG V1
+                        v2Manifest.files.default = parsed.code;
+                    }
                 } catch (e) {
-                    // If parsing the JSON failed, it means it's a PG V1 snippet, so we just read the code directly
+                    // If parsing the JSON failed, treat it as code just in case
                     v2Manifest.files.default = parsed.code;
                 }
 

--- a/components/contentComponents/playgroundSearchResult.tsx
+++ b/components/contentComponents/playgroundSearchResult.tsx
@@ -66,6 +66,7 @@ export const PlaygroundSearchResult: FunctionComponent<{ searchResult: IPlaygrou
                     const visible: string[] = [];
                     for (let i = clampedStart; i < clampedEnd; ++i) {
                         let line = allLines[i] ?? "";
+                        // Long lines get trimmed because some playgrounds contain base64 strings textures and other objects
                         if (line.length > MaxLineLength) {
                             line = line.substring(0, MaxLineLength) + " ...";
                         }
@@ -122,6 +123,11 @@ export const PlaygroundSearchResult: FunctionComponent<{ searchResult: IPlaygrou
                     const lowerTerm = term.toLowerCase();
                     
                     for (foundLine = 0; foundLine < codeLines.length; ++foundLine) {
+                        // Long lines get trimmed because some playgrounds contain base64 strings textures and other objects
+                        if (codeLines[foundLine].length > MaxLineLength) {
+                            codeLines[foundLine] = `${codeLines[foundLine].substring(0, MaxLineLength)}...`;
+                        }
+
                         if (codeLines[foundLine].toLowerCase().indexOf(lowerTerm) !== -1) {
                             codeFound = true;
                             startingLine = Math.max(foundLine - Math.round(NumberOfLinesToShow / 2), 0);


### PR DESCRIPTION
This PR updates the Playground search page to handle the new manifest that the Playground V2 uses (from this PR: https://github.com/BabylonJS/Babylon.js/pull/17175).

The schema of the manifest of the PG V2 is defined as:
```
export type V2Manifest = {
    v: 2;
    language: "JS" | "TS";
    entry: string;
    imports: Record<string, string>;
    files: Record<string, string>;
    cdnBase?: string;
};
```

For search, we care about the _files_ property, which contains pairs with the name of the file and the code of the file. Most of the parsing changes are related to dealing with the fact that now there are multiple files to search in a PG and to surface the name of the file where the code is found (if we are searching by Code).

All search behavior is identical for V1 and V2, except for the following changes: 
- If the playground is a V2 playground, when searching for code with an exact match the name of the file will be printed with the results:
<img width="1869" height="1069" alt="image" src="https://github.com/user-attachments/assets/72d96489-08e8-41ae-a065-08c3dee4abbf" />
- Ellipsis in the code are removed for long lines, this is done to simplify the code that handles finding the correct line and the current page handles long lines correctly by wrapping the lines.