### PR TITLE
docs: refresh Babylon.js monorepo contribution guide

### DIFF
--- a/content/contribute/toBabylon/HowToContribute.md
+++ b/content/contribute/toBabylon/HowToContribute.md
@@ -110,7 +110,7 @@ Before embarking on editing or adding to Babylon.js please make sure you are fam
 
 Please note that some of these are checked on submission automatically by software, including
 
-- The addition of comments to your code as described [here](/contribute/toBabylon/contributeToAPI);
+- The addition of comments to your code as described in [Contribute to the API](/contribute/toBabylon/contributeToAPI);
 - Consistent coding style (linting).
 
 ### Editing with Visual Studio Code
@@ -161,15 +161,7 @@ git commit file1.ts file2.ts file3.ts -m "Description of Changes"
 
 Node.js and npm can be installed from the [Node.js home page](https://nodejs.org/en/).
 
-The package manager npm is updated regularly and often to test Babylon.js you will need the latest v8 version. To update to the latest v8 version in your CLI:
-
-```bash
-npm install -g npm@8.x
-```
-
-the `g` installs npm globally so you can use it in any folder.
-
-Note that we currently don't support npm v6.x or under.
+Babylon.js currently requires Node.js `>=20.11.0 <23.0.0` and npm `>=8.0.0`.
 
 To check your npm and node version after node was installed:
 
@@ -184,7 +176,7 @@ run `npm install` in the main directory. This will build everything needed to ge
 
 It is recommended to run `npm run build:dev` before starting to work to make sure everything is in the right place.
 
-Using VSCode? Install the recommended extensions and start `Run and Watch Dev Host` to compile and get started with the esm dev host. TO use the classic UMD-based development (and have the BABYLON namespace available), run `Run and Watch Babylon Server`.
+Using VSCode? Install the recommended extensions and start `Run and Watch Dev Host (Dev)` to compile and get started with the esm dev host. To use the classic UMD-based development (and have the BABYLON namespace available), run `CDN Serve and watch (Dev)`.
 
 To build the dev sources, shaders, and assets, run `npm run build:dev`.
 
@@ -208,7 +200,7 @@ Using command line:
 - run `npm run watch:dev` (If you want to make changes to the dev packages. Otherwise run `npm run build:dev`)
 - run `npm run serve -w @tools/babylon-server` in a new terminal window
 
-The Babylon server offers 2 variants - js and ts. To load the js version (the default one) navigate to http://localhost:1337. To use the TS version navigate to http://localhost:1337/index-ts.html.
+The Babylon server offers 2 variants - js and ts. To load the js version (the default one) navigate to [http://localhost:1337](http://localhost:1337). To use the TS version navigate to [http://localhost:1337/index-ts.html](http://localhost:1337/index-ts.html).
 The files to edit are sceneJs.js and sceneTs.ts in the source folder of the Babylon server package.
 
 As described in the next section, the Babylon server also offers a playground-snippet debugging.
@@ -360,11 +352,11 @@ _Hint_: You may need to refresh the code before adding back a new breakpoint.
 
 ## Repository structure
 
-The repository is built similar to a mono-repo. Every package has its own package.json and can be used independently, of course taking its dependencies into account.
+The repository is a monorepo. Every package has its own package.json and can be used independently, taking its dependencies into account.
 
-Packages in `dev` and `lts` are composites ([https://www.typescriptlang.org/tsconfig#composite](https://www.typescriptlang.org/tsconfig#composite)) and can compile using a single command if needed. When watching, dependent packages will be automatically compiled as well, when needed.
+Packages under `packages/dev` can be compiled together using the root TypeScript build, and dependent packages will be rebuilt automatically when needed.
 
-All packages (with the exception of public es6 packages) have the same basic structure:
+Most packages share the same basic structure:
 
 - src folder holds typescript files and assets
 - test folder holds tests (See [Testing](#testing))
@@ -385,7 +377,7 @@ To run a specific npm command on a specific package, run `npm <command> -w <pack
 
 To run a specific npm command on the root package, run `npm <command>`.
 
-Read more about node workspaces - [https://docs.npmjs.com/cli/v7/using-npm/workspaces](https://docs.npmjs.com/cli/v7/using-npm/workspaces)
+Read more about node workspaces - [https://docs.npmjs.com/cli/using-npm/workspaces](https://docs.npmjs.com/cli/using-npm/workspaces)
 
 ### Naming convention
 
@@ -394,18 +386,12 @@ Read more about node workspaces - [https://docs.npmjs.com/cli/v7/using-npm/works
 
 ### Types of packages
 
-There are 4 different types of packages:
+There are 3 different types of packages:
 
 #### dev packages
 
 Packages with their name starting with `@dev`. These are the main packages that will be used on day-to-day work with the repository.
 Those packages will hold raw assets in their dist directory, and are ready to be consumed by any packer (like webpack or rollup).
-
-#### lts packages
-
-Packages with their name starting with `@lts`. These are packages that are used for the long-term support of the repository. In time some code will move to the LTS packages (for example side effects or deprecated functions). LTS packages will be used to generate the public packages.
-
-LTS packages are an extension of the dev packages and should never include duplicated code.
 
 #### Tools packages
 
@@ -414,7 +400,7 @@ Tools are, for example, the playground, the sandbox, node and GUI editor.
 
 #### Public packages
 
-The public-facing packages are the ones that are served using NPM. They are mainly built using the LTS or Tools packages. They are also the only ones not marked "private" in their package.json.
+The public-facing packages live under `packages/public`. They are the packages published to npm and are the only ones not marked `private` in their package.json.
 
 ### Running scripts
 
@@ -591,7 +577,7 @@ import { Control } from "gui/2D/controls/control";
 import { AdvancedDynamicTexture } from "gui/2D/advancedDynamicTexture";
 ```
 
-Using the dev package names (defined in packageMapping.ts in the build tools) will allow the build system to choose which project to take sources from - dev, or lts.
+Using the dev package names (defined in the build tools) keeps local development pointed at the monorepo sources instead of published packages.
 
 ### Serving the repository
 
@@ -617,7 +603,7 @@ When loading from the different packages in the dev host you will use the packag
 import { Scene } from "@dev/core";
 ```
 
-It is important to stay consistent when importing, i.e. not to load a part from the @lts packages and another part from the @dev package, as typescript will complain they are not the same object.
+It is important to stay consistent when importing, i.e. not to mix published `@babylonjs/*` packages with local `@dev/*` packages for the same codepath, as TypeScript will treat them as different copies.
 
 The dev host is configured to be much more forgiving when developing. The best example is the `noImplicitAny` rule, which is set to false. This is done mainly so you could load .js files as well as typescript file. This is the reason for the `allowJs` flag being set to true.
 
@@ -788,9 +774,9 @@ Note about dev host - the dev host is not using any best practices for productio
 
 The Babylon server is a direct copy of the Babylon CDN structure. It serves javascript files, along with sourcemaps and declarations.
 
-Similar to the dev host, the Babylon server will take the latest compiled code from the dev (or lts) packages and serve it to the browser. The default address for the local CDN is [http://localhost:1338](http://localhost:1338)
+Similar to the dev host, the Babylon server will take the latest compiled code from the current monorepo packages and serve it to the browser. The default address for the local CDN is [http://localhost:1337](http://localhost:1337).
 
-The Babylon server's _index.html_ has references to all of our public packages and has the BABYLON namespace populated, similar to the way the playground is working. If you want to debug a playground scene without starting the playground, edit the file sceneJs.js or sceneTs.ts for typescript, and open http://localhost:1338/index.html or http://localhost:1338/index-ts.html
+The Babylon server's _index.html_ has references to all of our public packages and has the BABYLON namespace populated, similar to the way the playground is working. If you want to debug a playground scene without starting the playground, edit the files `sceneJs.js` or `sceneTs.ts` in the babylon-server package and open [http://localhost:1337/index.html](http://localhost:1337/index.html) or [http://localhost:1337/index-ts.html](http://localhost:1337/index-ts.html).
 
 To start the Babylon server, run:
 
@@ -815,7 +801,6 @@ A few notes:
 
 As with any webpack-hosted package, there are a few properties that can be configured (using either the CLA od the .env file as discussed above):
 
-- source: the type of source you will use. This can be either 'dev' or 'lts'. The default is 'dev'.
 - mode: the type of build you will use. This can be either 'production' or 'development'. The default is 'development'.
 - cdnPort: the port that the Babylon server will be hosted on. The default is 1337.
 - enableHttps: whether or not to use https. The default is false.
@@ -840,7 +825,7 @@ Notes:
 
 - If the playground is served using HTTPS, the Babylon server must be HTTPS-Enabled as well.
 - To load the dist files (and avoid using the babylon-server) add ?dist=true to the url.
-- All tools will open on [http://localhost:1338](http://localhost:1338)
+- Local ports vary by tool. Use the relevant section above or the VS Code launch configuration for the exact URL.
 
 ### Playground
 
@@ -899,17 +884,9 @@ You can reference this package in other packages to link them together. Once thi
 
 To build each and every package available in the repository, run `npm run build -w @namespace/package-name`. There is, however, a quicker and more efficient way of building a package that has dependencies.
 
-`nx` is integrated in the repository, and can be seen as a local assets repository to run build much faster. When running an npm script using nx it will automatically run the same command in local dependencies and in the right order. So, for example, when building the public `babylonjs-gui` package using `npx nx run babylonjs-gui:build`, nx will add the following projects to the sequence:
+`nx` is integrated in the repository, and can be seen as a local assets repository to run builds much faster. When running an npm script using nx it will automatically run the same command in local dependencies and in the right order. For example, when building a public package such as `babylonjs-gui` using `npx nx run babylonjs-gui:build`, nx will add the required dependent projects to the sequence automatically.
 
-- @dev/build-tools (a dependency of each dev package)
-- @dev/core
-- @lts/core
-- babylonjs
-- @dev/gui
-- @lts/gui
-- babylonjs-gui
-
-It will run the build in sequence (because of the predefined dependencies), but will skip building a package if it hasn't changed since the last build call. So calling `npx nx run babylonjs:build` will build dev, lts, and public, but those 3 will be ready when building babylonjs-gui and will not build again.
+It will run the build in sequence (because of the predefined dependencies), but will skip building a package if it hasn't changed since the last build call. So calling `npx nx run babylonjs:build` will build the projects needed for that target and reuse anything that is already up to date when another package depends on it.
 
 This should be used only when you want to build the public packages in the repository, and will mainly be used by the CI. However, nx is available to you and is a very powerful tool. In the future we might integrate it more in the repository. TO read more about nx: [https://nx.dev/getting-started/intro](https://nx.dev/getting-started/intro)
 
@@ -1000,7 +977,7 @@ You can break the execution and still see the report (if any tests filed) by pre
 
 #### Adding a new test
 
-To add a new test to the visualization tests, add the test data to this file: https://github.com/BabylonJS/Babylon.js/blob/master/packages/tools/tests/test/visualization/config.json
+To add a new test to the visualization tests, add the test data to [packages/tools/tests/test/visualization/config.json](https://github.com/BabylonJS/Babylon.js/blob/master/packages/tools/tests/test/visualization/config.json)
 
 The best way to do that is first create a playground, save it (using a local version of the playground, for example) and then add it at the end of the config file:
 
@@ -1114,7 +1091,7 @@ npm install
 
 ### Local Build and Serve
 
-Using VSCode? Install the recommended extensions and start `Run and Watch Dev Host` to compile and get started with the esm dev host. TO use the classic UMD-based development (and have the BABYLON namespace available), run `Run and Watch Babylon Server`.
+Using VSCode? Install the recommended extensions and start `Run and Watch Dev Host (Dev)` to compile and get started with the esm dev host. To use the classic UMD-based development (and have the BABYLON namespace available), run `CDN Serve and watch (Dev)`.
 
 To build the dev sources, shaders, and assets, run `npm run build:dev`.
 
@@ -1139,5 +1116,3 @@ Commit files you have added or edited but not those built.
 ### Push Pull-Request Check
 
 ![Pull-Request](/img/contribute/summary3.jpg)
-
-

--- a/content/contribute/toBabylon/HowToContribute.md
+++ b/content/contribute/toBabylon/HowToContribute.md
@@ -316,13 +316,13 @@ Open [http://localhost:1346](http://localhost:1346) in your browser.
 
 Using VSCode:
 
-- In the Run and Debug Menu, choose "Run and debug unit tests" or "Run and debug visualization tests", OR
-- Open the Command Palette, type "Run Task", select "Run unit tests` or "Run visualization tests"
+- In the Run and Debug Menu, choose "Run and Debug unit tests (Dev)" for the Vitest unit suite, or one of the validation test launch configurations for Playwright-based browser tests.
+- Open the Command Palette, type "Run Task", and select "Run visualization tests (Dev)" or "Launch visualization test runner (Dev)".
 
 Using command line:
 
 - Run `npm run test:unit` or `npm run test:visualization`
-- Or run `npm run test` or `npx jest` to launch all tests at the same time
+- Run `npm run test` to execute the default root unit-test run
 
 #### Link a public project to an external one
 
@@ -869,7 +869,7 @@ To start the debugger using VS Code use the launch task you want to debug and ru
 
 All packages are built with sourcemaps (when not in production mode), so opening the browser and choose the file to debug will allow to debug using typescript sources.
 
-Unit tests can be debugged as well using the VS Code debugger. When in debug mode tests will run "in band" and not parallel. Set the breakpoint beforehand and run the tests. The initial run might take some time, but once the debugger is connected it will stop at that breakpoint.
+Unit tests can be debugged as well using the VS Code debugger. The built-in Vitest launch configurations run without file parallelism, which makes breakpoints predictable. Set the breakpoint beforehand and run the tests. The initial run might take some time, but once the debugger is connected it will stop at that breakpoint.
 
 Contact us in the forum with any issues regarding debugging.
 
@@ -917,9 +917,9 @@ This should be used only when you want to build the public packages in the repos
 
 There are 3 types of tests configured in the repository:
 
-- unit
-- visualization
-- integration (TBD)
+- unit (Vitest)
+- visualization (Playwright)
+- integration (Playwright)
 
 Each package can have a "test" folder with a specific structure. The structure of the test folder will allow tests to run automatically in the entire repository (and in a single package). The structure is as follows:
 
@@ -927,57 +927,56 @@ Each package can have a "test" folder with a specific structure. The structure o
 
 All files must follow this schema:
 
-`(.*).test.{js, ts, tsx}`, for example - materials.test.ts or babylon.physicsEngine.test.js
+`(.*).test.{ts, tsx}`, for example - materials.test.ts
 
-Those files will be automatically picked by jest and will run as part of the test script, using the correct environment (jsdom/node for unit tests)
+At the repository level, the Vitest `unit` project automatically picks up files matching `packages/**/test/unit/**/*.test.{ts,tsx}`.
 
-The possible test environment are node and jsdom for unit tests, and also puppeteer for visualization and integration (see [https://jestjs.io/docs/configuration#testenvironment-string](https://jestjs.io/docs/configuration#testenvironment-string)). The default test environment is node (and puppeteer for visualization). To change the environment, add a comment at the first line of the file. For example:
+The default unit-test environment is `node`. When a unit test needs DOM APIs, switch the file to `jsdom` by adding a comment at the first line of the file. For example:
 
 ```javascript
 /**
- * @jest-environment jsdom
+ * @vitest-environment jsdom
  */
 ```
 
-will enable jsdom as the test environment and will make the window and document object available in unit tests.
+This enables jsdom for that file and makes `window` and `document` available in the test. Browser-based visualization and integration tests run separately through Playwright rather than through the Vitest unit project.
 
-Test results can be seen on the console. A junit.xml file is also generated after every test run, but it is mainly used for CI reporting.
+Test results can be seen on the console. In CI, Vitest also emits a `junit.xml` report for test reporting.
 
 Visualization tests will generate a report if any test failed. The report will open automatically after running the tests.
 
-To run all tests in a single command run `npm run test` or `npx jest` in the main directory.
+To run the repository's unit-test suite from the root, run `npm run test` or `npm run test:unit` in the main directory.
 
-We are testing using jest. To know everything you need to know, read their documentation - [https://jestjs.io/docs/getting-started](https://jestjs.io/docs/getting-started)
+We are testing unit suites using Vitest. To learn more about the test runner and its API, read the Vitest documentation - [https://vitest.dev/guide/](https://vitest.dev/guide/)
 
 ### Unit testing
 
 Apart from what's written before, there are a few things that need to be observed when writing unit tests.
 
-- Unit tests are meant to test a specific unit or module. Anything else must be mocked. To read more about jest mocking - [https://jestjs.io/docs/mock-functions](https://jestjs.io/docs/mock-functions)
+- Unit tests are meant to test a specific unit or module. Anything else should be mocked. To read more about Vitest mocking, see [https://vitest.dev/guide/mocking.html](https://vitest.dev/guide/mocking.html)
 - If you are testing the connection between two or more modules it is not a unit test and should probably be an integration test.
-- It is recommended not to use puppeteer as the environment for unit testing
+- Do not use browser-based Playwright tests as a substitute for unit tests. If `node` is not enough, prefer `@vitest-environment jsdom` before moving to visualization or integration coverage.
 - jsdom does not allow adding script tags to the DOM. Anything that needs to be added externally must be mocked.
 
-To run all unit tests run `npm run test -- --selectProjects unit`. To run tests only in a specific project, run the npm command with the right workspace package: `npm run test -w @dev/core -- --selectProjects unit`
+To run all unit tests, run `npm run test:unit` from the repository root.
 
-To run a specific unit test you can use jest filtering, which is either filter per filename:
+To run a specific unit test file, pass its path to Vitest from the repository root:
 
-`npm run test -w @dev/core -- --selectProjects unit -i "material"`
+`npm run test:unit -- packages/dev/core/test/unit/Math/babylon.math.vector.test.ts`
 
-This will run all tests that their filename has "material" in them.
+To run tests matching part of the test name, use Vitest's `-t` filter:
 
-You can also filter using term in the test name itself (the "it" and "describes" functions in your tests):
+`npm run test:unit -- -t "material"`
 
-`npm run test -w @dev/core -- --selectProjects unit -t "material"`
-
-This will run all tests that have the word "material" in their name.
+To debug the current test file from VS Code, use the "Run and Debug current unit test file (Dev)" launch configuration.
 
 ### Visualization tests
 
 Before running the visualization tests, you'll need to start the local server:
+
 ```shell
 npm start
-``` 
+```
 
 Run all visualization tests (WebGL1, WebGL2 and WebGPU) using `npm run test:visualization` in the main directory.
 


### PR DESCRIPTION
## Summary
- update the Babylon.js contribution guide for the current Vitest and Playwright test setup
- refresh stale monorepo guidance in HowToContribute.md to match the current package layout, task names, Node/npm requirements, and Babylon server details
- remove obsolete @lts references and fix adjacent markdown issues in the same file

## Validation
- verified the guide against the local Babylon.js monorepo in ../Babylon.js
- checked markdown diagnostics for content/contribute/toBabylon/HowToContribute.md