### PR TITLE
Fix build warnings

### DIFF
--- a/lib/buildUtils/typedoc.utils.ts
+++ b/lib/buildUtils/typedoc.utils.ts
@@ -139,7 +139,8 @@ export const getAPIPageData = async (id: string[], baseLocation: string = "typed
     let filename = `${basePath}${sep}files${sep}${id.join(sep)}.html`;
     const allLowerCase = id.every((i) => i.toLowerCase() === i);
     if (allLowerCase && id.length > 1) {
-        glob.sync(path.relative(path.resolve("."), path.resolve(filename)).replace(/\\/g, "/"), { nocase: true }).forEach((f) => {
+        const relPattern = path.relative(basePath, filename).replace(/\\/g, "/");
+        glob.sync(relPattern, { nocase: true, cwd: basePath }).forEach((f) => {
             filename = f.substring(f.indexOf(id[0]));
         });
         return {

--- a/next.config.js
+++ b/next.config.js
@@ -3,6 +3,9 @@
 const withMDX = require("@next/mdx")();
 module.exports = withMDX({
     output: "export",
+    outputFileTracingExcludes: {
+        "*": ["./.temp/**"],
+    },
     sassOptions: {
         includePaths: ["./styles"],
         silenceDeprecations: ["legacy-js-api"],


### PR DESCRIPTION
Address build warnings by updating file path handling and excluding temporary files from output tracing.