### PR TITLE
Replace deprecated Babylon.js APIs in documentation code examples

### DIFF
--- a/content/features/featuresDeepDive/animation/advanced_animations.md
+++ b/content/features/featuresDeepDive/animation/advanced_animations.md
@@ -276,6 +276,7 @@ const FunnyEase = (function (_super) {
 You will find a complete demonstration of the easing functions behaviors, in this playground: <Playground id="#8ZNVGR" title="Easing Behavior Examples" description="Examples of the easing functions available." image="/img/playgroundsAndNMEs/divingDeeperAdvancedAnimation4.jpg"/>
 
 If you need finer control of the easing function than at animation level, you can also define it at animation key level:
+
 ```javascript
 export interface IAnimationKey {
     /**
@@ -353,14 +354,11 @@ this.engine = new BABYLON.Engine(theCanvas, true, {
 This way, the scene will render quantizing physics and animation steps by discrete chunks of the timeStep amount, as set in the physics engine. For example:
 
 ```javascript
-const physEngine = new BABYLON.CannonJSPlugin(false);
+const physEngine = new BABYLON.HavokPlugin();
 newScene.enablePhysics(this.gravity, physEngine);
-physEngine.setTimeStep(1 / 60);
 ```
 
 With the code above, the engine will run discrete steps at 60Hz (0.01666667s) and, in case of a late frame render time, it will try to calculate a maximum of 4 steps (lockstepMaxSteps) to recover eventual accumulated delay, before rendering the frame.
-
-Note that when explicitly creating the CannonJSPlugin, it is important to pass false as \_useDeltaForWorldStep parameter in its constructor, to disable CannonJS internal accumulator.
 
 To run logic code in sync with the steps, there are the two following observables on the scene:
 

--- a/content/features/featuresDeepDive/cameras/camera_introduction.md
+++ b/content/features/featuresDeepDive/cameras/camera_introduction.md
@@ -306,16 +306,18 @@ const camera = new BABYLON.VRDeviceOrientationGamepadCamera("Camera", new BABYLO
 
 ## WebVR Free Camera
 
-**NOTE:** WebVR is deprecated! Please use WebXR instead
+**NOTE:** WebVR has been removed from Babylon.js as of version 7.0. Please use [WebXR](/features/featuresDeepDive/webXR/introToWebXR) instead.
 
-[WebVRFreeCamera](/typedoc/classes/babylon.webvrfreecamera) is the legacy virtual reality camera, now intended for use with older VR device browsers that don't support the WebXR standard.
+The `WebVRFreeCamera` is no longer available. To create VR experiences, use the WebXR experience helper:
 
 ```javascript
-// Parameters : name, position, scene, webVROptions
-const camera = new BABYLON.WebVRFreeCamera("WVR", new BABYLON.Vector3(0, 1, -15), scene);
+// Create a default XR experience with immersive VR support
+const xrHelper = await scene.createDefaultXRExperienceAsync({
+  floorMeshes: [ground],
+});
 ```
 
-This camera deserves its own page: [Using the WebVR Camera](/features/featuresDeepDive/cameras/webVRCamera).
+See [Introduction to WebXR](/features/featuresDeepDive/webXR/introToWebXR) for full documentation.
 
 ## FlyCamera
 
@@ -387,4 +389,3 @@ While this is realistic, it may be visually unappealing. If the angle between th
 
 And if you want further control other the camera projection plane tilting, you can mess with the `camera.projectionPlaneTilt` property.
 See [this forum post](https://forum.babylonjs.com/t/add-vertical-shift-to-3ds-max-exporter-babylon-cameras/17480/16) for more information.
-

--- a/content/features/featuresDeepDive/mesh/LOD.md
+++ b/content/features/featuresDeepDive/mesh/LOD.md
@@ -14,10 +14,10 @@ This feature allows you to specify different meshes based on distance to viewer 
 For instance, here is how to define 4 levels of details for a given mesh, with distance comparison :
 
 ```javascript
-const knot00 = BABYLON.Mesh.CreateTorusKnot("knot0", 0.5, 0.2, 128, 64, 2, 3, scene);
-const knot01 = BABYLON.Mesh.CreateTorusKnot("knot1", 0.5, 0.2, 32, 16, 2, 3, scene);
-const knot02 = BABYLON.Mesh.CreateTorusKnot("knot2", 0.5, 0.2, 24, 12, 2, 3, scene);
-const knot03 = BABYLON.Mesh.CreateTorusKnot("knot3", 0.5, 0.2, 16, 8, 2, 3, scene);
+const knot00 = BABYLON.MeshBuilder.CreateTorusKnot("knot0", { radius: 0.5, tube: 0.2, radialSegments: 128, tubularSegments: 64, p: 2, q: 3 }, scene);
+const knot01 = BABYLON.MeshBuilder.CreateTorusKnot("knot1", { radius: 0.5, tube: 0.2, radialSegments: 32, tubularSegments: 16, p: 2, q: 3 }, scene);
+const knot02 = BABYLON.MeshBuilder.CreateTorusKnot("knot2", { radius: 0.5, tube: 0.2, radialSegments: 24, tubularSegments: 12, p: 2, q: 3 }, scene);
+const knot03 = BABYLON.MeshBuilder.CreateTorusKnot("knot3", { radius: 0.5, tube: 0.2, radialSegments: 16, tubularSegments: 8, p: 2, q: 3 }, scene);
 
 knot00.addLODLevel(15, knot01);
 knot00.addLODLevel(30, knot02);
@@ -75,10 +75,10 @@ By default, instances will use LOD defined on root mesh. You do not have to spec
 const count = 3;
 const scale = 4;
 
-const knot00 = BABYLON.Mesh.CreateTorusKnot("knot0", 0.5, 0.2, 128, 64, 2, 3, scene);
-const knot01 = BABYLON.Mesh.CreateTorusKnot("knot1", 0.5, 0.2, 32, 16, 2, 3, scene);
-const knot02 = BABYLON.Mesh.CreateTorusKnot("knot2", 0.5, 0.2, 24, 12, 2, 3, scene);
-const knot03 = BABYLON.Mesh.CreateTorusKnot("knot3", 0.5, 0.2, 16, 8, 2, 3, scene);
+const knot00 = BABYLON.MeshBuilder.CreateTorusKnot("knot0", { radius: 0.5, tube: 0.2, radialSegments: 128, tubularSegments: 64, p: 2, q: 3 }, scene);
+const knot01 = BABYLON.MeshBuilder.CreateTorusKnot("knot1", { radius: 0.5, tube: 0.2, radialSegments: 32, tubularSegments: 16, p: 2, q: 3 }, scene);
+const knot02 = BABYLON.MeshBuilder.CreateTorusKnot("knot2", { radius: 0.5, tube: 0.2, radialSegments: 24, tubularSegments: 12, p: 2, q: 3 }, scene);
+const knot03 = BABYLON.MeshBuilder.CreateTorusKnot("knot3", { radius: 0.5, tube: 0.2, radialSegments: 16, tubularSegments: 8, p: 2, q: 3 }, scene);
 
 knot00.setEnabled(false);
 

--- a/content/features/featuresDeepDive/mesh/drawCurves.md
+++ b/content/features/featuresDeepDive/mesh/drawCurves.md
@@ -321,7 +321,7 @@ If you then need to draw the curve or use it for whatever you want you just get 
 
 ```javascript
 const path = myFullCurve.getPoints();
-const extruded = BABYLON.Mesh.ExtrudeShape("extrudedShape", shape, path, 1, 0, scene);
+const extruded = BABYLON.MeshBuilder.ExtrudeShape("extrudedShape", { shape: shape, path: path, scale: 1, rotation: 0 }, scene);
 ```
 
 If you need then to know the curve length, just use the _**length()**_ method.

--- a/content/features/featuresDeepDive/mesh/dynamicMeshMorph.md
+++ b/content/features/featuresDeepDive/mesh/dynamicMeshMorph.md
@@ -50,7 +50,7 @@ const pathArray = [];
 for (let i = -20; i < 20; i++) {
   pathArray.push(pathFunction(i * 2));
 }
-const mesh = BABYLON.Mesh.CreateRibbon("ribbon", pathArray, false, false, 0, scene, true, sideO);
+const mesh = BABYLON.MeshBuilder.CreateRibbon("ribbon", { pathArray: pathArray, closeArray: false, closePath: false, offset: 0, updatable: true, sideOrientation: sideO }, scene);
 ```
 
 example : <Playground id="#1MSEBT" title="Dynamic Mesh Morph Example 1" description="Simple example of dynamically morphing a mesh."/> _(please rotate the cam to see it)_
@@ -81,14 +81,6 @@ for (let p = 0; p < pathArray.length; p++) {
 The way to update then our existing mesh is quite simple : let's just re-use the _CreateRibbon()_ method and give it this mesh as last parameter with our modified _pathArray_.
 
 ```javascript
-mesh = BABYLON.Mesh.CreateRibbon(null, pathArray, null, null, null, null, null, null, mesh);
-```
-
-The other parameters than _pathArray_ and _mesh_ are just ignored when updating, so they can be set to _null_ for better understanding.  
-The _CreateRibbon()_ method thus updates the given ribbon and returns it.  
-You can also use the other call signature :
-
-```javascript
 mesh = BABYLON.MeshBuilder.CreateRibbon(null, { pathArray: pathArray, instance: mesh });
 ```
 
@@ -111,7 +103,7 @@ const updatePath = function (path, k) {
 };
 
 // path array population ...
-const mesh = BABYLON.Mesh.CreateRibbon("ribbon", pathArray, false, false, 0, scene, true);
+const mesh = BABYLON.MeshBuilder.CreateRibbon("ribbon", { pathArray: pathArray, closeArray: false, closePath: false, offset: 0, updatable: true }, scene);
 
 // morphing
 const k = 0;
@@ -121,9 +113,7 @@ scene.registerBeforeRender(function () {
     updatePath(pathArray[p], k);
   }
   // ribbon update
-  mesh = BABYLON.Mesh.CreateRibbon(null, pathArray, null, null, null, null, null, null, mesh);
-  // or also :
-  // mesh = BABYLON.MeshBuilder.CreateRibbon(null, {pathArray: pathArray, instance: mesh});
+  mesh = BABYLON.MeshBuilder.CreateRibbon(null, { pathArray: pathArray, instance: mesh });
   k += 0.05;
 });
 ```
@@ -144,7 +134,7 @@ It's even easier as Lines just require a path of points as parameter.
 ```javascript
 const points1 = [v1, v2, ..., vN]; // vector3 array
 let lines = BABYLON.MeshBuilder.CreateLines("lines", {points: points1, updatable: true}, scene, true);
-let dashedLines = BABYLON.Mesh.CreateDashedLines("lines", points1, dashSize, gapSize, nb, scene, true);
+let dashedLines = BABYLON.MeshBuilder.CreateDashedLines("lines", { points: points1, dashSize: dashSize, gapSize: gapSize, dashNb: nb, updatable: true }, scene);
 
 lines = BABYLON.MeshBuilder.CreateLines(null, {points: points2, instance: lines});
 dashedLines = BABYLON.MeshBuilder.CreateDashedLines(null, {points: points2, instance: dashedLines});
@@ -168,8 +158,8 @@ const path1 = [v1, ..., vN]; //vector3 array : tube axis1
 const radius1 = 5;
 const path2 = [u1, ..., uN]; // another vector3 array : tube axis2
 const radius2 = 8;
-const tube = BABYLON.Mesh.CreateTube("tube", path1, radius1, 12, null, cap, scene, true);
-tube = BABYLON.MeshBuilder.CreateTube(null, {path: path2, radius: radius2, instance: tube});
+const tube = BABYLON.MeshBuilder.CreateTube("tube", { path: path1, radius: radius1, tessellation: 12, cap: cap, updatable: true }, scene);
+tube = BABYLON.MeshBuilder.CreateTube(null, { path: path2, radius: radius2, instance: tube });
 ```
 
 Of course, it also works with the _radiusFunction_ parameter :
@@ -221,7 +211,7 @@ const myScale2 = function(i, distance) { ... };
 const myRotation1 = function(i, distance) { ... };
 const myRotation2 = function(i, distance) { ... };
 // extrusion
-let ext = BABYLON.Mesh.ExtrudeShapeCustom("ext", { shape: shape1, path: path1, scaleFunction: myScale1, rotationFunction: myRotation1, updatable: true, cap }, scene);
+let ext = BABYLON.MeshBuilder.ExtrudeShapeCustom("ext", { shape: shape1, path: path1, scaleFunction: myScale1, rotationFunction: myRotation1, updatable: true, cap: cap }, scene);
 // mesh update
 ext = BABYLON.MeshBuilder.ExtrudeShapeCustom(null,{shape: shape2, path: path2, scaleFunction: myScale2, rotationFunction: myRotation2, instance: ext});
 ```
@@ -231,9 +221,9 @@ Both new functions can be used in the render loop.
 The funny part is, as _ExtrudeShape()_ and _ExtrudedShapeCustom()_ build the same mesh (only parameters change), you can create a simple extruded shape with _ExtrudeShape()_ and then morph it with _ExtrudeShapeCustom()_ if you need more complexity.
 
 ```javascript
-let ext = BABYLON.Mesh.ExtrudeShape("ext", shape1, path1, scale1, rotation1, cap, scene, true);
+let ext = BABYLON.MeshBuilder.ExtrudeShape("ext", { shape: shape1, path: path1, scale: scale1, rotation: rotation1, cap: cap, updatable: true }, scene);
 // mesh update
-ext = BABYLON.Mesh.ExtrudeShapeCustom(null, shape2, path2, myScale2, myRotation2, null, null, null, null, null, null, ext);
+ext = BABYLON.MeshBuilder.ExtrudeShapeCustom(null, { shape: shape2, path: path2, scaleFunction: myScale2, rotationFunction: myRotation2, instance: ext });
 ```
 
 Example: <Playground id="#20IBWW#14" title="Extruded Shape Example" description="Simple example of dynamically morphing an extruded shape."/>
@@ -271,10 +261,10 @@ So, if your mesh doesn't need to reflect the light (emissive color only for inst
 Use then the _freezeNormals()_ method just after your mesh is created :
 
 ```javascript
-const tube = BABYLON.Mesh.CreateTube("tube", path, 3, 12, null, BABYLON.Mesh.NO_CAP, scene, true);
+const tube = BABYLON.MeshBuilder.CreateTube("tube", { path: path, radius: 3, tessellation: 12, cap: BABYLON.Mesh.NO_CAP, updatable: true }, scene);
 tube.freezeNormals();
 // path update here ...
-tube = BABYLON.Mesh.CreateTube(null, path, 3, null, null, null, null, null, null, tube);
+tube = BABYLON.MeshBuilder.CreateTube(null, { path: path, instance: tube });
 ```
 
 If you need to reset the normals computation process on, use then once the _unfreezeNormals()_ method.

--- a/content/features/featuresDeepDive/physics/v1/advancedPhysicsFeatures.md
+++ b/content/features/featuresDeepDive/physics/v1/advancedPhysicsFeatures.md
@@ -39,9 +39,9 @@ There are certain conditions in which a heightmap can be initialized:
 To create a ground from an image-based ground mesh:
 
 ```javascript
-var ground = BABYLON.Mesh.CreateGroundFromHeightMap("ground", "textures/worldHeightMap.jpg", 200, 200, 50, 0, 30, scene, false, function () {
+var ground = BABYLON.MeshBuilder.CreateGroundFromHeightMap("ground", "textures/worldHeightMap.jpg", { width: 200, height: 200, subdivisions: 50, minHeight: 0, maxHeight: 30, onReady: function () {
     ground.physicsImpostor = new BABYLON.PhysicsImpostor(ground, BABYLON.PhysicsImpostor.HeightmapImpostor, { mass: 0 });
-});
+} }, scene);
 ```
 
 To create a heightmap from a square ribbon:
@@ -61,7 +61,7 @@ for (let p = 0; p <= 100; p++) {
 
 }
 
-var mesh = BABYLON.Mesh.CreateRibbon("ribbon", arrayOfPaths, false, false, 0, scene);
+var mesh = BABYLON.MeshBuilder.CreateRibbon("ribbon", { pathArray: arrayOfPaths, closeArray: false, closePath: false, offset: 0 }, scene);
 mesh.physicsImpostor = new BABYLON.PhysicsImpostor(mesh, BABYLON.PhysicsImpostor.HeightmapImpostor, { mass: 0, friction:1, restitution: 0.5 });
 ```
 

--- a/content/features/featuresDeepDive/physics/v2/aggregates.md
+++ b/content/features/featuresDeepDive/physics/v2/aggregates.md
@@ -19,7 +19,7 @@ The Physics Aggregate is an object that contains a Body and a Shape. It's a help
 ## How to use it
 
 ```javascript
-const sphere = BABYLON.Mesh.CreateSphere("sphere", 16, 2, scene);
+const sphere = BABYLON.MeshBuilder.CreateSphere("sphere", { segments: 16, diameter: 2 }, scene);
 const aggregate = new BABYLON.PhysicsAggregate(sphere, BABYLON.PhysicsShapeType.SPHERE, { mass: 1 }, scene);
 ```
 
@@ -27,7 +27,7 @@ This is very similar to the Physics V1 Impostor.
 At aggregate creation, a body and a shape are instantiated all at once. However, recreating shapes is not the most performant choice. You can alternatively pass the shape instead of the PhysicsShapeType, and the aggregate will reuse that shape:
 
 ```javascript
-const sphere = BABYLON.Mesh.CreateSphere("sphere", 16, 2, scene);
+const sphere = BABYLON.MeshBuilder.CreateSphere("sphere", { segments: 16, diameter: 2 }, scene);
 const sphere2 = sphere.clone("sphere2");
 
 const aggregate = new BABYLON.PhysicsAggregate(sphere, BABYLON.PhysicsShapeType.SPHERE, { mass: 1 }, scene);

--- a/content/features/featuresDeepDive/scene/optimizeOctrees.md
+++ b/content/features/featuresDeepDive/scene/optimizeOctrees.md
@@ -54,7 +54,7 @@ You can even specify the usage of your octree independently:
 * ```mesh.useOctreeForRenderingSelection``` : Octree for submeshes can even be used during mesh selection based on camera field of view. Once a mesh is selected by the camera, if the mesh has submeshes, the camera has to select which one is visible. In this case, having an octree can be really helpful.
 
 ## GroundMesh
-For the specific case of ground meshes, Babylon.js provides a class called ```BABYLON.GroundMesh``` that you can create using ```BABYLON.Mesh.CreateGround``` and ```BABYLON.Mesh.CreateGroundFromHeightMap```.
+For the specific case of ground meshes, Babylon.js provides a class called ```BABYLON.GroundMesh``` that you can create using ```BABYLON.MeshBuilder.CreateGround``` and ```BABYLON.MeshBuilder.CreateGroundFromHeightMap```.
 
 By calling ```groundMesh.optimize(chunkSize)``` where chunkSize defines the number of submeshes you want, the mesh will be optimized for rendering, picking and collisions by creating an internal octree (Be sure to select a correct chunkSize).
 

--- a/content/features/featuresDeepDive/webXR/WebXRHandTracking.md
+++ b/content/features/featuresDeepDive/webXR/WebXRHandTracking.md
@@ -286,7 +286,7 @@ featureManager.enableFeature(BABYLON.WebXRFeatureName.HAND_TRACKING, "latest", {
 });
 ```
 
-To configure the physics impostor (which defaults to a sphere with the default friction and restitution) use the physics props option:
+To configure the physics properties (which defaults to a sphere with the default friction and restitution) use the physics props option:
 
 ```javascript
 const featureManager = xrHelper.baseExperience.featuresManager;
@@ -296,7 +296,6 @@ featureManager.enableFeature(BABYLON.WebXRFeatureName.HAND_TRACKING, "latest", {
   jointMeshes: {
     enablePhysics: true,
     physicsProps: {
-      impostorType: PhysicsImpostor.BoxImpostor,
       friction: 0.5,
       restitution: 0.3,
     },
@@ -306,7 +305,7 @@ featureManager.enableFeature(BABYLON.WebXRFeatureName.HAND_TRACKING, "latest", {
 
 Notice that you can't define the mass. that is because the tracked joints will always have mass `0` to prevent them from constantly "falling down" towards the center of gravity.
 
-<Playground id="#X7Y4H8#73" title="Hand tracking with legacy physics" description="A simple example of a hands-enabled legacy physics playground" image="/img/how_to/xr/handTrackingSpheres.jpg"/>
+<Playground id="#X7Y4H8#73" title="Hand tracking with physics" description="A simple example of a hands-enabled physics playground" image="/img/how_to/xr/handTrackingSpheres.jpg"/>
 
 
 ### Microgestures

--- a/content/features/featuresDeepDive/webXR/introToWebXR.md
+++ b/content/features/featuresDeepDive/webXR/introToWebXR.md
@@ -332,7 +332,7 @@ var createScene = function () {
   var scene = new BABYLON.Scene(engine);
 
   // Create simple sphere
-  var sphere = BABYLON.Mesh.CreateIcoSphere(
+  var sphere = BABYLON.MeshBuilder.CreateIcoSphere(
     "sphere",
     {
       radius: 0.2,
@@ -378,7 +378,7 @@ var createScene = function () {
   });
 
   // GUI
-  var plane = BABYLON.Mesh.CreatePlane("plane", 1);
+  var plane = BABYLON.MeshBuilder.CreatePlane("plane", { size: 1 });
   plane.position = new BABYLON.Vector3(0.4, 4, 0.4);
   var advancedTexture = BABYLON.GUI.AdvancedDynamicTexture.CreateForMesh(plane);
   var panel = new BABYLON.GUI.StackPanel();

--- a/content/features/featuresDeepDive/webXR/webXRDemos.md
+++ b/content/features/featuresDeepDive/webXR/webXRDemos.md
@@ -43,7 +43,7 @@ Notice that no changes were made in the XR code, and that the scene works perfec
 
 ```javascript
 // GUI
-var plane = BABYLON.Mesh.CreatePlane("plane", 1);
+var plane = BABYLON.MeshBuilder.CreatePlane("plane", { size: 1 });
 plane.position = new BABYLON.Vector3(1.4, 1.5, 0.4);
 var advancedTexture = BABYLON.GUI.AdvancedDynamicTexture.CreateForMesh(plane);
 var panel = new BABYLON.GUI.StackPanel();

--- a/content/guidedLearning/createAGame/simpleGameState.md
+++ b/content/guidedLearning/createAGame/simpleGameState.md
@@ -136,7 +136,7 @@ var box = MeshBuilder.CreateBox("Small1", { width: 0.5, depth: 0.5, height: 0.25
 box.position.y = 1.5;
 box.position.z = 1;
 
-var body = Mesh.CreateCylinder("body", 3, 2, 2, 0, 0, scene);
+var body = MeshBuilder.CreateCylinder("body", { height: 3, diameterTop: 2, diameterBottom: 2 }, scene);
 var bodymtl = new StandardMaterial("red", scene);
 bodymtl.diffuseColor = new Color3(0.8, 0.5, 0.5);
 body.material = bodymtl;

--- a/content/guidedLearning/networking/Colyseus_ammojs.md
+++ b/content/guidedLearning/networking/Colyseus_ammojs.md
@@ -82,14 +82,14 @@ Yes, that's it
 First, we create a box and ground, and add physics to it,the ground represents the scene, and the box represents the interactive objects in the scene (such as a football played by many people)
 
 ```javascript
-scene.enablePhysics(new BABYLON.Vector3(0, -10, 0), new AmmoJSPlugin(true, Ammo));
+scene.enablePhysics(new BABYLON.Vector3(0, -10, 0), new BABYLON.HavokPlugin(true, havokInstance));
 var ground = BABYLON.MeshBuilder.CreateGround("ground1", { width: 160, height: 160, subdivisions: 2 }, scene);
 ground.position.y = -5;
-ground.physicsImpostor = new BABYLON.PhysicsImpostor(ground, BABYLON.PhysicsImpostor.BoxImpostor, { mass: 0, friction: 0.5, restitution: 0.7 }, scene);
+const groundAggregate = new BABYLON.PhysicsAggregate(ground, BABYLON.PhysicsShapeType.BOX, { mass: 0, friction: 0.5, restitution: 0.7 }, scene);
 
 var box = BABYLON.MeshBuilder.CreateBox("box", { size: 2 }, scene);
 box.position.y = 1;
-box.physicsImpostor = new BABYLON.PhysicsImpostor(box, BABYLON.PhysicsImpostor.BoxImpostor, { mass: 1, restitution: 0.9 }, scene);
+const boxAggregate = new BABYLON.PhysicsAggregate(box, BABYLON.PhysicsShapeType.BOX, { mass: 1, restitution: 0.9 }, scene);
 box.material = new BABYLON.StandardMaterial("s-mat", scene);
 box.material.diffuseColor = new BABYLON.Color3(0, 0, 1);
 box.material.emissiveTexture = new BABYLON.Texture("./src/grass.png", scene);
@@ -125,7 +125,7 @@ window.addEventListener("keydown", function (e) {
   } else if (e.which === Keycode.DOWN) {
     keyboard.y = -10;
   }
-  playerViews[sessionId].physicsImpostor.setLinearVelocity(new BABYLON.Vector3(keyboard.x, 0, keyboard.y));
+  playerViews[sessionId].physics.body.setLinearVelocity(new BABYLON.Vector3(keyboard.x, 0, keyboard.y));
 });
 
 window.addEventListener("keyup", function (e) {
@@ -139,7 +139,7 @@ window.addEventListener("keyup", function (e) {
     keyboard.y = 0;
   }
 
-  playerViews[sessionId].physicsImpostor.setLinearVelocity(new BABYLON.Vector3(0, 0, 0));
+  playerViews[sessionId].physics.body.setLinearVelocity(new BABYLON.Vector3(0, 0, 0));
 });
 ```
 
@@ -201,7 +201,7 @@ player.position.onChange = () => {
     if (Math.abs(playerViews[key].position.x) < 0.2 && Math.abs(playerViews[key].position.y) < 0.5 && Math.abs(playerViews[key].position.x) < 0.2) {
       playerViews[key].position = new BABYLON.Vector3(player.position.x, player.position.y, player.position.z);
     } else {
-      playerViews[key].physicsImpostor.setLinearVelocity(new BABYLON.Vector3((player.position.x - playerViews[key].position.x) * 10, (player.position.y - playerViews[key].position.y) * 10, (player.position.z - playerViews[key].position.z) * 10));
+      playerViews[key].physics.body.setLinearVelocity(new BABYLON.Vector3((player.position.x - playerViews[key].position.x) * 10, (player.position.y - playerViews[key].position.y) * 10, (player.position.z - playerViews[key].position.z) * 10));
 
       playerViews[key].rotationQuaternion = BABYLON.Quaternion.Slerp(playerViews[key].rotationQuaternion, new BABYLON.Quaternion(player.quaternion.x, player.quaternion.y, player.quaternion.z, player.quaternion.w), 0.4);
     }
@@ -297,7 +297,8 @@ If other players collide with the box, the targetid will be replaced by the sess
 ```javascript
 if (key === room.sessionId) {
   //...
-  box.physicsImpostor.registerOnPhysicsCollide(playerViews[sessionId].physicsImpostor, function (main, collided) {
+  boxAggregate.body.setCollisionCallbackEnabled(true);
+  boxAggregate.body.getCollisionObservable().add((event) => {
     room.send("boxUpdate", {
       targetId: sessionId,
       position: { x: box.position.x, y: box.position.y, z: box.position.z },

--- a/content/guidedLearning/workshop/vr_game.md
+++ b/content/guidedLearning/workshop/vr_game.md
@@ -114,14 +114,19 @@ blubox.actionManager.registerAction(new BABYLON.IncrementValueAction(BABYLON.Act
 
 ### VR Cameras
 
-Babylon.js makes it very easy to use VR camera. Our scene has two options. The default implemented is the `WebVRFreeCamera`, the documentation, including browser/device limitations and motion controls, can be found [here](/features/featuresDeepDive/cameras/webVRCamera).
+Babylon.js makes it very easy to use VR cameras via the WebXR API. The documentation for WebXR, including browser/device support and motion controls, can be found [here](/features/featuresDeepDive/webXR/introToWebXR).
 
 ```javascript
-var camera = new BABYLON.WebVRFreeCamera("Camera", new BABYLON.Vector3(0, 1, 0), scene);
+var camera = new BABYLON.FreeCamera("Camera", new BABYLON.Vector3(0, 1, 0), scene);
 camera.attachControl(canvas, true);
+
+// Enable WebXR immersive VR
+const xrHelper = await scene.createDefaultXRExperienceAsync({
+  floorMeshes: [ground],
+});
 ```
 
-Alternatively, you can include `scene.createDefaultVRExperience();` to toggle between VR capable scenes. In the playground code, comment out the lines that use the `camera` var and uncomment the lines that have `//to use with createDefaultVRExperience()`.
+You can use `scene.createDefaultXRExperienceAsync()` to easily add WebXR VR support to your scene.
 
 ### Spatial Sound
 

--- a/content/setup/frameworkPackages/es6Support.md
+++ b/content/setup/frameworkPackages/es6Support.md
@@ -456,77 +456,26 @@ new PolygonMeshBuilder("polytri", corners, scene, MyEarcut);
 
 It would be the same for physics plugin where you can either provide the underlying engine as a var or inject it in the constructor of the Babylon.js respective plugin.
 
-## Ammo
+## Havok Physics
 
-Exactly like in the previous paragraph, you can inject your ammo dependency into Babylon.js. Either you can keep as a global script reference thus not including the dependency in your bundle or you could follow the following steps to include ammo as part of your bundled application.
+The recommended physics engine for Babylon.js is [Havok](/features/featuresDeepDive/physics/usingPhysicsEngine). To use Havok with ES6/npm, install it:
 
-First, install ammo.js from its Github build folder (in order to benefit from an up to date version):
-
-```javascript
-npm install kripken/ammo.js
+```bash
+npm install @babylonjs/havok
 ```
 
-Then in Webpack, you need to disable the node.js dependencies to generate a successful package (obviously if you are targeting web builds):
+Then in your code:
 
 ```javascript
-module.exports = {
-  ...
-  resolve: {
-    fallback: {
-      'fs': false,
-      'path': false,
-    }
-  }
-}
+import HavokPhysics from "@babylonjs/havok";
+import { HavokPlugin } from "@babylonjs/core/Physics/v2/Plugins/havokPlugin.js";
+
+const havokInstance = await HavokPhysics();
+const havokPlugin = new HavokPlugin(true, havokInstance);
+scene.enablePhysics(new Vector3(0, -9.81, 0), havokPlugin);
 ```
 
-Finally, in your code, you can setup the AmmoJSPlugin this way:
-
-```javascript
-import ammo from "ammo.js";
-const Ammo = await ammo();
-...
-const ammoPlugin = new AmmoJSPlugin(true, Ammo);
-```
-
-For Webpack versions before 5, you'll instead need:
-
-```javascript
-module.exports = {
-    context: __dirname,
-    ...
-    node: {
-        fs: 'empty'
-    }
-}
-```
-
-```javascript
-import * as ammo from "ammo.js";
-const Ammo = await ammo.default();
-...
-const ammoPlugin = new AmmoJSPlugin(true, Ammo);
-```
-
-## Ammo with types enabled
-
-Follow the instructions at https://github.com/giniedp/ammojs-typed.
-
-Import the dependencies:
-
-```javascript
-import { AmmoJSPlugin } from "@babylonjs/core/Physics/Plugins/ammoJSPlugin.js";
-import Ammo from "ammojs-typed";
-```
-
-and in your code:
-
-```javascript
-const ammo = await Ammo();
-scene.enablePhysics(new Vector3(0, -9.81, 0), new AmmoJSPlugin(true, ammo));
-```
-
-![](/img/resources/ammo-es6/ammo-es6-typed.png)
+<Alert severity="warning" title="Deprecated: Ammo.js" description="AmmoJSPlugin, CannonJSPlugin, and OimoJSPlugin are legacy Physics V1 plugins and have been deprecated in favor of HavokPlugin (Physics V2). See the migration guide at /features/featuresDeepDive/physics/v2/migrateFromV1."/>
 
 ## Loaders
 

--- a/content/toolsAndResources/assetLibraries/materialsLibrary/fireMat.md
+++ b/content/toolsAndResources/assetLibraries/materialsLibrary/fireMat.md
@@ -32,7 +32,7 @@ fireMaterial.diffuseTexture = new BABYLON.Texture("diffuse.png", scene);
 fireMaterial.distortionTexture = new BABYLON.Texture("distortion.png", scene);
 fireMaterial.opacityTexture = new BABYLON.Texture("opacity.png", scene);
 
-var plane = BABYLON.Mesh.CreatePlane("fireplane", 1.0, scene);
+var plane = BABYLON.MeshBuilder.CreatePlane("fireplane", { size: 1.0 }, scene);
 plane.material = fireMaterial;
 ```
 

--- a/content/toolsAndResources/assetLibraries/materialsLibrary/gridMat.md
+++ b/content/toolsAndResources/assetLibraries/materialsLibrary/gridMat.md
@@ -31,7 +31,7 @@ You can access the live example in this PG: <Playground id="#2KKVBH" title="Grid
 The grid is using the local position to outline any of the axis fitting with one unit in black. Only one on ten lines will be fully black, the other lines will be in lighter grey. You can imagine it as a ruler with bigger marks for centimeters and smaller for millimeters.
 
 ```javascript
-var ground = BABYLON.Mesh.CreateGroundFromHeightMap("ground", "textures/heightMap.png", 100, 100, 100, 0, 10, scene, false);
+var ground = BABYLON.MeshBuilder.CreateGroundFromHeightMap("ground", "textures/heightMap.png", { width: 100, height: 100, subdivisions: 100, minHeight: 0, maxHeight: 10 }, scene);
 ground.material = new BABYLON.GridMaterial("groundMaterial", scene);
 ```
 

--- a/content/toolsAndResources/assetLibraries/materialsLibrary/mixMat.md
+++ b/content/toolsAndResources/assetLibraries/materialsLibrary/mixMat.md
@@ -1,6 +1,6 @@
 ---
 title: Mix Material
-image: 
+image:
 description: The Babylon.js materials library mix map textures.
 keywords: library, materials, materials library, mix materil
 further-reading:
@@ -17,16 +17,17 @@ PG: <Playground id="#1DFTDT" title="Mix Material" description="Example of mix ma
 ## Using the mix material
 
 The mix material is based on the terrain material but works with up to 8 diffuse textures. It is composed of:
+
 - 8 Diffuse textures. (at least 4 required)
 - 2 Mixmap textures: represents the intensity of each diffuse texture according the channels R (red), G (green), B (blue) and A (alpha). (at least one required)
 
-__Note 1: the alpha channel is inverted in order to help creating the mix map textures. In other words, less you have alpha, more the diffuse texture attached to the alpha channel will be visible.__
+**Note 1: the alpha channel is inverted in order to help creating the mix map textures. In other words, less you have alpha, more the diffuse texture attached to the alpha channel will be visible.**
 
-__Note 2: the mix material doesn't support bump mapping for instance.__
+**Note 2: the mix material doesn't support bump mapping for instance.**
 
 ```
 // Create a terrain
-var terrain = BABYLON.Mesh.CreateGroundFromHeightMap("terrain", "heightMap.png", 100, 100, 100, 0, 10, scene, false);
+var terrain = BABYLON.MeshBuilder.CreateGroundFromHeightMap("terrain", "heightMap.png", { width: 100, height: 100, subdivisions: 100, minHeight: 0, maxHeight: 10 }, scene);
 
 // Create the mix material
 var mix = new BABYLON.MixMaterial("mix", scene);
@@ -56,13 +57,15 @@ terrain.material = mix;
 That's all!
 
 ## Result with only the mix texture 1
-With ```mix.mixTexture2``` undefined or null, the material will only apply the mix texture 1:
+
+With `mix.mixTexture2` undefined or null, the material will only apply the mix texture 1:
 
 ![Mix Texture 1](/img/extensions/materials/mixMap.png)
 ![Mix Material 1](/img/extensions/materials/terrainMixtexture1.png)
 
 ## Result with both mix textures 1 & 2
-With ```mix.mixTexture2 = new BABYLON.Texture("/playground/textures/mixMap_2.png", scene)``` the material will continue mixing the mix texture 1 with the mix texture2. Then, you are able to mix up to 8 diffuse textures:
+
+With `mix.mixTexture2 = new BABYLON.Texture("/playground/textures/mixMap_2.png", scene)` the material will continue mixing the mix texture 1 with the mix texture2. Then, you are able to mix up to 8 diffuse textures:
 
 ![Mix Texture 2](/img/extensions/materials/mixMap_2.png)
 ![Mix Material 2](/img/extensions/materials/mixResult.png)

--- a/content/toolsAndResources/assetLibraries/materialsLibrary/shadowOnlyMat.md
+++ b/content/toolsAndResources/assetLibraries/materialsLibrary/shadowOnlyMat.md
@@ -25,7 +25,7 @@ A demo can be found here: PG: <Playground id="#1KF7V1" title="Shadow Only Materi
 ShadowOnly material is dead simple to use. Just apply it as material to any mesh where you want to display only shadow:
 
 ```
-var ground = BABYLON.Mesh.CreatePlane('ground', 1000, scene)
+var ground = BABYLON.MeshBuilder.CreatePlane('ground', { size: 1000 }, scene)
 ground.rotation.x = Math.PI / 2
 ground.material = new BABYLON.ShadowOnlyMaterial('shadowOnly', scene)
 ground.receiveShadows = true

--- a/content/toolsAndResources/assetLibraries/materialsLibrary/terrainMat.md
+++ b/content/toolsAndResources/assetLibraries/materialsLibrary/terrainMat.md
@@ -28,7 +28,7 @@ A Mixmap texture looks like (result on the screenshot above):
 The method applied by the terrain material is also called "texture splatting".
 
 ```
-var terrain = BABYLON.Mesh.CreateGroundFromHeightMap("terrain", "heightMap.png", 100, 100, 100, 0, 10, scene, false);
+var terrain = BABYLON.MeshBuilder.CreateGroundFromHeightMap("terrain", "heightMap.png", { width: 100, height: 100, subdivisions: 100, minHeight: 0, maxHeight: 10 }, scene);
 
 var terrainMaterial = new BABYLON.TerrainMaterial("terrainMaterial", scene);
 terrainMaterial.mixTexture = new BABYLON.Texture("mixMap.png", scene);

--- a/content/toolsAndResources/utilities/Sector.md
+++ b/content/toolsAndResources/utilities/Sector.md
@@ -43,14 +43,14 @@ function showAngleSector(origin, vector1, vector2, radius, sectorType) {
       sector = BABYLON.MeshBuilder.CreateLines("sector", { points }, scene);
       break;
     case 1:
-      sector = BABYLON.Mesh.CreateDashedLines("sector", points, 3, 1, nbPoints, scene);
+      sector = BABYLON.MeshBuilder.CreateDashedLines(\"sector\", { points: points, dashSize: 3, gapSize: 1, dashNb: nbPoints }, scene);
       break;
     case 2:
       const pointO = [];
       for (let j = 0; j < points.length; j++) {
         pointO.push(origin);
       }
-      sector = BABYLON.Mesh.CreateRibbon("sector", [points, pointO], null, null, 0, scene);
+      sector = BABYLON.MeshBuilder.CreateRibbon(\"sector\", { pathArray: [points, pointO] }, scene);
       break;
     default:
       sector = BABYLON.MeshBuilder.CreateLines("sector", { points }, scene);


### PR DESCRIPTION
## Summary

Audit and replace deprecated Babylon.js API usage in documentation code examples across 21 files.

Fixes #1312

## Changes

### WebVR (removed in 7.0) → WebXR
- **vr_game.md** — Replaced `WebVRFreeCamera` with `FreeCamera` + `createDefaultXRExperienceAsync()`
- **camera_introduction.md** — Updated WebVR section to note removal and show WebXR equivalent

### Physics V1 → Physics V2 (in non-legacy docs)
- **advanced_animations.md** — `CannonJSPlugin` → `HavokPlugin`
- **es6Support.md** — Replaced entire Ammo.js/AmmoJSPlugin section with Havok setup guide
- **Colyseus_ammojs.md** — `AmmoJSPlugin`/`PhysicsImpostor` → `HavokPlugin`/`PhysicsAggregate`
- **WebXRHandTracking.md** — Removed deprecated `PhysicsImpostor.BoxImpostor` from hand tracking config

### `Mesh.Create*` → `MeshBuilder.Create*` (15 files)
- **LOD.md** — 8× `CreateTorusKnot`
- **dynamicMeshMorph.md** — `CreateRibbon`, `CreateDashedLines`, `CreateTube`, `ExtrudeShape`, `ExtrudeShapeCustom`
- **drawCurves.md** — `ExtrudeShape`
- **optimizeOctrees.md** — Prose references
- **aggregates.md** — 2× `CreateSphere`
- **introToWebXR.md** — `CreateIcoSphere`, `CreatePlane`
- **webXRDemos.md** — `CreatePlane`
- **simpleGameState.md** — `CreateCylinder`
- **advancedPhysicsFeatures.md** — `CreateGroundFromHeightMap`, `CreateRibbon`
- **Sector.md** — `CreateDashedLines`, `CreateRibbon`
- 5 material library files — `CreatePlane`, `CreateGroundFromHeightMap`

### Not changed (intentionally legacy)
- Files under `physics/v1/` — V1 physics API usage is by design
- Files under `audio/v1/` — legacy audio documentation
- `cameras/webVRCamera.md` — dedicated legacy WebVR page
- `importers/legacy.md` — legacy loader documentation
- `mesh/creation/` reference pages — show both `MeshBuilder` (primary) and `Mesh` (legacy) syntaxes by design
- `physics/v2/migrateFromV1.md` — migration guide showing V1 → V2 comparison"