### PR TITLE
feat: add collapsible sidebar and examples panel toggles

### DIFF
--- a/components/layout.component.tsx
+++ b/components/layout.component.tsx
@@ -7,6 +7,8 @@ import RightArrowIcon from "@mui/icons-material/LastPage";
 import SearchIcon from "@mui/icons-material/Search";
 import Brightness4Icon from "@mui/icons-material/Brightness4";
 import Brightness7Icon from "@mui/icons-material/Brightness7";
+import ChevronLeftIcon from "@mui/icons-material/ChevronLeft";
+import ChevronRightIcon from "@mui/icons-material/ChevronRight";
 import { AppBar, Drawer, alpha, Hidden, IconButton, InputBase, Toolbar, Tooltip, Typography } from "@mui/material";
 import Box from "@mui/system/Box";
 import { useTheme } from "@mui/material/styles";
@@ -28,6 +30,7 @@ const menuStructure = generateMenuStructure();
 
 export const Layout: FunctionComponent<PropsWithChildren<IPageProps>> = ({ id, previous, next, children, metadata, breadcrumbs, disableMetadataAugmentation = false }) => {
     const [mobileOpen, setMobileOpen] = useState(false);
+    const [sidebarCollapsed, setSidebarCollapsed] = useState(false);
     const [searchTerm, setSearchTerm] = useState<string>("");
     const breadcrumbContainerRef = useRef<HTMLDivElement>(null);
     const measureRef = useRef<HTMLDivElement>(null);
@@ -250,7 +253,8 @@ export const Layout: FunctionComponent<PropsWithChildren<IPageProps>> = ({ id, p
                         flexWrap: "nowrap",
                         alignItems: "center",
                         [theme.breakpoints.up("md")]: {
-                            paddingLeft: "300px",
+                            paddingLeft: sidebarCollapsed ? "0px" : "300px",
+                            transition: "padding-left 0.2s ease",
                         },
                         "& > a": {
                             padding: theme.spacing(1),
@@ -367,6 +371,7 @@ export const Layout: FunctionComponent<PropsWithChildren<IPageProps>> = ({ id, p
                     flex: 1,
                     [theme.breakpoints.up("md")]: {
                         pt: 0,
+                        position: "relative",
                     },
                     paddingTop: "100px",
                 }}
@@ -378,8 +383,10 @@ export const Layout: FunctionComponent<PropsWithChildren<IPageProps>> = ({ id, p
                         display: "block",
                         // paddingBottom: "40px",
                         [theme.breakpoints.up("md")]: {
-                            width: "300px",
+                            width: sidebarCollapsed ? "0px" : "300px",
                             flexShrink: 0,
+                            transition: "width 0.2s ease",
+                            overflow: "hidden",
                             "& > div": {
                                 height: "100%",
                             },
@@ -434,12 +441,39 @@ export const Layout: FunctionComponent<PropsWithChildren<IPageProps>> = ({ id, p
                                 height: "100%",
                                 backgroundColor: theme.customPalette.sideMenu.backgroundColor,
                                 zIndex: 1500,
+                                minWidth: "300px",
                             }}
                         >
                             {MenuStructure}
                         </Box>
                     </Hidden>
                 </Box>
+                <Hidden mdDown implementation="css">
+                    <Box
+                        sx={{
+                            position: "absolute",
+                            top: "16px",
+                            left: sidebarCollapsed ? "0px" : "288px",
+                            transition: "left 0.2s ease",
+                            zIndex: 1501,
+                            backgroundColor: theme.customPalette.sideMenu.backgroundColor,
+                            borderRadius: "0 4px 4px 0",
+                            border: `1px solid ${theme.palette.divider}`,
+                            borderLeft: "none",
+                            cursor: "pointer",
+                            display: "flex",
+                            alignItems: "center",
+                            padding: "4px 0",
+                            "&:hover": {
+                                backgroundColor: theme.palette.action.hover,
+                            },
+                        }}
+                        onClick={() => setSidebarCollapsed(!sidebarCollapsed)}
+                        title={sidebarCollapsed ? "Expand sidebar" : "Collapse sidebar"}
+                    >
+                        {sidebarCollapsed ? <ChevronRightIcon fontSize="small" /> : <ChevronLeftIcon fontSize="small" />}
+                    </Box>
+                </Hidden>
                 <Box
                     component="main"
                     sx={{
@@ -448,7 +482,8 @@ export const Layout: FunctionComponent<PropsWithChildren<IPageProps>> = ({ id, p
                         flexDirection: "column",
                         maxWidth: "100%",
                         [theme.breakpoints.up("md")]: {
-                            width: `calc(100% - 300px)`,
+                            width: `calc(100% - ${sidebarCollapsed ? "0px" : "300px"})`,
+                            transition: "width 0.2s ease",
                         },
                     }}
                 >

--- a/pages/[...id].tsx
+++ b/pages/[...id].tsx
@@ -1,4 +1,6 @@
 import ExpandLessIcon from "@mui/icons-material/ExpandLess";
+import ChevronLeftIcon from "@mui/icons-material/ChevronLeft";
+import ChevronRightIcon from "@mui/icons-material/ChevronRight";
 import Layout from "../components/layout.component";
 import GithubIcon from "@mui/icons-material/GitHub";
 import { Box, useTheme } from "@mui/material";
@@ -65,6 +67,7 @@ export const DocumentationPage: FunctionComponent<IDocumentationPageProps> = ({ 
     const [activeExample, setActiveExample] = useState<IExampleLink | null>(null);
     const [tocLinks, setTocLinks] = useState<ITableOfContentsItem[]>([]);
     const [activeTOCItem, setActiveTOCItem] = useState<ITableOfContentsItem | null>(null);
+    const [examplesCollapsed, setExamplesCollapsed] = useState(false);
 
     const tocLevel = typeof metadata.tocLevels === "number" ? metadata.tocLevels : 3;
 
@@ -192,14 +195,46 @@ export const DocumentationPage: FunctionComponent<IDocumentationPageProps> = ({ 
                         </div>
                     </div>
                     {exampleLinks.length !== 0 && (
-                        <Box
-                            sx={{
-                                backgroundColor: theme.customPalette.examples.backgroundColor,
-                            }}
-                            className={[styles["examples-container"]].join(" ")}
-                        >
-                            <ExamplesComponent examples={exampleLinks}></ExamplesComponent>
-                        </Box>
+                        <>
+                            <Box
+                                sx={{
+                                    display: { xs: "none", sm: "flex" },
+                                    position: "absolute",
+                                    right: examplesCollapsed ? 0 : 280,
+                                    top: 16,
+                                    transition: "right 0.2s ease",
+                                    alignItems: "center",
+                                    cursor: "pointer",
+                                    backgroundColor: theme.customPalette.examples.backgroundColor,
+                                    borderRadius: "4px 0 0 4px",
+                                    border: `1px solid ${theme.palette.divider}`,
+                                    borderRight: "none",
+                                    padding: "4px 0",
+                                    "&:hover": {
+                                        backgroundColor: theme.palette.action.hover,
+                                    },
+                                    zIndex: 2,
+                                }}
+                                onClick={() => setExamplesCollapsed(!examplesCollapsed)}
+                                title={examplesCollapsed ? "Show examples" : "Hide examples"}
+                            >
+                                {examplesCollapsed ? <ChevronLeftIcon fontSize="small" /> : <ChevronRightIcon fontSize="small" />}
+                            </Box>
+                            <Box
+                                sx={{
+                                    backgroundColor: theme.customPalette.examples.backgroundColor,
+                                    transition: "width 0.2s ease, min-width 0.2s ease",
+                                    ...(examplesCollapsed && {
+                                        width: "0px !important",
+                                        minWidth: "0px !important",
+                                        overflow: "hidden",
+                                    }),
+                                }}
+                                className={[styles["examples-container"]].join(" ")}
+                            >
+                                <ExamplesComponent examples={exampleLinks}></ExamplesComponent>
+                            </Box>
+                        </>
                     )}
                 </div>
             </DocumentationContext.Provider>


### PR DESCRIPTION
## Summary

Adds toggle buttons to collapse/expand the desktop sidebar navigation and the examples panel on documentation pages, giving users more screen space for reading documentation.

### Changes

**Sidebar toggle** (`components/layout.component.tsx`):
- Chevron button at the top-right edge of the sidebar
- Smoothly animates sidebar width between 300px and 0px
- Breadcrumb bar padding and main content width adjust dynamically
- Desktop only — mobile retains the existing hamburger menu drawer

**Examples panel toggle** (`pages/[...id].tsx`):
- Chevron button at the top-left edge of the examples panel
- Hides/shows the panel with a smooth width animation
- Desktop only (≥640px) — examples panel already hidden on mobile

### Mobile behavior
No changes to mobile. The sidebar continues to use the hamburger menu drawer, and the examples panel remains hidden below 640px.

Closes #606
Closes #20