### PR TITLE
Add pure barrel tree-shaking docs

### DIFF
--- a/configuration/structure.json
+++ b/configuration/structure.json
@@ -2434,7 +2434,34 @@
                         },
                         "es6Support": {
                             "friendlyName": "ES6/NPM Support",
-                            "children": {},
+                            "children": {
+                                "treeShaking": {
+                                    "friendlyName": "Tree-Shaking with Pure Imports",
+                                    "children": {
+                                        "usingPureImports": {
+                                            "friendlyName": "Using Pure Imports",
+                                            "children": {},
+                                            "content": "setup/frameworkPackages/es6Support/treeShaking/usingPureImports"
+                                        },
+                                        "registeringSideEffects": {
+                                            "friendlyName": "Registering Side Effects",
+                                            "children": {},
+                                            "content": "setup/frameworkPackages/es6Support/treeShaking/registeringSideEffects"
+                                        },
+                                        "troubleshooting": {
+                                            "friendlyName": "Troubleshooting Pure Imports",
+                                            "children": {},
+                                            "content": "setup/frameworkPackages/es6Support/treeShaking/troubleshooting"
+                                        },
+                                        "contributing": {
+                                            "friendlyName": "Adding Tree-Shakeable Features",
+                                            "children": {},
+                                            "content": "setup/frameworkPackages/es6Support/treeShaking/contributing"
+                                        }
+                                    },
+                                    "content": "setup/frameworkPackages/es6Support/treeShaking"
+                                }
+                            },
                             "content": "setup/frameworkPackages/es6Support"
                         }
                     },

--- a/content/setup/frameworkPackages/es6Support.md
+++ b/content/setup/frameworkPackages/es6Support.md
@@ -8,6 +8,8 @@ further-reading:
     url: /setup/frameworkPackages/frameworkVers
   - title: NPM Support
     url: /setup/frameworkPackages/npmSupport
+  - title: Tree-Shaking with Pure Imports
+    url: /setup/frameworkPackages/es6Support/treeShaking
 video-overview:
 video-content:
 ---
@@ -338,6 +340,8 @@ This means the previous example is now requiring about 700Kb vs 2.3Mb before.
 **Please note we are continuing to improve our min package size by decoupling a bit more our packages so if you spot any unnecessary dependency, please, do not hesitate to create an issue on [GitHub](https://github.com/BabylonJS/Babylon.js).**
 
 **As you will see in the next paragraph, you also need to target individual files to fully benefit from tree shaking in your app.**
+
+Babylon.js also provides a pure import system that lets you import from a single barrel while preserving tree-shaking. See [Tree-Shaking with Pure Imports](/setup/frameworkPackages/es6Support/treeShaking) for the pure barrel workflow.
 
 ## Side Effects
 
@@ -697,6 +701,8 @@ SetBasisTranscoderWorker(worker);
 
 Starting with Babylon.js v7.23, we are introducing a new way for ES6 users to import optional features without side effects.
 Depending on how the internal engine works, we have aimed to reduce the number of functions that need to be added at the prototype level. Instead, when possible, we are offering more 'pick and choose' public functions.
+
+For the newer pure-barrel registration model, see [Tree-Shaking with Pure Imports](/setup/frameworkPackages/es6Support/treeShaking) and [Registering Side Effects](/setup/frameworkPackages/es6Support/treeShaking/registeringSideEffects).
 
 ### Animations
 

--- a/content/setup/frameworkPackages/es6Support/treeShaking.md
+++ b/content/setup/frameworkPackages/es6Support/treeShaking.md
@@ -1,0 +1,175 @@
+---
+title: Tree-Shaking with Pure Imports
+image:
+description: Use the Babylon.js pure barrel to keep a single import surface while preserving tree-shaking.
+keywords: babylon.js, es6, npm, tree shaking, pure imports, pure barrel, side effects, bundle size
+further-reading:
+  - title: Using Pure Imports
+    url: /setup/frameworkPackages/es6Support/treeShaking/usingPureImports
+  - title: Registering Side Effects
+    url: /setup/frameworkPackages/es6Support/treeShaking/registeringSideEffects
+  - title: Troubleshooting Pure Imports
+    url: /setup/frameworkPackages/es6Support/treeShaking/troubleshooting
+video-overview:
+video-content:
+---
+
+## Why Tree-Shaking Matters
+
+Babylon.js is a large framework. `@babylonjs/core` contains rendering, physics, animation, XR, particles, materials, loaders, and many other systems. Most applications use only part of this functionality, so bundling the whole package can include code your application never runs.
+
+Tree-shaking lets bundlers such as Webpack, Rollup, Vite, and esbuild analyze which exports your application actually uses and remove the rest from the final bundle. The exact savings depend on the features you use, but focused applications can often reduce their Babylon.js bundle significantly.
+
+## The Challenge: Side Effects
+
+JavaScript modules can have side effects: code that runs when a module is imported and changes global or shared state. Babylon.js uses side effects for several compatibility and discovery features:
+
+- Class registration, such as `RegisterClass("BABYLON.Camera", Camera)`, for deserialization by class name.
+- Prototype augmentation, such as adding optional methods to `Scene` or `Engine`.
+- Shader registration, which stores shader source code for the engine to compile.
+- Feature registration, such as making WebXR features discoverable by name.
+
+When a module has side effects, bundlers cannot safely remove it just because your code does not reference one of its exports. This is why the traditional ES6 tree-shaking guidance recommends deep imports and explicit side-effect imports.
+
+## The Pure Barrel
+
+Babylon.js provides a parallel pure import system that separates implementation code from side effects. This makes it possible to import from a single barrel while keeping tree-shaking effective.
+
+| Import style              | Example                             | Tree-shakeable | Side effects          |
+| ------------------------- | ----------------------------------- | -------------- | --------------------- |
+| Standard top-level barrel | `@babylonjs/core`                   | Limited        | Automatic             |
+| ES6 deep imports          | `@babylonjs/core/Engines/engine.js` | Yes            | Imported explicitly   |
+| Pure barrel               | `@babylonjs/core/pure`              | Yes            | Registered explicitly |
+
+The pure barrel re-exports the pure implementation modules. Your bundler can analyze which exports you import from the barrel and remove unused code, while features that historically depended on side effects are activated with explicit registration functions.
+
+## How It Works
+
+Modules with side effects are split into up to three files:
+
+```text
+camera.pure.ts  -> Pure implementation and registration function
+camera.types.ts -> Type augmentations only
+camera.ts       -> Backward-compatible wrapper that registers side effects
+```
+
+- `.pure.ts` contains implementation code and exports a `registerXxx()` function for any side effects.
+- `.types.ts` contains TypeScript `declare module` augmentations only.
+- `.ts` re-exports the pure module and calls the registration function to preserve existing import behavior.
+
+Existing imports keep working. Pure imports opt into the side-effect-free path.
+
+## Quick Start
+
+This complete example imports from the pure barrel, explicitly registers the rendering side effects it needs, loads an animated glTF character, places it on a ground mesh, and starts the render loop.
+
+The glTF loader package still registers its loader plugin through a side-effect import. The Babylon.js core rendering features used by the scene are registered explicitly.
+
+The example assumes your HTML contains a `<canvas id="renderCanvas"></canvas>` element.
+
+```typescript
+import {
+  Engine,
+  Scene,
+  ArcRotateCamera,
+  HemisphericLight,
+  DirectionalLight,
+  CreateGround,
+  PBRMaterial,
+  Color3,
+  Color4,
+  Vector3,
+  ImportMeshAsync,
+  registerAbstractEngineDom,
+  registerAbstractEngineRenderPass,
+  registerAbstractEngineStates,
+  registerAbstractEngineStencil,
+  registerAbstractEngineTexture,
+  registerExtensionsEngineRenderTarget,
+  registerEngineUniformBuffer,
+} from "@babylonjs/core/pure.js";
+
+import "@babylonjs/loaders/glTF/2.0/index.js";
+
+registerAbstractEngineDom();
+registerAbstractEngineRenderPass();
+registerAbstractEngineStates();
+registerAbstractEngineStencil();
+registerAbstractEngineTexture();
+registerExtensionsEngineRenderTarget();
+registerEngineUniformBuffer();
+
+const MODEL_URL = "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Assets/main/Models/Fox/glTF-Binary/Fox.glb";
+
+function createScene(engine: Engine, canvas: HTMLCanvasElement): Scene {
+  const scene = new Scene(engine);
+  scene.clearColor = new Color4(0.4, 0.6, 0.8, 1);
+
+  const camera = new ArcRotateCamera("camera", -Math.PI / 2, Math.PI / 4, 150, new Vector3(0, 30, 0), scene);
+  camera.attachControl(canvas, true);
+  camera.lowerRadiusLimit = 50;
+  camera.upperRadiusLimit = 300;
+
+  const hemisphericLight = new HemisphericLight("hemi", new Vector3(0, 1, 0), scene);
+  hemisphericLight.intensity = 0.5;
+
+  const directionalLight = new DirectionalLight("dir", new Vector3(-1, -3, -1), scene);
+  directionalLight.intensity = 0.8;
+  directionalLight.position = new Vector3(50, 100, 50);
+
+  const ground = CreateGround("ground", { width: 200, height: 200 }, scene);
+  const groundMaterial = new PBRMaterial("groundMat", scene);
+  groundMaterial.albedoColor = new Color3(0.3, 0.5, 0.2);
+  groundMaterial.metallic = 0;
+  groundMaterial.roughness = 0.95;
+  ground.material = groundMaterial;
+
+  ImportMeshAsync(MODEL_URL, scene).then((result) => {
+    const root = result.meshes[0];
+    root.position = Vector3.Zero();
+
+    const skeleton = result.skeletons[0];
+    skeleton?.returnToRest();
+
+    const animationGroups = result.animationGroups;
+    animationGroups.forEach((animationGroup) => animationGroup.stop());
+
+    const primaryAnimation = animationGroups[0];
+    primaryAnimation?.start(true, 1.0);
+
+    const secondaryAnimation = animationGroups[1];
+    if (secondaryAnimation) {
+      secondaryAnimation.start(true, 1.0);
+      secondaryAnimation.setWeightForAllAnimatables(0.3);
+    }
+  });
+
+  return scene;
+}
+
+const canvas = document.getElementById("renderCanvas") as HTMLCanvasElement;
+const engine = new Engine(canvas, true);
+const scene = createScene(engine, canvas);
+
+engine.runRenderLoop(() => scene.render());
+window.addEventListener("resize", () => engine.resize());
+```
+
+The pure barrel gives you the convenience of a single import surface. You can still import from individual `.pure` modules when you prefer explicit deep paths.
+
+## When to Use Pure Imports
+
+| Scenario                              | Recommended approach                                |
+| ------------------------------------- | --------------------------------------------------- |
+| Production app optimizing bundle size | Pure imports and explicit registration              |
+| Rapid prototyping                     | Standard imports or the Playground                  |
+| Library or plugin built on Babylon.js | Pure imports, so consumers decide what to register  |
+| Loading serialized scenes             | Pure imports plus registration for serialized types |
+| Math-only or utility-only code        | Pure deep imports or standalone function imports    |
+
+## Next Steps
+
+- [Using Pure Imports](/setup/frameworkPackages/es6Support/treeShaking/usingPureImports) explains pure barrel paths, subdirectory barrels, type augmentations, static function alternatives, and bundler configuration.
+- [Registering Side Effects](/setup/frameworkPackages/es6Support/treeShaking/registeringSideEffects) explains how to activate optional features when using pure imports.
+- [Troubleshooting Pure Imports](/setup/frameworkPackages/es6Support/treeShaking/troubleshooting) covers the most common runtime and TypeScript errors.
+- [Adding Tree-Shakeable Features](/setup/frameworkPackages/es6Support/treeShaking/contributing) describes the framework contribution pattern for pure modules.

--- a/content/setup/frameworkPackages/es6Support/treeShaking.md
+++ b/content/setup/frameworkPackages/es6Support/treeShaking.md
@@ -16,24 +16,24 @@ video-content:
 
 ## Why Tree-Shaking Matters
 
-Babylon.js is a large framework. `@babylonjs/core` contains rendering, physics, animation, XR, particles, materials, loaders, and many other systems. Most applications use only part of this functionality, so bundling the whole package can include code your application never runs.
+Babylon.js is a large framework. `@babylonjs/core` contains over 2,200 source files covering rendering, physics, animation, XR, particles, materials, loaders, and many other systems. Most applications use only part of this functionality, so bundling the whole package can include code your application never runs.
 
-Tree-shaking lets bundlers such as Webpack, Rollup, Vite, and esbuild analyze which exports your application actually uses and remove the rest from the final bundle. The exact savings depend on the features you use, but focused applications can often reduce their Babylon.js bundle significantly.
+Tree-shaking lets bundlers such as Webpack, Rollup, Vite, and esbuild figure out which code your application actually uses and remove the rest from the final bundle. This can cut bundle sizes by 50-80% depending on which features you use.
 
 ## The Challenge: Side Effects
 
-JavaScript modules can have side effects: code that runs when a module is imported and changes global or shared state. Babylon.js uses side effects for several compatibility and discovery features:
+JavaScript modules can have side effects: code that runs automatically when a file is imported, changing things globally. Babylon.js uses side effects for several compatibility and discovery features:
 
-- Class registration, such as `RegisterClass("BABYLON.Camera", Camera)`, for deserialization by class name.
-- Prototype augmentation, such as adding optional methods to `Scene` or `Engine`.
-- Shader registration, which stores shader source code for the engine to compile.
-- Feature registration, such as making WebXR features discoverable by name.
+- Class registration, such as `RegisterClass("BABYLON.Camera", Camera)`, which lets the engine recreate objects by name when loading saved scenes.
+- Prototype augmentation, such as `Scene.prototype.enablePhysics = function() {...}`, which attaches optional methods to existing classes.
+- Shader registration, which stores GPU shader source code so the engine can compile it later.
+- Feature registration, such as making WebXR features available by name.
 
-When a module has side effects, bundlers cannot safely remove it just because your code does not reference one of its exports. This is why the traditional ES6 tree-shaking guidance recommends deep imports and explicit side-effect imports.
+When a module has side effects, bundlers cannot safely remove it just because your code does not reference one of its exports. This is why `@babylonjs/core` historically shipped with `sideEffects: ["**/*"]`, telling bundlers that every file might have side effects.
 
 ## The Pure Barrel
 
-Babylon.js provides a parallel pure import system that separates implementation code from side effects. This makes it possible to import from a single barrel while keeping tree-shaking effective.
+Babylon.js provides an alternative import system where side effects are moved into explicit registration functions. This makes it possible to import from a single barrel while keeping tree-shaking effective.
 
 | Import style              | Example                             | Tree-shakeable | Side effects          |
 | ------------------------- | ----------------------------------- | -------------- | --------------------- |
@@ -41,121 +41,68 @@ Babylon.js provides a parallel pure import system that separates implementation 
 | ES6 deep imports          | `@babylonjs/core/Engines/engine.js` | Yes            | Imported explicitly   |
 | Pure barrel               | `@babylonjs/core/pure`              | Yes            | Registered explicitly |
 
-The pure barrel re-exports the pure implementation modules. Your bundler can analyze which exports you import from the barrel and remove unused code, while features that historically depended on side effects are activated with explicit registration functions.
+A barrel is a single file that re-exports symbols from many other files, giving you one convenient import path. The pure barrel re-exports the pure implementation modules without running their side effects. Your bundler can analyze which exports you import from the barrel and remove unused code, while features that historically depended on side effects are activated with explicit registration functions.
 
 ## How It Works
 
-Modules with side effects are split into up to three files:
+Most files in Babylon.js have no side effects and use their regular file name. The multi-file split only applies to modules that have side effects.
+
+For those modules, the code is split into up to three files:
 
 ```text
 camera.pure.ts  -> Pure implementation and registration function
-camera.types.ts -> Type augmentations only
+camera.types.ts -> Type augmentations only, when needed
 camera.ts       -> Backward-compatible wrapper that registers side effects
 ```
 
-- `.pure.ts` contains implementation code and exports a `registerXxx()` function for any side effects.
-- `.types.ts` contains TypeScript `declare module` augmentations only.
+- `.pure.ts` contains the implementation. Nothing runs automatically when you import it. It exports a `RegisterXxx()` function that you call when you need the side effects.
+- `.types.ts` contains TypeScript `declare module` augmentations for methods added to other classes. It is only needed when a file adds methods or properties to another class.
 - `.ts` re-exports the pure module and calls the registration function to preserve existing import behavior.
 
-Existing imports keep working. Pure imports opt into the side-effect-free path.
+If a module has no side effects, it just uses a normal `.ts` file. No `.pure.ts` or `.types.ts` file is needed.
 
 ## Quick Start
 
-This complete example imports from the pure barrel, explicitly registers the rendering side effects it needs, loads an animated glTF character, places it on a ground mesh, and starts the render loop.
-
-The glTF loader package still registers its loader plugin through a side-effect import. The Babylon.js core rendering features used by the scene are registered explicitly.
+This example imports from the pure barrel and explicitly registers the core engine extensions needed for rendering. The bundler can eliminate everything you do not use.
 
 The example assumes your HTML contains a `<canvas id="renderCanvas"></canvas>` element.
 
 ```typescript
-import {
-  Engine,
-  Scene,
-  ArcRotateCamera,
-  HemisphericLight,
-  DirectionalLight,
-  CreateGround,
-  PBRMaterial,
-  Color3,
-  Color4,
-  Vector3,
-  ImportMeshAsync,
-  registerAbstractEngineDom,
-  registerAbstractEngineRenderPass,
-  registerAbstractEngineStates,
-  registerAbstractEngineStencil,
-  registerAbstractEngineTexture,
-  registerExtensionsEngineRenderTarget,
-  registerEngineUniformBuffer,
-} from "@babylonjs/core/pure.js";
+import { Engine, Scene, FreeCamera, HemisphericLight, CreateSphere, StandardMaterial, Color3, Vector3, RegisterCoreEngineExtensions } from "@babylonjs/core/pure";
 
-import "@babylonjs/loaders/glTF/2.0/index.js";
-
-registerAbstractEngineDom();
-registerAbstractEngineRenderPass();
-registerAbstractEngineStates();
-registerAbstractEngineStencil();
-registerAbstractEngineTexture();
-registerExtensionsEngineRenderTarget();
-registerEngineUniformBuffer();
-
-const MODEL_URL = "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Assets/main/Models/Fox/glTF-Binary/Fox.glb";
-
-function createScene(engine: Engine, canvas: HTMLCanvasElement): Scene {
-  const scene = new Scene(engine);
-  scene.clearColor = new Color4(0.4, 0.6, 0.8, 1);
-
-  const camera = new ArcRotateCamera("camera", -Math.PI / 2, Math.PI / 4, 150, new Vector3(0, 30, 0), scene);
-  camera.attachControl(canvas, true);
-  camera.lowerRadiusLimit = 50;
-  camera.upperRadiusLimit = 300;
-
-  const hemisphericLight = new HemisphericLight("hemi", new Vector3(0, 1, 0), scene);
-  hemisphericLight.intensity = 0.5;
-
-  const directionalLight = new DirectionalLight("dir", new Vector3(-1, -3, -1), scene);
-  directionalLight.intensity = 0.8;
-  directionalLight.position = new Vector3(50, 100, 50);
-
-  const ground = CreateGround("ground", { width: 200, height: 200 }, scene);
-  const groundMaterial = new PBRMaterial("groundMat", scene);
-  groundMaterial.albedoColor = new Color3(0.3, 0.5, 0.2);
-  groundMaterial.metallic = 0;
-  groundMaterial.roughness = 0.95;
-  ground.material = groundMaterial;
-
-  ImportMeshAsync(MODEL_URL, scene).then((result) => {
-    const root = result.meshes[0];
-    root.position = Vector3.Zero();
-
-    const skeleton = result.skeletons[0];
-    skeleton?.returnToRest();
-
-    const animationGroups = result.animationGroups;
-    animationGroups.forEach((animationGroup) => animationGroup.stop());
-
-    const primaryAnimation = animationGroups[0];
-    primaryAnimation?.start(true, 1.0);
-
-    const secondaryAnimation = animationGroups[1];
-    if (secondaryAnimation) {
-      secondaryAnimation.start(true, 1.0);
-      secondaryAnimation.setWeightForAllAnimatables(0.3);
-    }
-  });
-
-  return scene;
-}
+RegisterCoreEngineExtensions();
 
 const canvas = document.getElementById("renderCanvas") as HTMLCanvasElement;
 const engine = new Engine(canvas, true);
-const scene = createScene(engine, canvas);
+const scene = new Scene(engine);
+
+const camera = new FreeCamera("camera", new Vector3(0, 5, -10), scene);
+camera.setTarget(Vector3.Zero());
+
+new HemisphericLight("light", new Vector3(0, 1, 0), scene);
+
+const material = new StandardMaterial("sphereMat", scene);
+material.diffuseColor = new Color3(0.4, 0.6, 0.9);
+
+const sphere = CreateSphere("sphere", { diameter: 2, segments: 32 }, scene);
+sphere.material = material;
 
 engine.runRenderLoop(() => scene.render());
-window.addEventListener("resize", () => engine.resize());
 ```
 
-The pure barrel gives you the convenience of a single import surface. You can still import from individual `.pure` modules when you prefer explicit deep paths.
+The pure barrel re-exports every class and function from the package. Your bundler figures out which exports you actually use and removes the rest, giving you the same tree-shaking benefit as individual `.pure` imports with less import code.
+
+### Engine Registration Tiers
+
+Engine extensions such as texture loading, alpha blending, render targets, and uniform buffers are side effects that must be registered when using pure imports. Three tiered helpers are available:
+
+| Helper                               | What it registers                                                                                |
+| ------------------------------------ | ------------------------------------------------------------------------------------------------ |
+| `RegisterCoreEngineExtensions()`     | DOM binding, render passes, GPU states, and stencil support                                      |
+| `RegisterStandardEngineExtensions()` | Core plus textures, file loading, alpha, render targets, and uniform buffers                     |
+| `RegisterFullEngineExtensions()`     | Standard plus cube/raw/dynamic textures, multi-render, multiview, queries, compute, video, debug |
+
+For most applications, `RegisterStandardEngineExtensions()` is the right choice. Use `RegisterFullEngineExtensions()` if you need advanced features like compute shaders, cube textures, or multiview rendering.
 
 ## When to Use Pure Imports
 

--- a/content/setup/frameworkPackages/es6Support/treeShaking/contributing.md
+++ b/content/setup/frameworkPackages/es6Support/treeShaking/contributing.md
@@ -1,0 +1,371 @@
+---
+title: Adding Tree-Shakeable Features
+image:
+description: Follow the Babylon.js pure-module pattern when contributing new tree-shakeable code.
+keywords: babylon.js, contribute, tree shaking, pure modules, side effects, registration functions
+further-reading:
+  - title: Tree-Shaking with Pure Imports
+    url: /setup/frameworkPackages/es6Support/treeShaking
+  - title: Registering Side Effects
+    url: /setup/frameworkPackages/es6Support/treeShaking/registeringSideEffects
+  - title: Contributing to Babylon.js
+    url: /contribute/toBabylon/HowToContribute
+video-overview:
+video-content:
+---
+
+This guide is for contributors adding or modifying Babylon.js framework code. Application developers should start with [Using Pure Imports](/setup/frameworkPackages/es6Support/treeShaking/usingPureImports) and [Registering Side Effects](/setup/frameworkPackages/es6Support/treeShaking/registeringSideEffects).
+
+## The Three-File Pattern
+
+Every module with side effects is split into up to three files:
+
+```text
+feature.pure.ts  -> Implementation and registration function
+feature.types.ts -> TypeScript module augmentations, if any
+feature.ts       -> Backward-compatible wrapper
+```
+
+Use all three files when a feature adds methods or properties to existing classes and needs `declare module` augmentation. Use only `feature.pure.ts` and `feature.ts` when a feature has runtime side effects, such as `RegisterClass`, but no type augmentation.
+
+### When You Need All Three Files
+
+You need all three if your feature:
+
+- Adds methods or properties to existing classes.
+- Uses `declare module` to augment type definitions.
+
+### When You Need Only Two Files
+
+If your feature only has `RegisterClass` calls or static assignments, with no prototype augmentation:
+
+- `feature.pure.ts` contains the implementation and `registerFeature()` function.
+- `feature.ts` is the wrapper that calls `registerFeature()`.
+
+No `.types.ts` file is needed if there are no `declare module` blocks.
+
+## Step-by-Step: Adding a New Prototype Augmentation
+
+This example adds `doSomething()` to `Scene`.
+
+### 1. Create the Types File
+
+```typescript
+// myFeatureSceneComponent.types.ts
+import type { Scene } from "../scene.pure";
+
+declare module "../scene.pure" {
+  export interface Scene {
+    /**
+     * Does something useful.
+     * @returns The result.
+     */
+    doSomething(): string;
+  }
+}
+```
+
+Rules:
+
+- Use type-only imports.
+- Target the `.pure` module in `declare module`.
+- Document augmented public members with JSDoc.
+
+### 2. Create the Pure Implementation
+
+```typescript
+// myFeatureSceneComponent.pure.ts
+/** This file must only contain pure code and pure imports */
+
+export * from "./myFeatureSceneComponent.types";
+
+import { Scene } from "../scene.pure";
+import { RegisterClass } from "../Misc/typeStore";
+
+export class MyFeatureSceneComponent {
+  // Implementation.
+}
+
+let _registered = false;
+export function registerMyFeatureSceneComponent(): void {
+  if (_registered) {
+    return;
+  }
+  _registered = true;
+
+  Scene.prototype.doSomething = function (): string {
+    return "something";
+  };
+
+  RegisterClass("BABYLON.MyFeatureSceneComponent", MyFeatureSceneComponent);
+}
+```
+
+Rules:
+
+- Start `.pure.ts` files with `/** This file must only contain pure code and pure imports */`.
+- Re-export the `.types` module when the feature has type augmentations.
+- Put all side effects inside the `registerXxx()` function.
+- Guard registration with an idempotency flag.
+- Import from `.pure` specifiers when a pure module exists.
+- Keep `RegisterClass` calls inside the registration function.
+
+### 3. Create the Wrapper
+
+```typescript
+// myFeatureSceneComponent.ts
+export * from "./myFeatureSceneComponent.pure";
+import { registerMyFeatureSceneComponent } from "./myFeatureSceneComponent.pure";
+
+registerMyFeatureSceneComponent();
+```
+
+The wrapper preserves existing behavior: importing the non-pure module still runs the compatibility side effects.
+
+### 4. Update Barrels
+
+Add the pure export to the directory's pure barrel:
+
+```typescript
+export * from "./myFeatureSceneComponent.pure";
+```
+
+Add the existing wrapper export to the standard barrel:
+
+```typescript
+export * from "./myFeatureSceneComponent";
+```
+
+### 5. Generate Side-Effect Stubs
+
+If your feature augments prototypes, regenerate the side-effect stubs:
+
+```bash
+npm run generate:side-effect-stubs
+```
+
+This adds a lightweight missing-side-effect stub to the relevant pure class.
+
+## Step-by-Step: Adding a RegisterClass-Only Module
+
+If a feature only needs deserialization support and does not augment another class, create a pure implementation and wrapper:
+
+### 1. Create the Pure Implementation
+
+```typescript
+// myNewMesh.pure.ts
+/** This file must only contain pure code and pure imports */
+
+import { Mesh } from "./mesh.pure";
+import { RegisterClass } from "../Misc/typeStore";
+
+export class MyNewMesh extends Mesh {
+  // Full implementation.
+
+  public static Parse(parsedMesh: unknown, scene: Scene): MyNewMesh {
+    return new MyNewMesh("name", scene);
+  }
+}
+
+let _registered = false;
+export function registerMyNewMesh(): void {
+  if (_registered) {
+    return;
+  }
+  _registered = true;
+
+  RegisterClass("BABYLON.MyNewMesh", MyNewMesh);
+}
+```
+
+### 2. Create the Wrapper
+
+```typescript
+// myNewMesh.ts
+export * from "./myNewMesh.pure";
+import { registerMyNewMesh } from "./myNewMesh.pure";
+
+registerMyNewMesh();
+```
+
+## Naming Conventions
+
+### Registration Function Naming
+
+Registration functions use `register` plus the PascalCase file name:
+
+| Filename                               | Function                                 |
+| -------------------------------------- | ---------------------------------------- |
+| `standardMaterial.pure.ts`             | `registerStandardMaterial()`             |
+| `engine.multiRender.pure.ts`           | `registerEngineMultiRender()`            |
+| `WebXRHandTracking.pure.ts`            | `registerWebXRHandTracking()`            |
+| `joinedPhysicsEngineComponent.pure.ts` | `registerJoinedPhysicsEngineComponent()` |
+
+## Import Specifiers in Pure Files
+
+When a `.pure.ts` module imports another module that also has a pure version, import the pure specifier:
+
+```typescript
+// Correct
+import { Scene } from "../scene.pure";
+import { Vector3 } from "../Maths/math.vector.pure";
+import { Mesh } from "../Meshes/mesh.pure";
+
+// Wrong: pulls in side effects
+import { Scene } from "../scene";
+import { Vector3 } from "../Maths/math.vector";
+```
+
+Do not import the non-pure module from a pure file, because that can pull side effects back into the pure graph.
+
+Exception: type-only imports are erased at compile time, so they do not create runtime side effects:
+
+```typescript
+import type { Scene } from "../scene";
+```
+
+Using the pure path is still the clearest convention for new pure code.
+
+## Static Method Extraction
+
+When adding static methods to a class in a `.pure.ts` file, consider whether the method can be exported as a standalone function. This can improve tree-shaking for utility-style operations.
+
+### Methods That Stay as Class Statics
+
+Keep a method as a class static when it needs private or protected class members, when it is a static getter or setter, or when class identity is part of the public API.
+
+### Methods That Should Be Standalone Functions
+
+Prefer a standalone function when the method is pure computation, a simple factory, or a utility operating on structural types.
+
+Example: if an existing class exposes `MyAsset.Parse(...)`, keep the parse implementation available from the pure module as a top-level function. Add the class static only in the wrapper so importing the pure module does not perform a static assignment side effect.
+
+```typescript
+// myAsset.pure.ts
+/** This file must only contain pure code and pure imports */
+
+export class MyAsset {
+  public name: string;
+
+  public constructor(name: string) {
+    this.name = name;
+  }
+}
+
+export function MyAssetParse(parsedAsset: { name: string }): MyAsset {
+  return new MyAsset(parsedAsset.name);
+}
+```
+
+```typescript
+// myAsset.types.ts
+import type { MyAssetParse } from "./myAsset.pure";
+
+declare module "./myAsset.pure" {
+  namespace MyAsset {
+    export let Parse: typeof MyAssetParse;
+  }
+}
+```
+
+```typescript
+// myAsset.ts
+export * from "./myAsset.pure";
+export * from "./myAsset.types";
+
+import { MyAsset, MyAssetParse } from "./myAsset.pure";
+
+MyAsset.Parse = MyAssetParse;
+```
+
+Users who import from `myAsset.pure` can tree-shake `MyAssetParse` independently from the compatibility static. Users who import from `myAsset` get the legacy `MyAsset.Parse(...)` API and its matching type augmentation.
+
+## Transitive Dependencies
+
+If a registration function requires another registered feature, call it explicitly inside registration:
+
+```typescript
+export function registerMyMaterial(): void {
+  if (_registered) {
+    return;
+  }
+  _registered = true;
+
+  // Register transitive dependencies needed for deserialization.
+  registerTexture();
+  registerImageProcessingConfiguration();
+
+  RegisterClass("BABYLON.MyMaterial", MyMaterial);
+  SerializationHelper._MyMaterialParser = MyMaterial.Parse;
+}
+```
+
+Add transitive registration when:
+
+- Your feature's `Parse()` method will trigger another parser stub.
+- Your feature's constructor always creates instances of another registered class.
+- Your feature is unusable without the dependency.
+
+Do not add transitive registration when:
+
+- The dependency is optional.
+- The user might not serialize that sub-feature.
+- Adding it would pull in a very large module from a small utility.
+
+## Pure Annotations
+
+TypeScript decorators compile to module-scope `__decorate(...)` calls, which can block tree-shaking. The build pipeline injects `/*#__PURE__*/` annotations into compiled `.pure.js` files automatically.
+
+If your `.pure.ts` file uses decorators, no manual annotation is needed. Make sure the file uses the `.pure.ts` suffix so the post-build script can process it.
+
+## Validation Checklist
+
+Before submitting a PR that adds or modifies tree-shakeable code:
+
+1. Run `npm run build:es6` and confirm TypeScript compiles with 0 errors.
+2. Run `npm run lint:check`. The `no-side-effect-imports-in-pure` rule catches bare side-effect imports in `.pure.ts` files and missing `/*#__PURE__*/` annotations on call expressions.
+3. Run `npm run check:treeshaking`. This unified check verifies manifest drift, pure barrels, and side-effect stubs.
+4. Run `npm run test:treeshaking` and confirm all bundle smoke tests pass.
+
+If `check:treeshaking` fails, the error message tells you which fix command to run:
+
+```bash
+# If manifest drift is detected:
+node scripts/treeshaking/auditSideEffects.mjs --out scripts/treeshaking/side-effects-manifest.json
+node scripts/treeshaking/syncSideEffects.mjs
+
+# If pure barrels are out of date:
+npm run generate:pure-barrels
+
+# If side-effect stubs are out of date:
+npm run generate:side-effect-stubs
+```
+
+## Automation Scripts
+
+| Script                                        | Purpose                                             | Usage                                         |
+| --------------------------------------------- | --------------------------------------------------- | --------------------------------------------- |
+| `verifyTreeShaking.mjs`                       | Unified CI check for manifest, barrels, and stubs   | `npm run check:treeshaking`                   |
+| `checkManifestDrift.mjs`                      | Verify manifest matches source                      | `npm run check:manifest-drift`                |
+| `generatePureBarrels.mjs`                     | Regenerate `pure.ts` barrel files                   | `npm run generate:pure-barrels`               |
+| `generateSideEffectStubs.mjs`                 | Generate prototype warning stubs                    | `npm run generate:side-effect-stubs`          |
+| `auditSideEffects.mjs`                        | Scan for all side effects                           | `npm run audit:side-effects`                  |
+| `syncSideEffects.mjs`                         | Sync manifest to package metadata                   | `npm run sync:side-effects`                   |
+| `injectPureAnnotations.mjs`                   | Inject `/*#__PURE__*/` in compiled JS               | Runs automatically during build               |
+| `bundleSmokeTest.mjs`                         | Run tree-shaking bundle tests                       | `npm run test:treeshaking`                    |
+| `fixPureImports.mjs`                          | Rewrite imports in `.pure.ts` to `.pure` specifiers | `node scripts/treeshaking/fixPureImports.mjs` |
+
+Both `generatePureBarrels.mjs` and `generateSideEffectStubs.mjs` support `--check` mode, which is used by `verifyTreeShaking.mjs` to compare expected output to committed files without modifying anything.
+
+## Quick Reference: File Header Convention
+
+```typescript
+// .pure.ts files:
+/** This file must only contain pure code and pure imports */
+
+// .types.ts files:
+// No special header needed. These only contain declare module blocks.
+
+// .ts wrapper files:
+// No special header needed. These are thin wrappers.
+```

--- a/content/setup/frameworkPackages/es6Support/treeShaking/contributing.md
+++ b/content/setup/frameworkPackages/es6Support/treeShaking/contributing.md
@@ -16,9 +16,11 @@ video-content:
 
 This guide is for contributors adding or modifying Babylon.js framework code. Application developers should start with [Using Pure Imports](/setup/frameworkPackages/es6Support/treeShaking/usingPureImports) and [Registering Side Effects](/setup/frameworkPackages/es6Support/treeShaking/registeringSideEffects).
 
-## The Three-File Pattern
+## The File Pattern
 
-Every module with side effects is split into up to three files:
+Most files in Babylon.js have no side effects. These use a regular filename, such as `feature.ts`, and do not need any special treatment.
+
+The multi-file pattern only applies to modules with side effects. Those are split into up to three files:
 
 ```text
 feature.pure.ts  -> Implementation and registration function
@@ -26,23 +28,27 @@ feature.types.ts -> TypeScript module augmentations, if any
 feature.ts       -> Backward-compatible wrapper
 ```
 
-Use all three files when a feature adds methods or properties to existing classes and needs `declare module` augmentation. Use only `feature.pure.ts` and `feature.ts` when a feature has runtime side effects, such as `RegisterClass`, but no type augmentation.
+Not every side-effect module needs all three files. The `.types.ts` file is only needed when the feature adds methods or properties to another class.
 
-### When You Need All Three Files
+### No Side Effects: Regular File
+
+If your feature has no side effects at all, use the regular filename: `feature.ts`. No `.pure.ts`, wrapper, or `.types.ts` file is needed. This is the most common case.
+
+### Side Effects Without Type Augmentations: Two Files
+
+If your feature only has `RegisterClass` calls or static assignments, with no prototype augmentation:
+
+- `feature.pure.ts` contains the implementation and `RegisterFeature()` function.
+- `feature.ts` is the wrapper that calls `RegisterFeature()`.
+
+No `.types.ts` file is needed if there are no `declare module` blocks.
+
+### Side Effects With Type Augmentations: Three Files
 
 You need all three if your feature:
 
 - Adds methods or properties to existing classes.
-- Uses `declare module` to augment type definitions.
-
-### When You Need Only Two Files
-
-If your feature only has `RegisterClass` calls or static assignments, with no prototype augmentation:
-
-- `feature.pure.ts` contains the implementation and `registerFeature()` function.
-- `feature.ts` is the wrapper that calls `registerFeature()`.
-
-No `.types.ts` file is needed if there are no `declare module` blocks.
+- Uses `declare module` to tell TypeScript about those added members.
 
 ## Step-by-Step: Adding a New Prototype Augmentation
 
@@ -87,7 +93,7 @@ export class MyFeatureSceneComponent {
 }
 
 let _registered = false;
-export function registerMyFeatureSceneComponent(): void {
+export function RegisterMyFeatureSceneComponent(): void {
   if (_registered) {
     return;
   }
@@ -105,7 +111,7 @@ Rules:
 
 - Start `.pure.ts` files with `/** This file must only contain pure code and pure imports */`.
 - Re-export the `.types` module when the feature has type augmentations.
-- Put all side effects inside the `registerXxx()` function.
+- Put all side effects inside the `RegisterXxx()` function.
 - Guard registration with an idempotency flag.
 - Import from `.pure` specifiers when a pure module exists.
 - Keep `RegisterClass` calls inside the registration function.
@@ -115,9 +121,9 @@ Rules:
 ```typescript
 // myFeatureSceneComponent.ts
 export * from "./myFeatureSceneComponent.pure";
-import { registerMyFeatureSceneComponent } from "./myFeatureSceneComponent.pure";
+import { RegisterMyFeatureSceneComponent } from "./myFeatureSceneComponent.pure";
 
-registerMyFeatureSceneComponent();
+RegisterMyFeatureSceneComponent();
 ```
 
 The wrapper preserves existing behavior: importing the non-pure module still runs the compatibility side effects.
@@ -168,7 +174,7 @@ export class MyNewMesh extends Mesh {
 }
 
 let _registered = false;
-export function registerMyNewMesh(): void {
+export function RegisterMyNewMesh(): void {
   if (_registered) {
     return;
   }
@@ -183,23 +189,23 @@ export function registerMyNewMesh(): void {
 ```typescript
 // myNewMesh.ts
 export * from "./myNewMesh.pure";
-import { registerMyNewMesh } from "./myNewMesh.pure";
+import { RegisterMyNewMesh } from "./myNewMesh.pure";
 
-registerMyNewMesh();
+RegisterMyNewMesh();
 ```
 
 ## Naming Conventions
 
 ### Registration Function Naming
 
-Registration functions use `register` plus the PascalCase file name:
+Registration functions always use `Register` plus the PascalCase file name:
 
 | Filename                               | Function                                 |
 | -------------------------------------- | ---------------------------------------- |
-| `standardMaterial.pure.ts`             | `registerStandardMaterial()`             |
-| `engine.multiRender.pure.ts`           | `registerEngineMultiRender()`            |
-| `WebXRHandTracking.pure.ts`            | `registerWebXRHandTracking()`            |
-| `joinedPhysicsEngineComponent.pure.ts` | `registerJoinedPhysicsEngineComponent()` |
+| `standardMaterial.pure.ts`             | `RegisterStandardMaterial()`             |
+| `engine.multiRender.pure.ts`           | `RegisterEngineMultiRender()`            |
+| `WebXRHandTracking.pure.ts`            | `RegisterWebXRHandTracking()`            |
+| `joinedPhysicsEngineComponent.pure.ts` | `RegisterJoinedPhysicsEngineComponent()` |
 
 ## Import Specifiers in Pure Files
 
@@ -280,39 +286,38 @@ MyAsset.Parse = MyAssetParse;
 
 Users who import from `myAsset.pure` can tree-shake `MyAssetParse` independently from the compatibility static. Users who import from `myAsset` get the legacy `MyAsset.Parse(...)` API and its matching type augmentation.
 
-## Transitive Dependencies
+## Automatic Dependencies
 
-If a registration function requires another registered feature, call it explicitly inside registration:
+If a registration function depends on another registered feature, call it inside your function:
 
 ```typescript
-export function registerMyMaterial(): void {
+export function RegisterMyMaterial(): void {
   if (_registered) {
     return;
   }
   _registered = true;
 
-  // Register transitive dependencies needed for deserialization.
-  registerTexture();
-  registerImageProcessingConfiguration();
+  // Register dependencies needed for loading saved scenes.
+  RegisterTexture();
+  RegisterImageProcessingConfiguration();
 
   RegisterClass("BABYLON.MyMaterial", MyMaterial);
   SerializationHelper._MyMaterialParser = MyMaterial.Parse;
 }
 ```
 
-Add transitive registration when:
+Add automatic dependencies when:
 
-- Your feature's `Parse()` method will trigger another parser stub.
+- Your feature's `Parse()` method will trigger another missing-registration error.
 - Your feature's constructor always creates instances of another registered class.
 - Your feature is unusable without the dependency.
 
 Do not add transitive registration when:
 
 - The dependency is optional.
-- The user might not serialize that sub-feature.
 - Adding it would pull in a very large module from a small utility.
 
-## Pure Annotations
+## The `#__PURE__` Annotation
 
 TypeScript decorators compile to module-scope `__decorate(...)` calls, which can block tree-shaking. The build pipeline injects `/*#__PURE__*/` annotations into compiled `.pure.js` files automatically.
 
@@ -322,16 +327,29 @@ If your `.pure.ts` file uses decorators, no manual annotation is needed. Make su
 
 Before submitting a PR that adds or modifies tree-shakeable code:
 
-1. Run `npm run build:es6` and confirm TypeScript compiles with 0 errors.
-2. Run `npm run lint:check`. The `no-side-effect-imports-in-pure` rule catches bare side-effect imports in `.pure.ts` files and missing `/*#__PURE__*/` annotations on call expressions.
-3. Run `npm run check:treeshaking`. This unified check verifies manifest drift, pure barrels, and side-effect stubs.
-4. Run `npm run test:treeshaking` and confirm all bundle smoke tests pass.
+1. **TypeScript compiles**: `npm run build:es6` with 0 errors.
+2. **ESLint passes**: `npm run lint:check`. Two custom ESLint rules enforce tree-shaking correctness.
+3. **Tree-shaking verification passes**: `npm run check:treeshaking`, which verifies manifest drift, pure barrels, and side-effect stubs.
+4. **Side-effects sync check passes**: `npm run check:side-effects-sync`, which verifies the `sideEffects` array in `@babylonjs/core/package.json` matches the manifest.
+5. **Bundle smoke tests pass**: `npm run test:treeshaking`.
+
+`@babylonjs/require-pure-annotation` requires `/*#__PURE__*/` on module-scope calls and static field initializers in `.pure.ts` files. It is auto-fixable.
+
+`@babylonjs/no-side-effect-imports-in-pure` disallows side-effect-only imports in `.pure.ts` files and checks that `pure.ts` barrels only re-export side-effect-free sources.
+
+The full CI check runs all of these together:
+
+```bash
+npm run check:treeshaking-all
+```
 
 If `check:treeshaking` fails, the error message tells you which fix command to run:
 
 ```bash
 # If manifest drift is detected:
-node scripts/treeshaking/auditSideEffects.mjs --out scripts/treeshaking/side-effects-manifest.json
+npm run update:manifest
+
+# If sideEffects array is out of sync:
 node scripts/treeshaking/syncSideEffects.mjs
 
 # If pure barrels are out of date:
@@ -343,19 +361,33 @@ npm run generate:side-effect-stubs
 
 ## Automation Scripts
 
-| Script                        | Purpose                                             | Usage                                         |
-| ----------------------------- | --------------------------------------------------- | --------------------------------------------- |
-| `verifyTreeShaking.mjs`       | Unified CI check for manifest, barrels, and stubs   | `npm run check:treeshaking`                   |
-| `checkManifestDrift.mjs`      | Verify manifest matches source                      | `npm run check:manifest-drift`                |
-| `generatePureBarrels.mjs`     | Regenerate `pure.ts` barrel files                   | `npm run generate:pure-barrels`               |
-| `generateSideEffectStubs.mjs` | Generate prototype warning stubs                    | `npm run generate:side-effect-stubs`          |
-| `auditSideEffects.mjs`        | Scan for all side effects                           | `npm run audit:side-effects`                  |
-| `syncSideEffects.mjs`         | Sync manifest to package metadata                   | `npm run sync:side-effects`                   |
-| `injectPureAnnotations.mjs`   | Inject `/*#__PURE__*/` in compiled JS               | Runs automatically during build               |
-| `bundleSmokeTest.mjs`         | Run tree-shaking bundle tests                       | `npm run test:treeshaking`                    |
-| `fixPureImports.mjs`          | Rewrite imports in `.pure.ts` to `.pure` specifiers | `node scripts/treeshaking/fixPureImports.mjs` |
+| Script                        | npm Command                          | Purpose                                             |
+| ----------------------------- | ------------------------------------ | --------------------------------------------------- |
+| `verifyTreeShaking.mjs`       | `npm run check:treeshaking`          | Unified CI check for manifest, barrels, and stubs   |
+| `checkManifestDrift.mjs`      | `npm run check:manifest-drift`       | Verify manifest matches source                      |
+| `generatePureBarrels.mjs`     | `npm run generate:pure-barrels`      | Regenerate `pure.ts` barrel files                   |
+| `generateSideEffectStubs.mjs` | `npm run generate:side-effect-stubs` | Generate prototype warning stubs                    |
+| `auditSideEffects.mjs`        | `npm run audit:side-effects`         | Scan for all side effects                           |
+| `syncSideEffects.mjs`         | (manual)                             | Sync manifest to package metadata                   |
+| `injectPureAnnotations.mjs`   | (runs automatically during build)    | Inject `/*#__PURE__*/` in compiled JS               |
+| `bundleSmokeTest.mjs`         | `npm run test:treeshaking`           | Run tree-shaking bundle tests                       |
+| `fixPureImports.mjs`          | (manual)                             | Rewrite imports in `.pure.ts` to `.pure` specifiers |
 
 Both `generatePureBarrels.mjs` and `generateSideEffectStubs.mjs` support `--check` mode, which is used by `verifyTreeShaking.mjs` to compare expected output to committed files without modifying anything.
+
+`syncSideEffects.mjs` also supports `--check` mode, used by `npm run check:side-effects-sync` in CI.
+
+## Pre-Commit Hook
+
+The Babylon.js repository uses a `.githooks/pre-commit` hook. When core source files are staged, the hook automatically:
+
+1. Runs `npm run precommit`.
+2. Regenerates the side-effects manifest with `npm run update:manifest`.
+3. Regenerates pure barrels with `npm run generate:pure-barrels`.
+4. Regenerates side-effect stubs with `npm run generate:side-effect-stubs`.
+5. Stages the updated manifest, package metadata, and generated barrels.
+
+After editing `.pure.ts` files, the hook handles the common generation steps. You can still run the individual commands manually to verify before committing.
 
 ## Quick Reference: File Header Convention
 
@@ -364,8 +396,8 @@ Both `generatePureBarrels.mjs` and `generateSideEffectStubs.mjs` support `--chec
 /** This file must only contain pure code and pure imports */
 
 // .types.ts files:
-// No special header needed. These only contain declare module blocks.
+// No special header needed; these only contain declare module blocks.
 
 // .ts wrapper files:
-// No special header needed. These are thin wrappers.
+// No special header needed; these are thin wrappers.
 ```

--- a/content/setup/frameworkPackages/es6Support/treeShaking/contributing.md
+++ b/content/setup/frameworkPackages/es6Support/treeShaking/contributing.md
@@ -343,17 +343,17 @@ npm run generate:side-effect-stubs
 
 ## Automation Scripts
 
-| Script                                        | Purpose                                             | Usage                                         |
-| --------------------------------------------- | --------------------------------------------------- | --------------------------------------------- |
-| `verifyTreeShaking.mjs`                       | Unified CI check for manifest, barrels, and stubs   | `npm run check:treeshaking`                   |
-| `checkManifestDrift.mjs`                      | Verify manifest matches source                      | `npm run check:manifest-drift`                |
-| `generatePureBarrels.mjs`                     | Regenerate `pure.ts` barrel files                   | `npm run generate:pure-barrels`               |
-| `generateSideEffectStubs.mjs`                 | Generate prototype warning stubs                    | `npm run generate:side-effect-stubs`          |
-| `auditSideEffects.mjs`                        | Scan for all side effects                           | `npm run audit:side-effects`                  |
-| `syncSideEffects.mjs`                         | Sync manifest to package metadata                   | `npm run sync:side-effects`                   |
-| `injectPureAnnotations.mjs`                   | Inject `/*#__PURE__*/` in compiled JS               | Runs automatically during build               |
-| `bundleSmokeTest.mjs`                         | Run tree-shaking bundle tests                       | `npm run test:treeshaking`                    |
-| `fixPureImports.mjs`                          | Rewrite imports in `.pure.ts` to `.pure` specifiers | `node scripts/treeshaking/fixPureImports.mjs` |
+| Script                        | Purpose                                             | Usage                                         |
+| ----------------------------- | --------------------------------------------------- | --------------------------------------------- |
+| `verifyTreeShaking.mjs`       | Unified CI check for manifest, barrels, and stubs   | `npm run check:treeshaking`                   |
+| `checkManifestDrift.mjs`      | Verify manifest matches source                      | `npm run check:manifest-drift`                |
+| `generatePureBarrels.mjs`     | Regenerate `pure.ts` barrel files                   | `npm run generate:pure-barrels`               |
+| `generateSideEffectStubs.mjs` | Generate prototype warning stubs                    | `npm run generate:side-effect-stubs`          |
+| `auditSideEffects.mjs`        | Scan for all side effects                           | `npm run audit:side-effects`                  |
+| `syncSideEffects.mjs`         | Sync manifest to package metadata                   | `npm run sync:side-effects`                   |
+| `injectPureAnnotations.mjs`   | Inject `/*#__PURE__*/` in compiled JS               | Runs automatically during build               |
+| `bundleSmokeTest.mjs`         | Run tree-shaking bundle tests                       | `npm run test:treeshaking`                    |
+| `fixPureImports.mjs`          | Rewrite imports in `.pure.ts` to `.pure` specifiers | `node scripts/treeshaking/fixPureImports.mjs` |
 
 Both `generatePureBarrels.mjs` and `generateSideEffectStubs.mjs` support `--check` mode, which is used by `verifyTreeShaking.mjs` to compare expected output to committed files without modifying anything.
 

--- a/content/setup/frameworkPackages/es6Support/treeShaking/registeringSideEffects.md
+++ b/content/setup/frameworkPackages/es6Support/treeShaking/registeringSideEffects.md
@@ -160,29 +160,54 @@ Some registration functions automatically register the features they depend on. 
 
 You do not need to manually register dependencies that are already handled this way. If you are unsure, calling a registration function multiple times is harmless.
 
-## CheckMissingImports Diagnostic
+## The `CheckMissingImports` Diagnostic
 
-If you are unsure which registrations your application needs, use the development diagnostic utility:
+If you're unsure which registrations your app needs, use the diagnostic utility:
 
 ```typescript
 import { CheckMissingImports } from "@babylonjs/core/Misc/checkMissingImports";
 
+// Call after all your imports but before scene logic
 const missing = CheckMissingImports();
 ```
 
-This scans all known placeholders and reports which features have not been registered:
+This scans all known placeholders (stubs) and reports which features haven't been registered:
 
-```text
+```
 [Babylon.js] The following side-effect modules have not been imported:
   - Ray
   - ImageProcessingConfiguration
   - Texture
 Note: These are only required if your application uses the corresponding features.
 If you do use them, import the modules or their parent packages to avoid runtime errors.
-See: https://doc.babylonjs.com/setup/frameworkPackages/es6Support/treeShaking
+See: https://doc.babylonjs.com/setup/treeshaking
 ```
 
-`CheckMissingImports` can report modules your application never uses. Treat it as a development aid, then register only the features your code actually needs. Do not include this diagnostic in production builds.
+**Important**: `CheckMissingImports` reports ALL unregistered stubs, even ones your app may never hit. Not every reported module needs to be imported — only the ones your code actually uses.
+
+This utility is intended for **development only**. It imports several core modules to test their stubs, so don't include it in production builds.
+
+## Runtime Stub Warning Diagnostics
+
+`CheckMissingImports()` reports all known unregistered stubs, including features your app may never use. If you want to debug only the missing side-effect registrations that are actually called at runtime, enable one-time stub warnings:
+
+```typescript
+import { SetMissingSideEffectWarningsEnabled } from "@babylonjs/core/Misc/devTools";
+
+SetMissingSideEffectWarningsEnabled(true);
+```
+
+Missing side-effect stubs are quiet by default because Babylon internals may probe optional augmented APIs. When warnings are enabled, each missing `Class.method` logs at most once. For code that intentionally probes optional APIs, suppress warnings around the synchronous probe:
+
+```typescript
+import { SuppressMissingSideEffectWarnings } from "@babylonjs/core/Misc/devTools";
+
+SuppressMissingSideEffectWarnings(() => {
+  scene.getPhysicsEngine?.();
+});
+```
+
+Keep runtime stub warnings as a development diagnostic unless your application intentionally wants this logging in production.
 
 ## Safe to Call Multiple Times
 

--- a/content/setup/frameworkPackages/es6Support/treeShaking/registeringSideEffects.md
+++ b/content/setup/frameworkPackages/es6Support/treeShaking/registeringSideEffects.md
@@ -1,0 +1,187 @@
+---
+title: Registering Side Effects
+image:
+description: Activate Babylon.js side-effect features explicitly when using pure imports.
+keywords: babylon.js, pure imports, side effects, register functions, serialization, shaders, xr, physics
+further-reading:
+  - title: Tree-Shaking with Pure Imports
+    url: /setup/frameworkPackages/es6Support/treeShaking
+  - title: Using Pure Imports
+    url: /setup/frameworkPackages/es6Support/treeShaking/usingPureImports
+  - title: Troubleshooting Pure Imports
+    url: /setup/frameworkPackages/es6Support/treeShaking/troubleshooting
+video-overview:
+video-content:
+---
+
+## What Side Effects Are
+
+In the context of tree-shaking, a side effect is code that modifies shared state when a module is imported. Babylon.js uses side effects for several categories of behavior:
+
+| Category                      | Purpose                                    | Example                                   |
+| ----------------------------- | ------------------------------------------ | ----------------------------------------- |
+| `RegisterClass`               | Enable deserialization by class name       | `RegisterClass("BABYLON.Camera", Camera)` |
+| Prototype augmentation        | Add optional methods to core classes       | `Scene.prototype.enablePhysics = ...`     |
+| Shader registration           | Register shader source for GPU compilation | `ShaderStore["default"] = "..."`          |
+| Feature registration          | Make features discoverable by name         | WebXR feature registration                |
+| Node constructor registration | Enable node-based editor blocks            | `AddNodeConstructor("Block", ...)`        |
+
+With pure imports, these side effects do not run automatically. You opt in by calling the matching `registerXxx()` function.
+
+## Finding Registration Functions
+
+Registration functions follow the naming pattern `register` plus the PascalCase file name:
+
+| File                                   | Registration function                    |
+| -------------------------------------- | ---------------------------------------- |
+| `standardMaterial.pure.ts`             | `registerStandardMaterial()`             |
+| `joinedPhysicsEngineComponent.pure.ts` | `registerJoinedPhysicsEngineComponent()` |
+| `engine.multiRender.pure.ts`           | `registerEngineMultiRender()`            |
+| `depthRendererSceneComponent.pure.ts`  | `registerDepthRendererSceneComponent()`  |
+| `boundingBoxRenderer.pure.ts`          | `registerBoundingBoxRenderer()`          |
+
+Type `register` in your IDE to discover available registration functions. The names map directly to the Babylon.js module paths you already know.
+
+## Material and Serialization Registration
+
+Serialized content needs class and parser registration so Babylon.js can recreate objects by class name:
+
+```typescript
+import { registerStandardMaterial, registerPBRMaterial, registerImageProcessingConfiguration, registerTexture, registerFresnelParameters } from "@babylonjs/core/pure";
+
+registerStandardMaterial();
+registerPBRMaterial();
+registerImageProcessingConfiguration();
+registerTexture();
+registerFresnelParameters();
+```
+
+Register these when loading `.babylon` files, snippets, or other serialized content that may contain those types.
+
+## Scene Component Registration
+
+Some features add methods to existing classes such as `Scene`, `Engine`, `Mesh`, or `Camera`:
+
+```typescript
+import { registerJoinedPhysicsEngineComponent } from "@babylonjs/core/pure";
+import "@babylonjs/core/Physics/joinedPhysicsEngineComponent.types";
+
+registerJoinedPhysicsEngineComponent();
+```
+
+After registration, methods such as `scene.enablePhysics()` are available at runtime. The `.types` import makes TypeScript aware of the same methods.
+
+Other common scene component registrations include:
+
+```typescript
+import { registerRay, registerDepthRendererSceneComponent, registerBoundingBoxRenderer } from "@babylonjs/core/pure";
+
+registerRay();
+registerDepthRendererSceneComponent();
+registerBoundingBoxRenderer();
+```
+
+## Engine Extension Registration
+
+Engine extensions are also explicit with pure imports:
+
+```typescript
+import { registerEngineMultiRender, registerEngineOcclusionQuery, registerEngineTransformFeedback } from "@babylonjs/core/pure";
+
+registerEngineMultiRender();
+registerEngineOcclusionQuery();
+registerEngineTransformFeedback();
+```
+
+## Node Editor Block Registration
+
+Node Material, Node Geometry, Node Particle, Flow Graph, and Node Render Graph systems need block registration for deserialization and editor workflows.
+
+Register all blocks for a system:
+
+```typescript
+import { registerAllNodeMaterialBlocks } from "@babylonjs/core/pure";
+
+registerAllNodeMaterialBlocks();
+```
+
+Or register only selected categories:
+
+```typescript
+import { registerNodeMaterialPBRBlocks, registerNodeMaterialMathBlocks, registerNodeMaterialVertexBlocks } from "@babylonjs/core/pure";
+
+registerNodeMaterialPBRBlocks();
+registerNodeMaterialMathBlocks();
+registerNodeMaterialVertexBlocks();
+```
+
+Bulk registrations include:
+
+| Function                             | System                   |
+| ------------------------------------ | ------------------------ |
+| `registerAllNodeMaterialBlocks()`    | Node Material Editor     |
+| `registerAllNodeGeometryBlocks()`    | Node Geometry Editor     |
+| `registerAllNodeParticleBlocks()`    | Node Particle Editor     |
+| `registerAllFlowGraphBlocks()`       | Flow Graph               |
+| `registerAllNodeRenderGraphBlocks()` | Node Render Graph Editor |
+
+## XR Feature Registration
+
+```typescript
+import { registerWebXRDefaultExperience, registerWebXRHandTracking, registerWebXRAnchorSystem, registerWebXRHitTest } from "@babylonjs/core/pure";
+
+registerWebXRDefaultExperience();
+registerWebXRHandTracking();
+registerWebXRAnchorSystem();
+registerWebXRHitTest();
+```
+
+## Transitive Dependencies
+
+Some registration functions register their own required dependencies. For example, `registerImageProcessingConfiguration()` can register related image-processing dependencies that are required by its parser path.
+
+You do not need to manually register dependencies that are already handled transitively. If you are unsure, calling a registration function multiple times is harmless because registration functions are idempotent.
+
+## CheckMissingImports Diagnostic
+
+If you are unsure which registrations your application needs, use the development diagnostic utility:
+
+```typescript
+import { CheckMissingImports } from "@babylonjs/core/Misc/checkMissingImports";
+
+const missing = CheckMissingImports();
+```
+
+It reports known side-effect stubs that have not been registered:
+
+```text
+[Babylon.js] The following side-effect modules have not been imported:
+  - Ray
+  - ImageProcessingConfiguration
+  - Texture
+Note: These are only required if your application uses the corresponding features.
+If you do use them, import the modules or their parent packages to avoid runtime errors.
+See: https://doc.babylonjs.com/setup/frameworkPackages/es6Support/treeShaking
+```
+
+`CheckMissingImports` can report modules your application never uses. Treat it as a development aid, then register only the features your code actually needs. Do not include this diagnostic in production builds.
+
+## Migration from Existing Side-Effect Imports
+
+To migrate an existing side-effect import:
+
+```typescript
+// Before:
+import "@babylonjs/core/Physics/joinedPhysicsEngineComponent";
+
+// After:
+import { registerJoinedPhysicsEngineComponent } from "@babylonjs/core/pure";
+registerJoinedPhysicsEngineComponent();
+```
+
+The mapping is straightforward:
+
+1. Take the side-effect import path.
+2. Import the matching `registerXxx` function from `@babylonjs/core/pure`.
+3. Call it before using the feature.
+4. Add the `.types` import when the feature augments TypeScript types.

--- a/content/setup/frameworkPackages/es6Support/treeShaking/registeringSideEffects.md
+++ b/content/setup/frameworkPackages/es6Support/treeShaking/registeringSideEffects.md
@@ -14,59 +14,63 @@ video-overview:
 video-content:
 ---
 
-## What Side Effects Are
+## What Are Side Effects?
 
-In the context of tree-shaking, a side effect is code that modifies shared state when a module is imported. Babylon.js uses side effects for several categories of behavior:
+In the context of tree-shaking, a side effect is any code that runs automatically when a file is imported, changing global state. Babylon.js has several categories:
 
-| Category                      | Purpose                                    | Example                                   |
-| ----------------------------- | ------------------------------------------ | ----------------------------------------- |
-| `RegisterClass`               | Enable deserialization by class name       | `RegisterClass("BABYLON.Camera", Camera)` |
-| Prototype augmentation        | Add optional methods to core classes       | `Scene.prototype.enablePhysics = ...`     |
-| Shader registration           | Register shader source for GPU compilation | `ShaderStore["default"] = "..."`          |
-| Feature registration          | Make features discoverable by name         | WebXR feature registration                |
-| Node constructor registration | Enable node-based editor blocks            | `AddNodeConstructor("Block", ...)`        |
+| Category               | Purpose                                                           | Example                                   |
+| ---------------------- | ----------------------------------------------------------------- | ----------------------------------------- |
+| `RegisterClass`        | Let the engine recreate objects by name when loading saved scenes | `RegisterClass("BABYLON.Camera", Camera)` |
+| Prototype augmentation | Attach optional methods to existing classes                       | `Scene.prototype.enablePhysics = ...`     |
+| Shader registration    | Store shader source code for GPU compilation                      | `ShaderStore["default"] = "..."`          |
+| Feature registration   | Make features available by name                                   | WebXR feature registration                |
+| Node constructor       | Enable node-based editor blocks                                   | `AddNodeConstructor("Block", ...)`        |
 
-With pure imports, these side effects do not run automatically. You opt in by calling the matching `registerXxx()` function.
+When using pure imports, these side effects do not run automatically. You turn them on by calling the corresponding `RegisterXxx()` function.
 
 ## Finding Registration Functions
 
-Registration functions follow the naming pattern `register` plus the PascalCase file name:
+All registration functions follow the naming pattern `Register` plus the PascalCase file name:
 
-| File                                   | Registration function                    |
+| File                                   | Registration Function                    |
 | -------------------------------------- | ---------------------------------------- |
-| `standardMaterial.pure.ts`             | `registerStandardMaterial()`             |
-| `joinedPhysicsEngineComponent.pure.ts` | `registerJoinedPhysicsEngineComponent()` |
-| `engine.multiRender.pure.ts`           | `registerEngineMultiRender()`            |
-| `depthRendererSceneComponent.pure.ts`  | `registerDepthRendererSceneComponent()`  |
-| `boundingBoxRenderer.pure.ts`          | `registerBoundingBoxRenderer()`          |
+| `standardMaterial.pure.ts`             | `RegisterStandardMaterial()`             |
+| `joinedPhysicsEngineComponent.pure.ts` | `RegisterJoinedPhysicsEngineComponent()` |
+| `engine.multiRender.pure.ts`           | `RegisterEngineMultiRender()`            |
+| `depthRendererSceneComponent.pure.ts`  | `RegisterDepthRendererSceneComponent()`  |
+| `boundingBoxRenderer.pure.ts`          | `RegisterBoundingBoxRenderer()`          |
 
-Type `register` in your IDE to discover available registration functions. The names map directly to the Babylon.js module paths you already know.
+Type `Register` in your IDE and autocomplete will list available registration functions. The names map directly to the Babylon.js module paths you already know.
 
-## Material and Serialization Registration
+## Categories of Registration
+
+### Material and Serialization Registration
 
 Serialized content needs class and parser registration so Babylon.js can recreate objects by class name:
 
 ```typescript
-import { registerStandardMaterial, registerPBRMaterial, registerImageProcessingConfiguration, registerTexture, registerFresnelParameters } from "@babylonjs/core/pure";
+import { RegisterStandardMaterial, RegisterPBRMaterial, RegisterImageProcessingConfiguration, RegisterTexture, RegisterFresnelParameters } from "@babylonjs/core/pure";
 
-registerStandardMaterial();
-registerPBRMaterial();
-registerImageProcessingConfiguration();
-registerTexture();
-registerFresnelParameters();
+RegisterStandardMaterial();
+RegisterPBRMaterial();
+RegisterImageProcessingConfiguration(); // Also registers ColorCurves automatically
+RegisterTexture();
+RegisterFresnelParameters();
 ```
 
 Register these when loading `.babylon` files, snippets, or other serialized content that may contain those types.
 
-## Scene Component Registration
+### Scene Component Registration
 
 Some features add methods to existing classes such as `Scene`, `Engine`, `Mesh`, or `Camera`:
 
 ```typescript
-import { registerJoinedPhysicsEngineComponent } from "@babylonjs/core/pure";
+// Physics
+import { RegisterJoinedPhysicsEngineComponent } from "@babylonjs/core/pure";
 import "@babylonjs/core/Physics/joinedPhysicsEngineComponent.types";
 
-registerJoinedPhysicsEngineComponent();
+RegisterJoinedPhysicsEngineComponent();
+// Now scene.enablePhysics(), scene.getPhysicsEngine(), etc. are available
 ```
 
 After registration, methods such as `scene.enablePhysics()` are available at runtime. The `.types` import makes TypeScript aware of the same methods.
@@ -74,73 +78,87 @@ After registration, methods such as `scene.enablePhysics()` are available at run
 Other common scene component registrations include:
 
 ```typescript
-import { registerRay, registerDepthRendererSceneComponent, registerBoundingBoxRenderer } from "@babylonjs/core/pure";
+import { RegisterRay, RegisterDepthRendererSceneComponent, RegisterBoundingBoxRenderer } from "@babylonjs/core/pure";
 
-registerRay();
-registerDepthRendererSceneComponent();
-registerBoundingBoxRenderer();
+RegisterRay();
+RegisterDepthRendererSceneComponent();
+RegisterBoundingBoxRenderer();
 ```
 
-## Engine Extension Registration
+### Engine Extension Registration
 
-Engine extensions are also explicit with pure imports:
+Engine extensions add capabilities like texture loading, alpha blending, multi-render targets, and uniform buffers. Three tiered helpers let you register groups of extensions at once:
 
 ```typescript
-import { registerEngineMultiRender, registerEngineOcclusionQuery, registerEngineTransformFeedback } from "@babylonjs/core/pure";
+import { RegisterCoreEngineExtensions, RegisterStandardEngineExtensions, RegisterFullEngineExtensions } from "@babylonjs/core/pure";
 
-registerEngineMultiRender();
-registerEngineOcclusionQuery();
-registerEngineTransformFeedback();
+RegisterCoreEngineExtensions(); // Minimum: DOM, render passes, GPU states, stencil
+RegisterStandardEngineExtensions(); // Most apps: Core + textures, file loading, alpha, render targets, uniform buffers
+RegisterFullEngineExtensions(); // Everything: Standard + cube/raw/dynamic textures, multi-render, multiview, queries, compute, video, debugging
 ```
 
-## Node Editor Block Registration
+For most applications, `RegisterStandardEngineExtensions()` is the right choice. All tiers are safe to call multiple times or in combination. Calling a higher tier after a lower one just adds the missing pieces.
+
+You can also register individual extensions if you need fine-grained control:
+
+```typescript
+import { RegisterEnginesExtensionsEngineMultiRender, RegisterEngineTransformFeedback } from "@babylonjs/core/pure";
+
+RegisterEnginesExtensionsEngineMultiRender();
+RegisterEngineTransformFeedback();
+```
+
+### Node Editor Block Registration
 
 Node Material, Node Geometry, Node Particle, Flow Graph, and Node Render Graph systems need block registration for deserialization and editor workflows.
 
 Register all blocks for a system:
 
 ```typescript
-import { registerAllNodeMaterialBlocks } from "@babylonjs/core/pure";
+import { RegisterAllNodeMaterialBlocks } from "@babylonjs/core/pure";
 
-registerAllNodeMaterialBlocks();
+RegisterAllNodeMaterialBlocks();
 ```
 
 Or register only selected categories:
 
 ```typescript
-import { registerNodeMaterialPBRBlocks, registerNodeMaterialMathBlocks, registerNodeMaterialVertexBlocks } from "@babylonjs/core/pure";
+import { RegisterNodeMaterialPBRBlocks, RegisterNodeMaterialMathBlocks, RegisterNodeMaterialVertexBlocks } from "@babylonjs/core/pure";
 
-registerNodeMaterialPBRBlocks();
-registerNodeMaterialMathBlocks();
-registerNodeMaterialVertexBlocks();
+RegisterNodeMaterialPBRBlocks();
+RegisterNodeMaterialMathBlocks();
+RegisterNodeMaterialVertexBlocks();
 ```
 
 Bulk registrations include:
 
-| Function                             | System                   |
-| ------------------------------------ | ------------------------ |
-| `registerAllNodeMaterialBlocks()`    | Node Material Editor     |
-| `registerAllNodeGeometryBlocks()`    | Node Geometry Editor     |
-| `registerAllNodeParticleBlocks()`    | Node Particle Editor     |
-| `registerAllFlowGraphBlocks()`       | Flow Graph               |
-| `registerAllNodeRenderGraphBlocks()` | Node Render Graph Editor |
+| Function                             | System                   | Blocks |
+| ------------------------------------ | ------------------------ | ------ |
+| `RegisterAllNodeMaterialBlocks()`    | Node Material Editor     | ~108   |
+| `RegisterAllNodeGeometryBlocks()`    | Node Geometry Editor     | ~80    |
+| `RegisterAllNodeParticleBlocks()`    | Node Particle Editor     | ~49    |
+| `RegisterAllFlowGraphBlocks()`       | Flow Graph               | ~47    |
+| `RegisterAllNodeRenderGraphBlocks()` | Node Render Graph Editor | ~44    |
 
-## XR Feature Registration
+### XR Feature Registration
 
 ```typescript
-import { registerWebXRDefaultExperience, registerWebXRHandTracking, registerWebXRAnchorSystem, registerWebXRHitTest } from "@babylonjs/core/pure";
+import { RegisterWebXRDefaultExperience, RegisterWebXRHandTracking, RegisterWebXRAnchorSystem, RegisterWebXRHitTest } from "@babylonjs/core/pure";
 
-registerWebXRDefaultExperience();
-registerWebXRHandTracking();
-registerWebXRAnchorSystem();
-registerWebXRHitTest();
+RegisterWebXRDefaultExperience();
+RegisterWebXRHandTracking();
+RegisterWebXRAnchorSystem();
+RegisterWebXRHitTest();
 ```
 
-## Transitive Dependencies
+## Automatic Dependencies
 
-Some registration functions register their own required dependencies. For example, `registerImageProcessingConfiguration()` can register related image-processing dependencies that are required by its parser path.
+Some registration functions automatically register the features they depend on. For example:
 
-You do not need to manually register dependencies that are already handled transitively. If you are unsure, calling a registration function multiple times is harmless because registration functions are idempotent.
+- `RegisterImageProcessingConfiguration()` automatically calls `RegisterColorCurves()`.
+- `RegisterStandardMaterial()` registers the class and its parser.
+
+You do not need to manually register dependencies that are already handled this way. If you are unsure, calling a registration function multiple times is harmless.
 
 ## CheckMissingImports Diagnostic
 
@@ -152,7 +170,7 @@ import { CheckMissingImports } from "@babylonjs/core/Misc/checkMissingImports";
 const missing = CheckMissingImports();
 ```
 
-It reports known side-effect stubs that have not been registered:
+This scans all known placeholders and reports which features have not been registered:
 
 ```text
 [Babylon.js] The following side-effect modules have not been imported:
@@ -166,6 +184,22 @@ See: https://doc.babylonjs.com/setup/frameworkPackages/es6Support/treeShaking
 
 `CheckMissingImports` can report modules your application never uses. Treat it as a development aid, then register only the features your code actually needs. Do not include this diagnostic in production builds.
 
+## Safe to Call Multiple Times
+
+All registration functions are safe to call more than once. Only the first call actually does anything:
+
+```typescript
+RegisterStandardMaterial();
+RegisterStandardMaterial(); // No-op, already registered
+RegisterStandardMaterial(); // No-op
+```
+
+This means:
+
+- You can safely call registration functions from multiple modules.
+- Libraries can register what they need without worrying about duplicate calls.
+- The order of registration usually does not matter, except for dependencies that must exist before use.
+
 ## Migration from Existing Side-Effect Imports
 
 To migrate an existing side-effect import:
@@ -175,13 +209,14 @@ To migrate an existing side-effect import:
 import "@babylonjs/core/Physics/joinedPhysicsEngineComponent";
 
 // After:
-import { registerJoinedPhysicsEngineComponent } from "@babylonjs/core/pure";
-registerJoinedPhysicsEngineComponent();
+import { RegisterJoinedPhysicsEngineComponent } from "@babylonjs/core/pure";
+RegisterJoinedPhysicsEngineComponent();
 ```
 
 The mapping is straightforward:
 
 1. Take the side-effect import path.
-2. Import the matching `registerXxx` function from `@babylonjs/core/pure`.
-3. Call it before using the feature.
-4. Add the `.types` import when the feature augments TypeScript types.
+2. Add `.pure` before the extension.
+3. Import the matching `RegisterXxx` function from `@babylonjs/core/pure`, where `Xxx` is the PascalCase filename.
+4. Call it before using the feature.
+5. Add the `.types` import when the feature augments TypeScript types.

--- a/content/setup/frameworkPackages/es6Support/treeShaking/troubleshooting.md
+++ b/content/setup/frameworkPackages/es6Support/treeShaking/troubleshooting.md
@@ -26,46 +26,60 @@ For example:
 Uncaught StandardMaterial needs to be imported before as it contains a side-effect required by your code.
 ```
 
-Register the matching feature:
+Import and call the corresponding registration function:
 
 ```typescript
-import { registerStandardMaterial } from "@babylonjs/core/pure";
+import { RegisterStandardMaterial } from "@babylonjs/core/pure";
 
-registerStandardMaterial();
+RegisterStandardMaterial();
 ```
 
 Common triggers include:
 
 | Error message                                          | Registration needed                      |
 | ------------------------------------------------------ | ---------------------------------------- |
-| `StandardMaterial needs to be imported...`             | `registerStandardMaterial()`             |
-| `ImageProcessingConfiguration needs to be imported...` | `registerImageProcessingConfiguration()` |
-| `ColorCurves needs to be imported...`                  | `registerColorCurves()`                  |
-| `Texture needs to be imported...`                      | `registerTexture()`                      |
-| `FresnelParameters needs to be imported...`            | `registerFresnelParameters()`            |
-| `Ray needs to be imported...`                          | `registerRay()`                          |
-| `CubeTexture needs to be imported...`                  | `registerCubeTexture()`                  |
-| `InstancedMesh needs to be imported...`                | `registerInstancedMesh()`                |
+| `StandardMaterial needs to be imported...`             | `RegisterStandardMaterial()`             |
+| `ImageProcessingConfiguration needs to be imported...` | `RegisterImageProcessingConfiguration()` |
+| `ColorCurves needs to be imported...`                  | `RegisterColorCurves()`                  |
+| `Texture needs to be imported...`                      | `RegisterTexture()`                      |
+| `FresnelParameters needs to be imported...`            | `RegisterFresnelParameters()`            |
+| `Ray needs to be imported...`                          | `RegisterRay()`                          |
+| `CubeTexture needs to be imported...`                  | `RegisterCubeTexture()`                  |
+| `InstancedMesh needs to be imported...`                | `RegisterInstancedMesh()`                |
 
 ### TypeError: scene.enablePhysics is not a function
 
-The physics scene component has not been registered. The method is added to `Scene` only after registration:
+The physics component has not been registered. The `enablePhysics` method only becomes available after registration:
 
 ```typescript
-import { registerJoinedPhysicsEngineComponent } from "@babylonjs/core/pure";
+import { RegisterJoinedPhysicsEngineComponent } from "@babylonjs/core/pure";
 import "@babylonjs/core/Physics/joinedPhysicsEngineComponent.types";
 
-registerJoinedPhysicsEngineComponent();
+RegisterJoinedPhysicsEngineComponent();
 ```
 
-### TypeError: scene.pick is not a function
+### Engine methods missing or textures not loading
+
+Engine extensions have not been registered. When using pure imports, the engine starts with minimal functionality. Texture loading, alpha blending, render targets, and other engine capabilities are optional extensions.
+
+Register engine extensions using one of the tiered helpers:
+
+```typescript
+import { RegisterStandardEngineExtensions } from "@babylonjs/core/pure";
+
+RegisterStandardEngineExtensions();
+```
+
+For advanced features such as compute shaders, cube textures, or multiview, use `RegisterFullEngineExtensions()` instead. See [Engine Registration Tiers](/setup/frameworkPackages/es6Support/treeShaking#engine-registration-tiers) for details.
+
+### TypeError: scene.pick is not a function (or createPickingRay)
 
 Picking functionality depends on ray registration:
 
 ```typescript
-import { registerRay } from "@babylonjs/core/pure";
+import { RegisterRay } from "@babylonjs/core/pure";
 
-registerRay();
+RegisterRay();
 ```
 
 ### TypeScript error: Property 'enablePhysics' does not exist on type 'Scene'
@@ -78,7 +92,7 @@ import "@babylonjs/core/Physics/joinedPhysicsEngineComponent.types";
 
 Use `.types` imports for features that augment classes with additional methods or properties.
 
-### Cascading Errors
+### Cascading Errors (Fix One, Hit the Next)
 
 Some features have dependencies. You might fix one missing registration and then see another error when a dependent feature is reached.
 
@@ -91,11 +105,13 @@ To resolve this:
 A common serialized-scene setup looks like this:
 
 ```typescript
-registerStandardMaterial();
-registerPBRMaterial();
-registerImageProcessingConfiguration();
-registerTexture();
-registerFresnelParameters();
+import { RegisterStandardMaterial, RegisterPBRMaterial, RegisterImageProcessingConfiguration, RegisterTexture, RegisterFresnelParameters } from "@babylonjs/core/pure";
+
+RegisterStandardMaterial();
+RegisterPBRMaterial();
+RegisterImageProcessingConfiguration();
+RegisterTexture();
+RegisterFresnelParameters();
 ```
 
 ### Materials Appear Black or Default After Loading
@@ -103,9 +119,9 @@ registerFresnelParameters();
 The material class was not registered, so deserialization could not recreate it correctly. Register the material type used by your content:
 
 ```typescript
-import { registerPBRMaterial } from "@babylonjs/core/pure";
+import { RegisterPBRMaterial } from "@babylonjs/core/pure";
 
-registerPBRMaterial();
+RegisterPBRMaterial();
 ```
 
 ### Shader compilation error: include "X" not found
@@ -113,9 +129,9 @@ registerPBRMaterial();
 A shader include has not been registered in the shader store. Register the material or effect that owns the shader dependency:
 
 ```typescript
-import { registerStandardMaterial } from "@babylonjs/core/pure";
+import { RegisterStandardMaterial } from "@babylonjs/core/pure";
 
-registerStandardMaterial();
+RegisterStandardMaterial();
 ```
 
 For custom shaders, import the shader include module your shader needs.
@@ -137,6 +153,15 @@ if (missing.length > 0) {
 
 It can check stubs for parser registration, scene factory methods, scene picking, texture factories, mesh parsers, and node factories.
 
+**What it checks**:
+
+- SerializationHelper parser stubs such as ImageProcessingConfiguration, FresnelParameters, ColorCurves, and Texture.
+- Scene factory stubs such as DefaultMaterialFactory and CollisionCoordinatorFactory.
+- Scene picking stubs such as Ray and createPickingRay.
+- Texture factory stubs such as CubeTexture, MirrorTexture, RenderTargetTexture, and VideoTexture.
+- Mesh parser stubs such as InstancedMesh, GroundMesh, LinesMesh, TrailMesh, and GaussianSplattingMesh.
+- Node factory stubs such as AnimationRange.
+
 Not every reported module is required. The report lists what is available but unregistered, so only import the features your application actually uses.
 
 ### Side-Effect Stubs
@@ -150,14 +175,20 @@ For example, code such as `if (scene.getPhysicsEngine()) { ... }` can evaluate t
 Register side effects before you use them. A common pattern is to group application registrations near the top of your entry point:
 
 ```typescript
-import { registerStandardMaterial, registerRay, registerJoinedPhysicsEngineComponent } from "@babylonjs/core/pure";
+import { RegisterStandardMaterial, RegisterRay, RegisterJoinedPhysicsEngineComponent } from "@babylonjs/core/pure";
 
-registerStandardMaterial();
-registerRay();
-registerJoinedPhysicsEngineComponent();
+RegisterStandardMaterial();
+RegisterRay();
+RegisterJoinedPhysicsEngineComponent();
 ```
 
 Registration functions are typically small. The main bundle-size benefit comes from not importing the modules your application does not need.
+
+| Approach                                | Approximate Bundle Size |
+| --------------------------------------- | ----------------------- |
+| `@babylonjs/core` (everything)          | ~6+ MB minified         |
+| `@babylonjs/core/pure` (typical app)    | ~1.5-3 MB minified      |
+| Minimal scene (pure, few registrations) | ~1-1.5 MB minified      |
 
 ## Migration Checklist
 
@@ -165,7 +196,7 @@ When converting an existing project to pure imports:
 
 1. Switch value imports to `.pure` paths or the pure barrel.
 2. Identify bare side-effect imports such as `import "@babylonjs/core/..."`.
-3. Replace each side-effect import with the matching `registerXxx()` import and call.
+3. Replace each side-effect import with the matching `RegisterXxx` import and call.
 4. Add `.types` imports for type augmentations you use.
 5. Run `CheckMissingImports()` during development.
 6. Test asset loading, picking, physics, XR, materials, and any optional systems your app uses.

--- a/content/setup/frameworkPackages/es6Support/treeShaking/troubleshooting.md
+++ b/content/setup/frameworkPackages/es6Support/treeShaking/troubleshooting.md
@@ -164,13 +164,47 @@ It can check stubs for parser registration, scene factory methods, scene picking
 
 Not every reported module is required. The report lists what is available but unregistered, so only import the features your application actually uses.
 
-### Side-Effect Stubs
+### Side-Effect Warning Stubs
 
 When pure imports are used, augmented prototype methods can be represented by lightweight stubs until registration occurs. These stubs make missing side effects easier to diagnose and allow feature-detection checks to remain safe.
 
+These stubs:
+
+- Return `undefined`, so feature-detection code like `if (scene.getPhysicsEngine())` works correctly.
+- Do not log warnings by default, because internal engine code may probe optional features frequently.
+- Produce a clear `TypeError` if you try to use the return value as an object.
+
 For example, code such as `if (scene.getPhysicsEngine()) { ... }` can evaluate to `false` when physics is not registered, instead of crashing during a feature check.
 
+To debug a pure-import scene and see which missing side-effect registrations are actually being called, enable runtime stub warnings during development:
+
+```typescript
+import { SetMissingSideEffectWarningsEnabled } from "@babylonjs/core/Misc/devTools";
+
+SetMissingSideEffectWarningsEnabled(true);
+```
+
+With this enabled, each missing side-effect stub logs at most once:
+
+```text
+[Babylon.js] Scene.getPhysicsEngine() requires a side-effect import. See: https://doc.babylonjs.com/setup/frameworkPackages/es6Support/treeShaking
+```
+
+If your code intentionally probes optional augmented APIs, suppress warnings around that synchronous probe:
+
+```typescript
+import { SuppressMissingSideEffectWarnings } from "@babylonjs/core/Misc/devTools";
+
+SuppressMissingSideEffectWarnings(() => {
+  scene.getPhysicsEngine?.();
+});
+```
+
+Use runtime warnings as a development diagnostic. For a broad startup report of all known unregistered stubs, use `CheckMissingImports()` instead.
+
 ## Performance Considerations
+
+### Registration Timing
 
 Register side effects before you use them. A common pattern is to group application registrations near the top of your entry point:
 
@@ -181,6 +215,8 @@ RegisterStandardMaterial();
 RegisterRay();
 RegisterJoinedPhysicsEngineComponent();
 ```
+
+### Bundle Size Impact
 
 Registration functions are typically small. The main bundle-size benefit comes from not importing the modules your application does not need.
 

--- a/content/setup/frameworkPackages/es6Support/treeShaking/troubleshooting.md
+++ b/content/setup/frameworkPackages/es6Support/treeShaking/troubleshooting.md
@@ -1,0 +1,172 @@
+---
+title: Troubleshooting Pure Imports
+image:
+description: Diagnose common runtime and TypeScript issues when using Babylon.js pure imports.
+keywords: babylon.js, pure imports, troubleshooting, side effects, tree shaking, missing imports
+further-reading:
+  - title: Tree-Shaking with Pure Imports
+    url: /setup/frameworkPackages/es6Support/treeShaking
+  - title: Using Pure Imports
+    url: /setup/frameworkPackages/es6Support/treeShaking/usingPureImports
+  - title: Registering Side Effects
+    url: /setup/frameworkPackages/es6Support/treeShaking/registeringSideEffects
+video-overview:
+video-content:
+---
+
+## Common Errors
+
+### "X needs to be imported before as it contains a side-effect required by your code"
+
+This means your code reached a feature that requires registration, but the matching registration function has not been called.
+
+For example:
+
+```text
+Uncaught StandardMaterial needs to be imported before as it contains a side-effect required by your code.
+```
+
+Register the matching feature:
+
+```typescript
+import { registerStandardMaterial } from "@babylonjs/core/pure";
+
+registerStandardMaterial();
+```
+
+Common triggers include:
+
+| Error message                                          | Registration needed                      |
+| ------------------------------------------------------ | ---------------------------------------- |
+| `StandardMaterial needs to be imported...`             | `registerStandardMaterial()`             |
+| `ImageProcessingConfiguration needs to be imported...` | `registerImageProcessingConfiguration()` |
+| `ColorCurves needs to be imported...`                  | `registerColorCurves()`                  |
+| `Texture needs to be imported...`                      | `registerTexture()`                      |
+| `FresnelParameters needs to be imported...`            | `registerFresnelParameters()`            |
+| `Ray needs to be imported...`                          | `registerRay()`                          |
+| `CubeTexture needs to be imported...`                  | `registerCubeTexture()`                  |
+| `InstancedMesh needs to be imported...`                | `registerInstancedMesh()`                |
+
+### TypeError: scene.enablePhysics is not a function
+
+The physics scene component has not been registered. The method is added to `Scene` only after registration:
+
+```typescript
+import { registerJoinedPhysicsEngineComponent } from "@babylonjs/core/pure";
+import "@babylonjs/core/Physics/joinedPhysicsEngineComponent.types";
+
+registerJoinedPhysicsEngineComponent();
+```
+
+### TypeError: scene.pick is not a function
+
+Picking functionality depends on ray registration:
+
+```typescript
+import { registerRay } from "@babylonjs/core/pure";
+
+registerRay();
+```
+
+### TypeScript error: Property 'enablePhysics' does not exist on type 'Scene'
+
+The runtime feature may be registered, but TypeScript still needs the type augmentation:
+
+```typescript
+import "@babylonjs/core/Physics/joinedPhysicsEngineComponent.types";
+```
+
+Use `.types` imports for features that augment classes with additional methods or properties.
+
+### Cascading Errors
+
+Some features have dependencies. You might fix one missing registration and then see another error when a dependent feature is reached.
+
+To resolve this:
+
+1. Use `CheckMissingImports()` during development to discover unregistered stubs.
+2. Prefer registration functions that handle their required transitive dependencies.
+3. For scene loading, register the material, texture, and parser types that your assets use.
+
+A common serialized-scene setup looks like this:
+
+```typescript
+registerStandardMaterial();
+registerPBRMaterial();
+registerImageProcessingConfiguration();
+registerTexture();
+registerFresnelParameters();
+```
+
+### Materials Appear Black or Default After Loading
+
+The material class was not registered, so deserialization could not recreate it correctly. Register the material type used by your content:
+
+```typescript
+import { registerPBRMaterial } from "@babylonjs/core/pure";
+
+registerPBRMaterial();
+```
+
+### Shader compilation error: include "X" not found
+
+A shader include has not been registered in the shader store. Register the material or effect that owns the shader dependency:
+
+```typescript
+import { registerStandardMaterial } from "@babylonjs/core/pure";
+
+registerStandardMaterial();
+```
+
+For custom shaders, import the shader include module your shader needs.
+
+## Diagnostic Tools
+
+### CheckMissingImports
+
+`CheckMissingImports` probes known stubs and reports side-effect modules that have not been registered:
+
+```typescript
+import { CheckMissingImports } from "@babylonjs/core/Misc/checkMissingImports";
+
+const missing = CheckMissingImports();
+if (missing.length > 0) {
+  console.log("You may need to register:", missing);
+}
+```
+
+It can check stubs for parser registration, scene factory methods, scene picking, texture factories, mesh parsers, and node factories.
+
+Not every reported module is required. The report lists what is available but unregistered, so only import the features your application actually uses.
+
+### Side-Effect Stubs
+
+When pure imports are used, augmented prototype methods can be represented by lightweight stubs until registration occurs. These stubs make missing side effects easier to diagnose and allow feature-detection checks to remain safe.
+
+For example, code such as `if (scene.getPhysicsEngine()) { ... }` can evaluate to `false` when physics is not registered, instead of crashing during a feature check.
+
+## Performance Considerations
+
+Register side effects before you use them. A common pattern is to group application registrations near the top of your entry point:
+
+```typescript
+import { registerStandardMaterial, registerRay, registerJoinedPhysicsEngineComponent } from "@babylonjs/core/pure";
+
+registerStandardMaterial();
+registerRay();
+registerJoinedPhysicsEngineComponent();
+```
+
+Registration functions are typically small. The main bundle-size benefit comes from not importing the modules your application does not need.
+
+## Migration Checklist
+
+When converting an existing project to pure imports:
+
+1. Switch value imports to `.pure` paths or the pure barrel.
+2. Identify bare side-effect imports such as `import "@babylonjs/core/..."`.
+3. Replace each side-effect import with the matching `registerXxx()` import and call.
+4. Add `.types` imports for type augmentations you use.
+5. Run `CheckMissingImports()` during development.
+6. Test asset loading, picking, physics, XR, materials, and any optional systems your app uses.
+7. Remove `CheckMissingImports()` from production code.

--- a/content/setup/frameworkPackages/es6Support/treeShaking/usingPureImports.md
+++ b/content/setup/frameworkPackages/es6Support/treeShaking/usingPureImports.md
@@ -1,0 +1,556 @@
+---
+title: Using Pure Imports
+image:
+description: Import Babylon.js through pure paths and the pure barrel without losing tree-shaking.
+keywords: babylon.js, pure imports, pure barrel, es6, npm, tree shaking, bundlers
+further-reading:
+  - title: Tree-Shaking with Pure Imports
+    url: /setup/frameworkPackages/es6Support/treeShaking
+  - title: Registering Side Effects
+    url: /setup/frameworkPackages/es6Support/treeShaking/registeringSideEffects
+  - title: Troubleshooting Pure Imports
+    url: /setup/frameworkPackages/es6Support/treeShaking/troubleshooting
+video-overview:
+video-content:
+---
+
+## Import Paths
+
+Every module in `@babylonjs/core` is available through the existing import path and, where applicable, a pure import path:
+
+```typescript
+// Existing path: includes the module's compatibility side effects.
+import { Scene } from "@babylonjs/core/scene";
+
+// Recommended pure path: tree-shakeable, with side effects registered manually.
+import { Scene } from "@babylonjs/core/pure";
+```
+
+## The Pure Barrel
+
+Instead of importing from individual deep paths, you can use the pure barrel:
+
+```typescript
+import { Scene, Engine, Vector3, Color3, FreeCamera } from "@babylonjs/core/pure";
+```
+
+The pure barrel re-exports the pure module graph. Your bundler analyzes which symbols you actually use and removes the rest. The result is intended to be equivalent to importing from deep pure paths, but with a more convenient import surface.
+
+## Subdirectory Barrels
+
+Subdirectories also expose pure barrels. Use the top-level `@babylonjs/core/pure` barrel by default; these grouped barrels are available when you intentionally want a narrower import surface:
+
+```typescript
+import { Vector3, Quaternion, Matrix } from "@babylonjs/core/Maths/pure";
+import { FreeCamera, ArcRotateCamera } from "@babylonjs/core/Cameras/pure";
+import { PointLight, DirectionalLight } from "@babylonjs/core/Lights/pure";
+```
+
+Use these when you want a smaller grouped import surface than the top-level pure barrel.
+
+## What Pure Imports Include
+
+Pure imports include:
+
+- Class definitions, such as `Scene`, `Engine`, `Mesh`, and `Camera`.
+- Functions and utilities, such as `MeshBuilder`, math helpers, and tools.
+- Type definitions, interfaces, enums, and type aliases.
+- Registration functions, such as `registerStandardMaterial()`.
+
+Pure imports do not automatically run:
+
+- `RegisterClass()` calls needed for deserialization by class name.
+- Prototype augmentations, such as methods added to `Scene`.
+- Shader registrations into the global shader store.
+- Feature registrations for systems such as XR, physics, rendering extensions, and node editors.
+
+## Registration Functions
+
+Every side effect is wrapped in a callable registration function exported from the corresponding pure module:
+
+```typescript
+import { registerStandardMaterial, registerJoinedPhysicsEngineComponent, registerRay } from "@babylonjs/core/pure";
+
+registerStandardMaterial();
+registerJoinedPhysicsEngineComponent();
+registerRay();
+```
+
+Registration functions are:
+
+- Idempotent, so calling one more than once is safe.
+- Discoverable in IDE autocomplete by typing `register`.
+- Named predictably with `register` plus the PascalCase file name, such as `registerEngineMultiRender()`.
+
+## Type Augmentations
+
+Optional features can add methods and properties to core classes through TypeScript module augmentation. With pure imports, import the `.types` module to make TypeScript aware of those members:
+
+```typescript
+import { Scene, registerJoinedPhysicsEngineComponent } from "@babylonjs/core/pure";
+import "@babylonjs/core/Physics/joinedPhysicsEngineComponent.types";
+
+registerJoinedPhysicsEngineComponent();
+
+const scene = new Scene(engine);
+scene.enablePhysics();
+```
+
+Without the `.types` import, TypeScript will not recognize the augmented method. This compile-time error is useful because it reminds you to register the feature you plan to use.
+
+If you import from the existing non-pure path, the wrapper path includes its side effects and type exports automatically.
+
+## Static Functions (Extracted as Free Functions)
+
+In the tree-shaking architecture, static methods that previously lived on classes have been extracted into standalone exported functions in the `.pure.ts` files. The class statics are **not** defined in the class body — instead, they're assigned only inside the registration function (the side-effects file):
+
+```typescript
+// In animation.pure.ts:
+
+export class Animation {
+    // No static Parse() in the class body!
+    // ...
+}
+
+// The free function is exported separately — always available from .pure.ts:
+export function AnimationParse(parsedAnimation: any): Animation {
+    // ... actual implementation ...
+}
+
+// Inside the registration function (called by animation.ts):
+export function registerAnimation(): void {
+    // ...
+    Animation.Parse = AnimationParse; // static only assigned here
+    RegisterClass("BABYLON.Animation", Animation);
+}
+```
+
+The class static (`Animation.Parse`, etc.) is **not** defined in the class body — it's only assigned inside the registration function. This means:
+
+- **From `.pure.ts`**: You can import the free function directly. The class itself won't have the static method.
+- **After registration**: The static method becomes available on the class (for backward compat).
+
+```typescript
+// Pure: import and use the free function directly (no registration needed):
+import { AnimationParse } from "@babylonjs/core/pure";
+const anim = AnimationParse(data);
+
+// Legacy: the class static only works AFTER calling the registration function:
+import { Animation, registerAnimation } from "@babylonjs/core/pure";
+registerAnimation(); // assigns Animation.Parse = AnimationParse
+const anim = Animation.Parse(data); // now works
+
+// Alternatively you can always import directly from the legacy path, which includes the registration side effects:
+import { Animation } from "@babylonjs/core/Animations/animation";
+const anim = Animation.Parse(data); // works because the existing path registers side effects
+```
+
+The naming convention is `ClassName` + `MethodName`:
+
+| Class Static                             | Extracted Free Function                 |
+| ---------------------------------------- | --------------------------------------- |
+| `AnimationGroup.Parse(...)`              | `AnimationGroupParse(...)`              |
+| `Animation.CreateAndStartAnimation(...)` | `AnimationCreateAndStartAnimation(...)` |
+| `ReflectionProbe.Parse(...)`             | `ReflectionProbeParse(...)`             |
+| `Node.ParseAnimationRanges(...)`         | `NodeParseAnimationRanges(...)`         |
+
+Additionally, math operations are available as structural-typed free functions in dedicated `.functions.ts` files:
+
+```typescript
+// Structural interface — no class dependency at all:
+import { Vector3CrossToRef } from "@babylonjs/core/Maths/math.vector.functions";
+Vector3CrossToRef(a, b, result);
+```
+
+Available function files:
+
+- `@babylonjs/core/Maths/math.vector.functions` — Vector2/3/4, Quaternion, Matrix operations
+- `@babylonjs/core/Maths/math.color.functions` — Color3/4 operations
+
+## Bundler Configuration
+
+### Vite
+
+Vite uses Rollup internally. No special configuration is normally required for pure imports:
+
+```typescript
+import { defineConfig } from "vite";
+
+export default defineConfig({
+    // The package sideEffects metadata guides tree-shaking.
+});
+```
+
+### Webpack
+
+Webpack respects the `sideEffects` field in `package.json`. Make sure tree-shaking is enabled for production builds:
+
+```javascript
+module.exports = {
+    optimization: {
+        usedExports: true,
+        sideEffects: true,
+    },
+};
+```
+
+### Rollup
+
+Rollup-based builds can mark pure modules as side-effect-free if additional control is needed:
+
+```javascript
+function markPureModules() {
+    return {
+        name: "mark-pure-modules",
+        async load(id) {
+            if (/\.pure\.(js|ts)$/.test(id) || /\.functions\.(js|ts)$/.test(id)) {
+                const fs = await import("fs");
+                const code = fs.readFileSync(id, "utf8");
+                return { code, moduleSideEffects: false };
+            }
+            return null;
+        },
+    };
+}
+
+export default {
+    plugins: [markPureModules()],
+};
+```
+
+## Common Patterns
+
+### Physics Playground
+
+This example uses Physics V2 with Havok, a ground plane, falling spheres, a hinged box chain, and shadows. It assumes your HTML contains a `<canvas id="renderCanvas"></canvas>` element and that `@babylonjs/havok` is installed.
+
+```typescript
+import {
+    Engine,
+    Scene,
+    ArcRotateCamera,
+    HemisphericLight,
+    DirectionalLight,
+    CreateSphere,
+    CreateBox,
+    CreateGround,
+    PBRMaterial,
+    Color3,
+    Color4,
+    Vector3,
+    ShadowGenerator,
+    PhysicsAggregate,
+    PhysicsShapeType,
+    HavokPlugin,
+    HingeConstraint,
+    registerAbstractEngineDom,
+    registerAbstractEngineRenderPass,
+    registerAbstractEngineStates,
+    registerAbstractEngineStencil,
+    registerAbstractEngineTexture,
+    registerExtensionsEngineRenderTarget,
+    registerEngineUniformBuffer,
+    registerShadowGeneratorSceneComponent,
+    registerJoinedPhysicsEngineComponent,
+    registerV2PhysicsEngineComponent,
+} from "@babylonjs/core/pure.js";
+
+import "@babylonjs/core/Physics/joinedPhysicsEngineComponent.types";
+
+registerAbstractEngineDom();
+registerAbstractEngineRenderPass();
+registerAbstractEngineStates();
+registerAbstractEngineStencil();
+registerAbstractEngineTexture();
+registerExtensionsEngineRenderTarget();
+registerEngineUniformBuffer();
+registerShadowGeneratorSceneComponent();
+registerJoinedPhysicsEngineComponent();
+registerV2PhysicsEngineComponent();
+
+function createScene(engine: Engine, canvas: HTMLCanvasElement): Scene {
+    const scene = new Scene(engine);
+    scene.clearColor = new Color4(0.05, 0.05, 0.1, 1);
+
+    const camera = new ArcRotateCamera("camera", -Math.PI / 4, Math.PI / 3, 20, new Vector3(0, 3, 0), scene);
+    camera.attachControl(canvas, true);
+    camera.lowerRadiusLimit = 8;
+    camera.upperRadiusLimit = 40;
+
+    const ambientLight = new HemisphericLight("ambient", new Vector3(0, 1, 0), scene);
+    ambientLight.intensity = 0.3;
+
+    const directionalLight = new DirectionalLight("dirLight", new Vector3(-1, -2, 1).normalize(), scene);
+    directionalLight.position = new Vector3(5, 10, -5);
+    directionalLight.intensity = 0.8;
+
+    const shadowGenerator = new ShadowGenerator(1024, directionalLight);
+    shadowGenerator.useBlurExponentialShadowMap = true;
+
+    const ground = CreateGround("ground", { width: 20, height: 20 }, scene);
+    const groundMaterial = new PBRMaterial("groundMat", scene);
+    groundMaterial.albedoColor = new Color3(0.15, 0.15, 0.15);
+    groundMaterial.metallic = 0.1;
+    groundMaterial.roughness = 0.9;
+    ground.material = groundMaterial;
+    ground.receiveShadows = true;
+
+    const sphereColors = [new Color3(0.8, 0.2, 0.2), new Color3(0.2, 0.8, 0.2), new Color3(0.2, 0.2, 0.8), new Color3(0.8, 0.8, 0.2)];
+
+    for (let index = 0; index < sphereColors.length; index++) {
+        const sphere = CreateSphere(`sphere${index}`, { diameter: 1, segments: 16 }, scene);
+        sphere.position = new Vector3((index - 1.5) * 2, 6 + index * 2, 0);
+
+        const sphereMaterial = new PBRMaterial(`sphereMat${index}`, scene);
+        sphereMaterial.albedoColor = sphereColors[index];
+        sphereMaterial.metallic = 0.5;
+        sphereMaterial.roughness = 0.4;
+        sphere.material = sphereMaterial;
+
+        shadowGenerator.addShadowCaster(sphere);
+    }
+
+    const boxA = CreateBox("boxA", { width: 1, height: 0.5, depth: 2 }, scene);
+    boxA.position = new Vector3(4, 4, 0);
+    const boxAMaterial = new PBRMaterial("boxAMat", scene);
+    boxAMaterial.albedoColor = new Color3(0.6, 0.3, 0.7);
+    boxAMaterial.metallic = 0.6;
+    boxAMaterial.roughness = 0.3;
+    boxA.material = boxAMaterial;
+    shadowGenerator.addShadowCaster(boxA);
+
+    const boxB = CreateBox("boxB", { width: 1, height: 0.5, depth: 2 }, scene);
+    boxB.position = new Vector3(4, 4, 2.5);
+    const boxBMaterial = new PBRMaterial("boxBMat", scene);
+    boxBMaterial.albedoColor = new Color3(0.3, 0.6, 0.7);
+    boxBMaterial.metallic = 0.6;
+    boxBMaterial.roughness = 0.3;
+    boxB.material = boxBMaterial;
+    shadowGenerator.addShadowCaster(boxB);
+
+    return scene;
+}
+
+async function initPhysics(scene: Scene, havokInstance: unknown): Promise<void> {
+    const plugin = new HavokPlugin(true, havokInstance);
+    scene.enablePhysics(new Vector3(0, -9.81, 0), plugin);
+
+    const ground = scene.getMeshByName("ground");
+    if (ground) {
+        new PhysicsAggregate(ground, PhysicsShapeType.BOX, { mass: 0 }, scene);
+    }
+
+    for (let index = 0; index < 4; index++) {
+        const sphere = scene.getMeshByName(`sphere${index}`);
+        if (sphere) {
+            new PhysicsAggregate(sphere, PhysicsShapeType.SPHERE, { mass: 1, restitution: 0.6 }, scene);
+        }
+    }
+
+    const boxA = scene.getMeshByName("boxA");
+    const boxB = scene.getMeshByName("boxB");
+    if (!boxA || !boxB) {
+        return;
+    }
+
+    const aggregateA = new PhysicsAggregate(boxA, PhysicsShapeType.BOX, { mass: 0 }, scene);
+    const aggregateB = new PhysicsAggregate(boxB, PhysicsShapeType.BOX, { mass: 2 }, scene);
+
+    const hinge = new HingeConstraint(new Vector3(0, 0, 1), new Vector3(0, 0, -1), new Vector3(1, 0, 0), new Vector3(1, 0, 0), scene);
+    aggregateA.body.addConstraint(aggregateB.body, hinge);
+}
+
+const canvas = document.getElementById("renderCanvas") as HTMLCanvasElement;
+const engine = new Engine(canvas, true);
+const scene = createScene(engine, canvas);
+
+engine.runRenderLoop(() => scene.render());
+window.addEventListener("resize", () => engine.resize());
+
+import("@babylonjs/havok").then((havok) => {
+    havok.default().then((havokInstance: unknown) => initPhysics(scene, havokInstance));
+});
+```
+
+### Loading a Serialized Scene
+
+Serialization relies on `RegisterClass` to reconstruct objects by class name. Register the classes you expect to encounter:
+
+```typescript
+import { SceneLoader, registerStandardMaterial, registerPBRMaterial, registerImageProcessingConfiguration, registerTexture } from "@babylonjs/core/pure";
+
+registerStandardMaterial();
+registerPBRMaterial();
+registerImageProcessingConfiguration();
+registerTexture();
+
+const scene = await SceneLoader.LoadAsync("./", "scene.babylon", engine);
+```
+
+### Node Material with Blocks
+
+```typescript
+import { NodeMaterial, registerAllNodeMaterialBlocks } from "@babylonjs/core/pure";
+
+registerAllNodeMaterialBlocks();
+
+const nodeMat = await NodeMaterial.ParseFromSnippetAsync("ABC123", scene);
+```
+
+You can also register only the block categories you need:
+
+```typescript
+import { registerNodeMaterialPBRBlocks, registerNodeMaterialMathBlocks, registerNodeMaterialInputBlocks } from "@babylonjs/core/pure";
+
+registerNodeMaterialPBRBlocks();
+registerNodeMaterialMathBlocks();
+registerNodeMaterialInputBlocks();
+```
+
+### WebXR Gallery
+
+This example creates a small VR gallery with teleportation, controller pointer selection, and interactive objects. It assumes your HTML contains a `<canvas id="renderCanvas"></canvas>` element. The glTF loader side-effect import is used so WebXR controller and hand model `.glb` assets can be loaded.
+
+```typescript
+import {
+    Engine,
+    Scene,
+    ArcRotateCamera,
+    HemisphericLight,
+    DirectionalLight,
+    CreateGround,
+    CreateCylinder,
+    CreateSphere,
+    CreateTorus,
+    CreateBox,
+    PBRMaterial,
+    StandardMaterial,
+    Color3,
+    Color4,
+    Vector3,
+    WebXRDefaultExperience,
+    WebXRFeatureName,
+    registerAbstractEngineDom,
+    registerAbstractEngineRenderPass,
+    registerAbstractEngineStates,
+    registerAbstractEngineStencil,
+    registerAbstractEngineTexture,
+    registerExtensionsEngineRenderTarget,
+    registerEngineUniformBuffer,
+    registerRay,
+    registerInstancedMesh,
+    registerAllNodeMaterialBlocks,
+    registerExtensionsEngineDynamicTexture,
+    registerAnimation,
+    registerImageProcessingConfiguration,
+    registerColorCurves,
+    registerTexture,
+    registerFresnelParameters,
+} from "@babylonjs/core/pure.js";
+
+import "@babylonjs/loaders/glTF";
+
+registerAbstractEngineDom();
+registerRay();
+registerInstancedMesh();
+registerAllNodeMaterialBlocks();
+registerExtensionsEngineDynamicTexture();
+registerAnimation();
+registerImageProcessingConfiguration();
+registerColorCurves();
+registerTexture();
+registerFresnelParameters();
+registerAbstractEngineRenderPass();
+registerAbstractEngineStates();
+registerAbstractEngineStencil();
+registerAbstractEngineTexture();
+registerExtensionsEngineRenderTarget();
+registerEngineUniformBuffer();
+
+function createScene(engine: Engine, canvas: HTMLCanvasElement): Scene {
+    const scene = new Scene(engine);
+    scene.clearColor = new Color4(0.05, 0.05, 0.1, 1);
+
+    const camera = new ArcRotateCamera("camera", -Math.PI / 2, Math.PI / 3, 10, Vector3.Zero(), scene);
+    camera.attachControl(canvas, true);
+    camera.lowerRadiusLimit = 2;
+    camera.upperRadiusLimit = 20;
+
+    const hemisphericLight = new HemisphericLight("hemi", new Vector3(0, 1, 0), scene);
+    hemisphericLight.intensity = 0.4;
+
+    const directionalLight = new DirectionalLight("dir", new Vector3(-1, -2, -1), scene);
+    directionalLight.intensity = 0.8;
+    directionalLight.position = new Vector3(5, 10, 5);
+
+    const floor = CreateGround("floor", { width: 20, height: 20 }, scene);
+    const floorMaterial = new PBRMaterial("floorMat", scene);
+    floorMaterial.albedoColor = new Color3(0.15, 0.15, 0.2);
+    floorMaterial.metallic = 0.1;
+    floorMaterial.roughness = 0.9;
+    floor.material = floorMaterial;
+
+    const pedestalMaterial = new PBRMaterial("pedestalMat", scene);
+    pedestalMaterial.albedoColor = new Color3(0.6, 0.6, 0.65);
+    pedestalMaterial.metallic = 0.3;
+    pedestalMaterial.roughness = 0.5;
+
+    const positions = [new Vector3(-3, 0, 3), new Vector3(0, 0, 4), new Vector3(3, 0, 3), new Vector3(-3, 0, -3), new Vector3(3, 0, -3)];
+
+    positions.forEach((position, index) => {
+        const pedestal = CreateCylinder(`pedestal${index}`, { diameter: 0.8, height: 1 }, scene);
+        pedestal.position = position.add(new Vector3(0, 0.5, 0));
+        pedestal.material = pedestalMaterial;
+
+        const object = index % 3 === 0 ? CreateSphere(`obj${index}`, { diameter: 0.5, segments: 32 }, scene) : index % 3 === 1 ? CreateTorus(`obj${index}`, { diameter: 0.5, thickness: 0.15 }, scene) : CreateBox(`obj${index}`, { size: 0.4 }, scene);
+        object.position = position.add(new Vector3(0, 1.3, 0));
+
+        const objectMaterial = new StandardMaterial(`objMat${index}`, scene);
+        objectMaterial.emissiveColor = Color3.FromHSV((index / positions.length) * 360, 0.7, 0.9);
+        objectMaterial.disableLighting = true;
+        object.material = objectMaterial;
+    });
+
+    WebXRDefaultExperience.CreateAsync(scene, {
+        floorMeshes: [floor],
+        optionalFeatures: true,
+        disableNearInteraction: true,
+    }).then((xr) => {
+        xr.teleportation?.addFloorMesh(floor);
+
+        try {
+            xr.baseExperience.featuresManager.enableFeature(WebXRFeatureName.POINTER_SELECTION, "stable", {
+                xrInput: xr.input,
+                enablePointerSelectionOnAllControllers: true,
+                disablePointerUpOnTouchOut: false,
+                forceGazeMode: false,
+                disableScenePointerVectorUpdate: false,
+            } as any);
+        } catch {
+            // Pointer selection is not available on every browser or device.
+        }
+    });
+
+    return scene;
+}
+
+const canvas = document.getElementById("renderCanvas") as HTMLCanvasElement;
+const engine = new Engine(canvas, true);
+const scene = createScene(engine, canvas);
+
+engine.runRenderLoop(() => scene.render());
+window.addEventListener("resize", () => engine.resize());
+```
+
+## Migration from Existing Imports
+
+New pure-import code should import Babylon.js core values and registration functions from `@babylonjs/core/pure`. During migration, you may temporarily keep an existing side-effect import when you have not yet converted that feature to an explicit registration call:
+
+```typescript
+import { Scene, Engine, Vector3 } from "@babylonjs/core/pure";
+
+// Temporary migration exception: replace this with an explicit registerXxx() call.
+import "@babylonjs/core/Physics/joinedPhysicsEngineComponent";
+```
+
+Convert those remaining imports as you identify the registrations your application actually needs.

--- a/content/setup/frameworkPackages/es6Support/treeShaking/usingPureImports.md
+++ b/content/setup/frameworkPackages/es6Support/treeShaking/usingPureImports.md
@@ -19,10 +19,10 @@ video-content:
 Every module in `@babylonjs/core` is available through the existing import path and, where applicable, a pure import path:
 
 ```typescript
-// Existing path: includes the module's compatibility side effects.
+// Existing path: includes side effects.
 import { Scene } from "@babylonjs/core/scene";
 
-// Recommended pure path: tree-shakeable, with side effects registered manually.
+// Pure path: tree-shakeable, with side effects registered manually.
 import { Scene } from "@babylonjs/core/pure";
 ```
 
@@ -34,7 +34,7 @@ Instead of importing from individual deep paths, you can use the pure barrel:
 import { Scene, Engine, Vector3, Color3, FreeCamera } from "@babylonjs/core/pure";
 ```
 
-The pure barrel re-exports the pure module graph. Your bundler analyzes which symbols you actually use and removes the rest. The result is intended to be equivalent to importing from deep pure paths, but with a more convenient import surface.
+The pure barrel re-exports the pure module graph. Your bundler figures out which symbols you actually use and removes the rest. The result is the same as importing from individual pure files, but the barrel is more convenient.
 
 ## Subdirectory Barrels
 
@@ -55,7 +55,7 @@ Pure imports include:
 - Class definitions, such as `Scene`, `Engine`, `Mesh`, and `Camera`.
 - Functions and utilities, such as `MeshBuilder`, math helpers, and tools.
 - Type definitions, interfaces, enums, and type aliases.
-- Registration functions, such as `registerStandardMaterial()`.
+- Registration functions, such as `RegisterStandardMaterial()`.
 
 Pure imports do not automatically run:
 
@@ -69,28 +69,28 @@ Pure imports do not automatically run:
 Every side effect is wrapped in a callable registration function exported from the corresponding pure module:
 
 ```typescript
-import { registerStandardMaterial, registerJoinedPhysicsEngineComponent, registerRay } from "@babylonjs/core/pure";
+import { RegisterStandardMaterial, RegisterJoinedPhysicsEngineComponent, RegisterRay } from "@babylonjs/core/pure";
 
-registerStandardMaterial();
-registerJoinedPhysicsEngineComponent();
-registerRay();
+RegisterStandardMaterial();
+RegisterJoinedPhysicsEngineComponent();
+RegisterRay();
 ```
 
 Registration functions are:
 
-- Idempotent, so calling one more than once is safe.
-- Discoverable in IDE autocomplete by typing `register`.
-- Named predictably with `register` plus the PascalCase file name, such as `registerEngineMultiRender()`.
+- Safe to call multiple times. Only the first call does anything; repeat calls are ignored.
+- Discoverable in IDE autocomplete by typing `Register`.
+- Named predictably with `Register` plus the PascalCase file name, such as `RegisterEngineMultiRender()`.
 
 ## Type Augmentations
 
 Optional features can add methods and properties to core classes through TypeScript module augmentation. With pure imports, import the `.types` module to make TypeScript aware of those members:
 
 ```typescript
-import { Scene, registerJoinedPhysicsEngineComponent } from "@babylonjs/core/pure";
+import { Scene, RegisterJoinedPhysicsEngineComponent } from "@babylonjs/core/pure";
 import "@babylonjs/core/Physics/joinedPhysicsEngineComponent.types";
 
-registerJoinedPhysicsEngineComponent();
+RegisterJoinedPhysicsEngineComponent();
 
 const scene = new Scene(engine);
 scene.enablePhysics();
@@ -118,7 +118,7 @@ export function AnimationParse(parsedAnimation: any): Animation {
 }
 
 // Inside the registration function (called by animation.ts):
-export function registerAnimation(): void {
+export function RegisterAnimation(): void {
     // ...
     Animation.Parse = AnimationParse; // static only assigned here
     RegisterClass("BABYLON.Animation", Animation);
@@ -136,8 +136,8 @@ import { AnimationParse } from "@babylonjs/core/pure";
 const anim = AnimationParse(data);
 
 // Legacy: the class static only works AFTER calling the registration function:
-import { Animation, registerAnimation } from "@babylonjs/core/pure";
-registerAnimation(); // assigns Animation.Parse = AnimationParse
+import { Animation, RegisterAnimation } from "@babylonjs/core/pure";
+RegisterAnimation(); // assigns Animation.Parse = AnimationParse
 const anim = Animation.Parse(data); // now works
 
 // Alternatively you can always import directly from the legacy path, which includes the registration side effects:
@@ -174,9 +174,11 @@ Available function files:
 Vite uses Rollup internally. No special configuration is normally required for pure imports:
 
 ```typescript
+// vite.config.ts
 import { defineConfig } from "vite";
 
 export default defineConfig({
+    // Vite handles .pure imports correctly.
     // The package sideEffects metadata guides tree-shaking.
 });
 ```
@@ -188,8 +190,8 @@ Webpack respects the `sideEffects` field in `package.json`. Make sure tree-shaki
 ```javascript
 module.exports = {
     optimization: {
-        usedExports: true,
-        sideEffects: true,
+        usedExports: true, // Enable tree-shaking (default in production)
+        sideEffects: true, // Respect package sideEffects metadata (default)
     },
 };
 ```
@@ -199,13 +201,14 @@ module.exports = {
 Rollup-based builds can mark pure modules as side-effect-free if additional control is needed:
 
 ```javascript
+import { readFileSync } from "fs";
+
 function markPureModules() {
     return {
         name: "mark-pure-modules",
-        async load(id) {
+        load(id) {
             if (/\.pure\.(js|ts)$/.test(id) || /\.functions\.(js|ts)$/.test(id)) {
-                const fs = await import("fs");
-                const code = fs.readFileSync(id, "utf8");
+                const code = readFileSync(id, "utf8");
                 return { code, moduleSideEffects: false };
             }
             return null;
@@ -214,7 +217,7 @@ function markPureModules() {
 }
 
 export default {
-    plugins: [markPureModules()],
+    plugins: [markPureModules() /* ... other plugins */],
 };
 ```
 
@@ -243,30 +246,18 @@ import {
     PhysicsShapeType,
     HavokPlugin,
     HingeConstraint,
-    registerAbstractEngineDom,
-    registerAbstractEngineRenderPass,
-    registerAbstractEngineStates,
-    registerAbstractEngineStencil,
-    registerAbstractEngineTexture,
-    registerExtensionsEngineRenderTarget,
-    registerEngineUniformBuffer,
-    registerShadowGeneratorSceneComponent,
-    registerJoinedPhysicsEngineComponent,
-    registerV2PhysicsEngineComponent,
-} from "@babylonjs/core/pure.js";
+    RegisterStandardEngineExtensions,
+    RegisterShadowGeneratorSceneComponent,
+    RegisterJoinedPhysicsEngineComponent,
+    RegisterV2PhysicsEngineComponent,
+} from "@babylonjs/core/pure";
 
 import "@babylonjs/core/Physics/joinedPhysicsEngineComponent.types";
 
-registerAbstractEngineDom();
-registerAbstractEngineRenderPass();
-registerAbstractEngineStates();
-registerAbstractEngineStencil();
-registerAbstractEngineTexture();
-registerExtensionsEngineRenderTarget();
-registerEngineUniformBuffer();
-registerShadowGeneratorSceneComponent();
-registerJoinedPhysicsEngineComponent();
-registerV2PhysicsEngineComponent();
+RegisterStandardEngineExtensions();
+RegisterShadowGeneratorSceneComponent();
+RegisterJoinedPhysicsEngineComponent();
+RegisterV2PhysicsEngineComponent();
 
 function createScene(engine: Engine, canvas: HTMLCanvasElement): Scene {
     const scene = new Scene(engine);
@@ -374,15 +365,29 @@ import("@babylonjs/havok").then((havok) => {
 
 ### Loading a Serialized Scene
 
-Serialization relies on `RegisterClass` to reconstruct objects by class name. Register the classes you expect to encounter:
+For glTF loading, use `SceneLoader` with the pure barrel and the glTF loader package:
 
 ```typescript
-import { SceneLoader, registerStandardMaterial, registerPBRMaterial, registerImageProcessingConfiguration, registerTexture } from "@babylonjs/core/pure";
+import { Engine, Scene, SceneLoader, RegisterStandardEngineExtensions, RegisterEnginesExtensionsEngineRawTexture } from "@babylonjs/core/pure";
+import "@babylonjs/loaders/glTF";
 
-registerStandardMaterial();
-registerPBRMaterial();
-registerImageProcessingConfiguration();
-registerTexture();
+RegisterStandardEngineExtensions();
+RegisterEnginesExtensionsEngineRawTexture();
+
+const engine = new Engine(canvas, true);
+const scene = new Scene(engine);
+const result = await SceneLoader.ImportMeshAsync("", "model.glb", undefined, scene);
+```
+
+For `.babylon` files, serialization relies on `RegisterClass` to reconstruct objects by class name. Register the classes you expect to encounter:
+
+```typescript
+import { SceneLoader, RegisterStandardMaterial, RegisterPBRMaterial, RegisterImageProcessingConfiguration, RegisterTexture } from "@babylonjs/core/pure";
+
+RegisterStandardMaterial();
+RegisterPBRMaterial();
+RegisterImageProcessingConfiguration();
+RegisterTexture();
 
 const scene = await SceneLoader.LoadAsync("./", "scene.babylon", engine);
 ```
@@ -390,9 +395,9 @@ const scene = await SceneLoader.LoadAsync("./", "scene.babylon", engine);
 ### Node Material with Blocks
 
 ```typescript
-import { NodeMaterial, registerAllNodeMaterialBlocks } from "@babylonjs/core/pure";
+import { NodeMaterial, RegisterAllNodeMaterialBlocks } from "@babylonjs/core/pure";
 
-registerAllNodeMaterialBlocks();
+RegisterAllNodeMaterialBlocks();
 
 const nodeMat = await NodeMaterial.ParseFromSnippetAsync("ABC123", scene);
 ```
@@ -400,11 +405,11 @@ const nodeMat = await NodeMaterial.ParseFromSnippetAsync("ABC123", scene);
 You can also register only the block categories you need:
 
 ```typescript
-import { registerNodeMaterialPBRBlocks, registerNodeMaterialMathBlocks, registerNodeMaterialInputBlocks } from "@babylonjs/core/pure";
+import { RegisterNodeMaterialPBRBlocks, RegisterNodeMaterialMathBlocks, RegisterNodeMaterialInputBlocks } from "@babylonjs/core/pure";
 
-registerNodeMaterialPBRBlocks();
-registerNodeMaterialMathBlocks();
-registerNodeMaterialInputBlocks();
+RegisterNodeMaterialPBRBlocks();
+RegisterNodeMaterialMathBlocks();
+RegisterNodeMaterialInputBlocks();
 ```
 
 ### WebXR Gallery
@@ -430,42 +435,30 @@ import {
     Vector3,
     WebXRDefaultExperience,
     WebXRFeatureName,
-    registerAbstractEngineDom,
-    registerAbstractEngineRenderPass,
-    registerAbstractEngineStates,
-    registerAbstractEngineStencil,
-    registerAbstractEngineTexture,
-    registerExtensionsEngineRenderTarget,
-    registerEngineUniformBuffer,
-    registerRay,
-    registerInstancedMesh,
-    registerAllNodeMaterialBlocks,
-    registerExtensionsEngineDynamicTexture,
-    registerAnimation,
-    registerImageProcessingConfiguration,
-    registerColorCurves,
-    registerTexture,
-    registerFresnelParameters,
-} from "@babylonjs/core/pure.js";
+    RegisterFullEngineExtensions,
+    RegisterWebXRDefaultExperience,
+    RegisterRay,
+    RegisterInstancedMesh,
+    RegisterAllNodeMaterialBlocks,
+    RegisterAnimation,
+    RegisterImageProcessingConfiguration,
+    RegisterColorCurves,
+    RegisterTexture,
+    RegisterFresnelParameters,
+} from "@babylonjs/core/pure";
 
 import "@babylonjs/loaders/glTF";
 
-registerAbstractEngineDom();
-registerRay();
-registerInstancedMesh();
-registerAllNodeMaterialBlocks();
-registerExtensionsEngineDynamicTexture();
-registerAnimation();
-registerImageProcessingConfiguration();
-registerColorCurves();
-registerTexture();
-registerFresnelParameters();
-registerAbstractEngineRenderPass();
-registerAbstractEngineStates();
-registerAbstractEngineStencil();
-registerAbstractEngineTexture();
-registerExtensionsEngineRenderTarget();
-registerEngineUniformBuffer();
+RegisterFullEngineExtensions();
+RegisterWebXRDefaultExperience();
+RegisterRay();
+RegisterInstancedMesh();
+RegisterAllNodeMaterialBlocks();
+RegisterAnimation();
+RegisterImageProcessingConfiguration();
+RegisterColorCurves();
+RegisterTexture();
+RegisterFresnelParameters();
 
 function createScene(engine: Engine, canvas: HTMLCanvasElement): Scene {
     const scene = new Scene(engine);
@@ -549,8 +542,70 @@ New pure-import code should import Babylon.js core values and registration funct
 ```typescript
 import { Scene, Engine, Vector3 } from "@babylonjs/core/pure";
 
-// Temporary migration exception: replace this with an explicit registerXxx() call.
+// Temporary migration exception: replace this with an explicit RegisterXxx() call.
 import "@babylonjs/core/Physics/joinedPhysicsEngineComponent";
 ```
 
 Convert those remaining imports as you identify the registrations your application actually needs.
+
+## Package Configuration
+
+### The `exports` Map
+
+The `@babylonjs/core` package uses Node.js [package exports](https://nodejs.org/api/packages.html#exports) to define entry points:
+
+```json
+"exports": {
+    ".": {
+        "types": "./index.d.ts",
+        "import": "./index.js",
+        "default": "./index.js"
+    },
+    "./pure": {
+        "types": "./pure.d.ts",
+        "import": "./pure.js",
+        "default": "./pure.js"
+    },
+    "./*": {
+        "types": "./*.d.ts",
+        "import": "./*.js",
+        "default": "./*.js"
+    }
+}
+```
+
+The `default` condition keeps compatibility with CommonJS consumers, while the `import` condition is used by ESM-aware bundlers.
+
+### The `sideEffects` Field
+
+The top-level `sideEffects` array in `package.json` lists every file that has module-level side effects. Bundlers use this to determine what can be safely tree-shaken. Files not in the list, including `.pure.js` files, are considered side-effect-free.
+
+This field is maintained by `syncSideEffects.mjs`; you should not need to edit it manually.
+
+## Testing Tree-Shaking
+
+### ES6 Visualization Tests
+
+The Babylon.js repository includes visualization tests that validate tree-shaking at runtime. Each test scene in `packages/tools/tests/es6Vis/` has three import styles:
+
+- `barrel.ts` imports from `@babylonjs/core`.
+- `deep.ts` imports from deep paths such as `@babylonjs/core/Engines/engine`.
+- `pure.ts` imports from `@babylonjs/core/pure` or `.pure` paths.
+
+All three styles must produce identical visual output. Run them with:
+
+```bash
+npm run test:es6vis -w @tools/tests
+npm run test:es6-packages -w @tools/tests
+```
+
+The bundle size test asserts that `pure <= deep < barrel` for each scene.
+
+### ES6 Package Smoke Tests
+
+The `test:es6-packages` script also:
+
+1. Type-checks all `@babylonjs/*` packages against `tsconfig.es6-smoke.json`.
+2. Bundles an ESM entry that imports all public packages with esbuild.
+3. Runs a Node.js smoke test that imports `@babylonjs/core` and verifies basic runtime behavior.
+4. Validates editor package entry points.

--- a/content/setup/frameworkPackages/es6Support/treeShaking/usingPureImports.md
+++ b/content/setup/frameworkPackages/es6Support/treeShaking/usingPureImports.md
@@ -108,20 +108,20 @@ In the tree-shaking architecture, static methods that previously lived on classe
 // In animation.pure.ts:
 
 export class Animation {
-    // No static Parse() in the class body!
-    // ...
+  // No static Parse() in the class body!
+  // ...
 }
 
 // The free function is exported separately — always available from .pure.ts:
 export function AnimationParse(parsedAnimation: any): Animation {
-    // ... actual implementation ...
+  // ... actual implementation ...
 }
 
 // Inside the registration function (called by animation.ts):
 export function RegisterAnimation(): void {
-    // ...
-    Animation.Parse = AnimationParse; // static only assigned here
-    RegisterClass("BABYLON.Animation", Animation);
+  // ...
+  Animation.Parse = AnimationParse; // static only assigned here
+  RegisterClass("BABYLON.Animation", Animation);
 }
 ```
 
@@ -178,8 +178,8 @@ Vite uses Rollup internally. No special configuration is normally required for p
 import { defineConfig } from "vite";
 
 export default defineConfig({
-    // Vite handles .pure imports correctly.
-    // The package sideEffects metadata guides tree-shaking.
+  // Vite handles .pure imports correctly.
+  // The package sideEffects metadata guides tree-shaking.
 });
 ```
 
@@ -189,10 +189,10 @@ Webpack respects the `sideEffects` field in `package.json`. Make sure tree-shaki
 
 ```javascript
 module.exports = {
-    optimization: {
-        usedExports: true, // Enable tree-shaking (default in production)
-        sideEffects: true, // Respect package sideEffects metadata (default)
-    },
+  optimization: {
+    usedExports: true, // Enable tree-shaking (default in production)
+    sideEffects: true, // Respect package sideEffects metadata (default)
+  },
 };
 ```
 
@@ -204,20 +204,20 @@ Rollup-based builds can mark pure modules as side-effect-free if additional cont
 import { readFileSync } from "fs";
 
 function markPureModules() {
-    return {
-        name: "mark-pure-modules",
-        load(id) {
-            if (/\.pure\.(js|ts)$/.test(id) || /\.functions\.(js|ts)$/.test(id)) {
-                const code = readFileSync(id, "utf8");
-                return { code, moduleSideEffects: false };
-            }
-            return null;
-        },
-    };
+  return {
+    name: "mark-pure-modules",
+    load(id) {
+      if (/\.pure\.(js|ts)$/.test(id) || /\.functions\.(js|ts)$/.test(id)) {
+        const code = readFileSync(id, "utf8");
+        return { code, moduleSideEffects: false };
+      }
+      return null;
+    },
+  };
 }
 
 export default {
-    plugins: [markPureModules() /* ... other plugins */],
+  plugins: [markPureModules() /* ... other plugins */],
 };
 ```
 
@@ -229,126 +229,125 @@ This example uses Physics V2 with Havok, a ground plane, falling spheres, a hing
 
 ```typescript
 import {
-    Engine,
-    Scene,
-    ArcRotateCamera,
-    HemisphericLight,
-    DirectionalLight,
-    CreateSphere,
-    CreateBox,
-    CreateGround,
-    PBRMaterial,
-    Color3,
-    Color4,
-    Vector3,
-    ShadowGenerator,
-    PhysicsAggregate,
-    PhysicsShapeType,
-    HavokPlugin,
-    HingeConstraint,
-    RegisterStandardEngineExtensions,
-    RegisterShadowGeneratorSceneComponent,
-    RegisterJoinedPhysicsEngineComponent,
-    RegisterV2PhysicsEngineComponent,
-} from "@babylonjs/core/pure";
+  Engine,
+  Scene,
+  ArcRotateCamera,
+  HemisphericLight,
+  DirectionalLight,
+  CreateSphere,
+  CreateBox,
+  CreateGround,
+  PBRMaterial,
+  Color3,
+  Color4,
+  Vector3,
+  ShadowGenerator,
+  PhysicsAggregate,
+  PhysicsShapeType,
+  HavokPlugin,
+  HingeConstraint,
+  RegisterStandardEngineExtensions,
+  RegisterJoinedPhysicsEngineComponent,
+  RegisterPhysicsV2PhysicsEngineComponent,
+} from "@babylonjs/core/pure.js";
 
-import "@babylonjs/core/Physics/joinedPhysicsEngineComponent.types";
-
+// Engine extensions required for rendering
 RegisterStandardEngineExtensions();
-RegisterShadowGeneratorSceneComponent();
+
+// Physics v2 engine components
 RegisterJoinedPhysicsEngineComponent();
-RegisterV2PhysicsEngineComponent();
+RegisterPhysicsV2PhysicsEngineComponent();
 
 function createScene(engine: Engine, canvas: HTMLCanvasElement): Scene {
-    const scene = new Scene(engine);
-    scene.clearColor = new Color4(0.05, 0.05, 0.1, 1);
+  const scene = new Scene(engine);
+  scene.clearColor = new Color4(0.05, 0.05, 0.1, 1);
 
-    const camera = new ArcRotateCamera("camera", -Math.PI / 4, Math.PI / 3, 20, new Vector3(0, 3, 0), scene);
-    camera.attachControl(canvas, true);
-    camera.lowerRadiusLimit = 8;
-    camera.upperRadiusLimit = 40;
+  const camera = new ArcRotateCamera("camera", -Math.PI / 4, Math.PI / 3, 20, new Vector3(0, 3, 0), scene);
+  camera.attachControl(canvas, true);
+  camera.lowerRadiusLimit = 8;
+  camera.upperRadiusLimit = 40;
 
-    const ambientLight = new HemisphericLight("ambient", new Vector3(0, 1, 0), scene);
-    ambientLight.intensity = 0.3;
+  const ambientLight = new HemisphericLight("ambient", new Vector3(0, 1, 0), scene);
+  ambientLight.intensity = 0.3;
 
-    const directionalLight = new DirectionalLight("dirLight", new Vector3(-1, -2, 1).normalize(), scene);
-    directionalLight.position = new Vector3(5, 10, -5);
-    directionalLight.intensity = 0.8;
+  const directionalLight = new DirectionalLight("dirLight", new Vector3(-1, -2, 1).normalize(), scene);
+  directionalLight.position = new Vector3(5, 10, -5);
+  directionalLight.intensity = 0.8;
 
-    const shadowGenerator = new ShadowGenerator(1024, directionalLight);
-    shadowGenerator.useBlurExponentialShadowMap = true;
+  const shadowGenerator = new ShadowGenerator(1024, directionalLight);
+  shadowGenerator.useBlurExponentialShadowMap = true;
 
-    const ground = CreateGround("ground", { width: 20, height: 20 }, scene);
-    const groundMaterial = new PBRMaterial("groundMat", scene);
-    groundMaterial.albedoColor = new Color3(0.15, 0.15, 0.15);
-    groundMaterial.metallic = 0.1;
-    groundMaterial.roughness = 0.9;
-    ground.material = groundMaterial;
-    ground.receiveShadows = true;
+  const ground = CreateGround("ground", { width: 20, height: 20 }, scene);
+  const groundMaterial = new PBRMaterial("groundMat", scene);
+  groundMaterial.albedoColor = new Color3(0.15, 0.15, 0.15);
+  groundMaterial.metallic = 0.1;
+  groundMaterial.roughness = 0.9;
+  ground.material = groundMaterial;
+  ground.receiveShadows = true;
 
-    const sphereColors = [new Color3(0.8, 0.2, 0.2), new Color3(0.2, 0.8, 0.2), new Color3(0.2, 0.2, 0.8), new Color3(0.8, 0.8, 0.2)];
+  const sphereColors = [new Color3(0.8, 0.2, 0.2), new Color3(0.2, 0.8, 0.2), new Color3(0.2, 0.2, 0.8), new Color3(0.8, 0.8, 0.2)];
 
-    for (let index = 0; index < sphereColors.length; index++) {
-        const sphere = CreateSphere(`sphere${index}`, { diameter: 1, segments: 16 }, scene);
-        sphere.position = new Vector3((index - 1.5) * 2, 6 + index * 2, 0);
+  for (let index = 0; index < sphereColors.length; index++) {
+    const sphere = CreateSphere(`sphere${index}`, { diameter: 1, segments: 16 }, scene);
+    sphere.position = new Vector3((index - 1.5) * 2, 6 + index * 2, 0);
 
-        const sphereMaterial = new PBRMaterial(`sphereMat${index}`, scene);
-        sphereMaterial.albedoColor = sphereColors[index];
-        sphereMaterial.metallic = 0.5;
-        sphereMaterial.roughness = 0.4;
-        sphere.material = sphereMaterial;
+    const sphereMaterial = new PBRMaterial(`sphereMat${index}`, scene);
+    sphereMaterial.albedoColor = sphereColors[index];
+    sphereMaterial.metallic = 0.5;
+    sphereMaterial.roughness = 0.4;
+    sphere.material = sphereMaterial;
 
-        shadowGenerator.addShadowCaster(sphere);
-    }
+    shadowGenerator.addShadowCaster(sphere);
+  }
 
-    const boxA = CreateBox("boxA", { width: 1, height: 0.5, depth: 2 }, scene);
-    boxA.position = new Vector3(4, 4, 0);
-    const boxAMaterial = new PBRMaterial("boxAMat", scene);
-    boxAMaterial.albedoColor = new Color3(0.6, 0.3, 0.7);
-    boxAMaterial.metallic = 0.6;
-    boxAMaterial.roughness = 0.3;
-    boxA.material = boxAMaterial;
-    shadowGenerator.addShadowCaster(boxA);
+  const boxA = CreateBox("boxA", { width: 1, height: 0.5, depth: 2 }, scene);
+  boxA.position = new Vector3(4, 4, 0);
+  const boxAMaterial = new PBRMaterial("boxAMat", scene);
+  boxAMaterial.albedoColor = new Color3(0.6, 0.3, 0.7);
+  boxAMaterial.metallic = 0.6;
+  boxAMaterial.roughness = 0.3;
+  boxA.material = boxAMaterial;
+  shadowGenerator.addShadowCaster(boxA);
 
-    const boxB = CreateBox("boxB", { width: 1, height: 0.5, depth: 2 }, scene);
-    boxB.position = new Vector3(4, 4, 2.5);
-    const boxBMaterial = new PBRMaterial("boxBMat", scene);
-    boxBMaterial.albedoColor = new Color3(0.3, 0.6, 0.7);
-    boxBMaterial.metallic = 0.6;
-    boxBMaterial.roughness = 0.3;
-    boxB.material = boxBMaterial;
-    shadowGenerator.addShadowCaster(boxB);
+  const boxB = CreateBox("boxB", { width: 1, height: 0.5, depth: 2 }, scene);
+  boxB.position = new Vector3(4, 4, 2.5);
+  const boxBMaterial = new PBRMaterial("boxBMat", scene);
+  boxBMaterial.albedoColor = new Color3(0.3, 0.6, 0.7);
+  boxBMaterial.metallic = 0.6;
+  boxBMaterial.roughness = 0.3;
+  boxB.material = boxBMaterial;
+  shadowGenerator.addShadowCaster(boxB);
 
-    return scene;
+  return scene;
 }
 
 async function initPhysics(scene: Scene, havokInstance: unknown): Promise<void> {
-    const plugin = new HavokPlugin(true, havokInstance);
-    scene.enablePhysics(new Vector3(0, -9.81, 0), plugin);
+  const plugin = new HavokPlugin(true, havokInstance);
+  scene.enablePhysics(new Vector3(0, -9.81, 0), plugin);
 
-    const ground = scene.getMeshByName("ground");
-    if (ground) {
-        new PhysicsAggregate(ground, PhysicsShapeType.BOX, { mass: 0 }, scene);
+  const ground = scene.getMeshByName("ground");
+  if (ground) {
+    new PhysicsAggregate(ground, PhysicsShapeType.BOX, { mass: 0 }, scene);
+  }
+
+  for (let index = 0; index < 4; index++) {
+    const sphere = scene.getMeshByName(`sphere${index}`);
+    if (sphere) {
+      new PhysicsAggregate(sphere, PhysicsShapeType.SPHERE, { mass: 1, restitution: 0.6 }, scene);
     }
+  }
 
-    for (let index = 0; index < 4; index++) {
-        const sphere = scene.getMeshByName(`sphere${index}`);
-        if (sphere) {
-            new PhysicsAggregate(sphere, PhysicsShapeType.SPHERE, { mass: 1, restitution: 0.6 }, scene);
-        }
-    }
+  const boxA = scene.getMeshByName("boxA");
+  const boxB = scene.getMeshByName("boxB");
+  if (!boxA || !boxB) {
+    return;
+  }
 
-    const boxA = scene.getMeshByName("boxA");
-    const boxB = scene.getMeshByName("boxB");
-    if (!boxA || !boxB) {
-        return;
-    }
+  const aggregateA = new PhysicsAggregate(boxA, PhysicsShapeType.BOX, { mass: 0 }, scene);
+  const aggregateB = new PhysicsAggregate(boxB, PhysicsShapeType.BOX, { mass: 2 }, scene);
 
-    const aggregateA = new PhysicsAggregate(boxA, PhysicsShapeType.BOX, { mass: 0 }, scene);
-    const aggregateB = new PhysicsAggregate(boxB, PhysicsShapeType.BOX, { mass: 2 }, scene);
-
-    const hinge = new HingeConstraint(new Vector3(0, 0, 1), new Vector3(0, 0, -1), new Vector3(1, 0, 0), new Vector3(1, 0, 0), scene);
-    aggregateA.body.addConstraint(aggregateB.body, hinge);
+  const hinge = new HingeConstraint(new Vector3(0, 0, 1), new Vector3(0, 0, -1), new Vector3(1, 0, 0), new Vector3(1, 0, 0), scene);
+  aggregateA.body.addConstraint(aggregateB.body, hinge);
 }
 
 const canvas = document.getElementById("renderCanvas") as HTMLCanvasElement;
@@ -359,7 +358,7 @@ engine.runRenderLoop(() => scene.render());
 window.addEventListener("resize", () => engine.resize());
 
 import("@babylonjs/havok").then((havok) => {
-    havok.default().then((havokInstance: unknown) => initPhysics(scene, havokInstance));
+  havok.default().then((havokInstance: unknown) => initPhysics(scene, havokInstance));
 });
 ```
 
@@ -368,15 +367,35 @@ import("@babylonjs/havok").then((havok) => {
 For glTF loading, use `SceneLoader` with the pure barrel and the glTF loader package:
 
 ```typescript
-import { Engine, Scene, SceneLoader, RegisterStandardEngineExtensions, RegisterEnginesExtensionsEngineRawTexture } from "@babylonjs/core/pure";
-import "@babylonjs/loaders/glTF";
+import { Engine, Scene, ArcRotateCamera, DirectionalLight, Vector3, ImportMeshAsync, RegisterStandardEngineExtensions, RegisterEnginesExtensionsEngineRawTexture } from "@babylonjs/core/pure.js";
 
+// Register glTF loader plugin
+import "@babylonjs/loaders/glTF/2.0/index.js";
+
+// Engine extensions required for rendering
 RegisterStandardEngineExtensions();
+
+// Raw texture support (needed by glTF loader internally)
 RegisterEnginesExtensionsEngineRawTexture();
 
-const engine = new Engine(canvas, true);
-const scene = new Scene(engine);
-const result = await SceneLoader.ImportMeshAsync("", "model.glb", undefined, scene);
+const MODEL_URL = "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Assets/main/Models/Fox/glTF-Binary/Fox.glb";
+
+function createScene(engine) {
+  const scene = new Scene(engine);
+
+  // ── Camera ────────────────────────────────────────────────────────
+  const camera = new ArcRotateCamera("camera", -Math.PI / 2, Math.PI / 4, 150, new Vector3(0, 30, 0), scene);
+  camera.attachControl(true);
+  camera.lowerRadiusLimit = 50;
+  camera.upperRadiusLimit = 300;
+
+  const dir = new DirectionalLight("dir", new Vector3(-1, -3, -1), scene);
+  dir.intensity = 0.8;
+  dir.position = new Vector3(50, 100, 50);
+
+  // ── Load animated model ───────────────────────────────────────────
+  ImportMeshAsync(MODEL_URL, scene);
+}
 ```
 
 For `.babylon` files, serialization relies on `RegisterClass` to reconstruct objects by class name. Register the classes you expect to encounter:
@@ -418,36 +437,36 @@ This example creates a small VR gallery with teleportation, controller pointer s
 
 ```typescript
 import {
-    Engine,
-    Scene,
-    ArcRotateCamera,
-    HemisphericLight,
-    DirectionalLight,
-    CreateGround,
-    CreateCylinder,
-    CreateSphere,
-    CreateTorus,
-    CreateBox,
-    PBRMaterial,
-    StandardMaterial,
-    Color3,
-    Color4,
-    Vector3,
-    WebXRDefaultExperience,
-    WebXRFeatureName,
-    RegisterFullEngineExtensions,
-    RegisterWebXRDefaultExperience,
-    RegisterRay,
-    RegisterInstancedMesh,
-    RegisterAllNodeMaterialBlocks,
-    RegisterAnimation,
-    RegisterImageProcessingConfiguration,
-    RegisterColorCurves,
-    RegisterTexture,
-    RegisterFresnelParameters,
+  Engine,
+  Scene,
+  ArcRotateCamera,
+  HemisphericLight,
+  DirectionalLight,
+  CreateGround,
+  CreateCylinder,
+  CreateSphere,
+  CreateTorus,
+  CreateBox,
+  PBRMaterial,
+  StandardMaterial,
+  Color3,
+  Color4,
+  Vector3,
+  WebXRDefaultExperience,
+  WebXRFeatureName,
+  RegisterFullEngineExtensions,
+  RegisterWebXRDefaultExperience,
+  RegisterRay,
+  RegisterInstancedMesh,
+  RegisterAllNodeMaterialBlocks,
+  RegisterAnimation,
+  RegisterImageProcessingConfiguration,
+  RegisterColorCurves,
+  RegisterTexture,
+  RegisterFresnelParameters,
 } from "@babylonjs/core/pure";
 
-import "@babylonjs/loaders/glTF";
+import "@babylonjs/loaders/glTF/2.0";
 
 RegisterFullEngineExtensions();
 RegisterWebXRDefaultExperience();
@@ -461,70 +480,70 @@ RegisterTexture();
 RegisterFresnelParameters();
 
 function createScene(engine: Engine, canvas: HTMLCanvasElement): Scene {
-    const scene = new Scene(engine);
-    scene.clearColor = new Color4(0.05, 0.05, 0.1, 1);
+  const scene = new Scene(engine);
+  scene.clearColor = new Color4(0.05, 0.05, 0.1, 1);
 
-    const camera = new ArcRotateCamera("camera", -Math.PI / 2, Math.PI / 3, 10, Vector3.Zero(), scene);
-    camera.attachControl(canvas, true);
-    camera.lowerRadiusLimit = 2;
-    camera.upperRadiusLimit = 20;
+  const camera = new ArcRotateCamera("camera", -Math.PI / 2, Math.PI / 3, 10, Vector3.Zero(), scene);
+  camera.attachControl(canvas, true);
+  camera.lowerRadiusLimit = 2;
+  camera.upperRadiusLimit = 20;
 
-    const hemisphericLight = new HemisphericLight("hemi", new Vector3(0, 1, 0), scene);
-    hemisphericLight.intensity = 0.4;
+  const hemisphericLight = new HemisphericLight("hemi", new Vector3(0, 1, 0), scene);
+  hemisphericLight.intensity = 0.4;
 
-    const directionalLight = new DirectionalLight("dir", new Vector3(-1, -2, -1), scene);
-    directionalLight.intensity = 0.8;
-    directionalLight.position = new Vector3(5, 10, 5);
+  const directionalLight = new DirectionalLight("dir", new Vector3(-1, -2, -1), scene);
+  directionalLight.intensity = 0.8;
+  directionalLight.position = new Vector3(5, 10, 5);
 
-    const floor = CreateGround("floor", { width: 20, height: 20 }, scene);
-    const floorMaterial = new PBRMaterial("floorMat", scene);
-    floorMaterial.albedoColor = new Color3(0.15, 0.15, 0.2);
-    floorMaterial.metallic = 0.1;
-    floorMaterial.roughness = 0.9;
-    floor.material = floorMaterial;
+  const floor = CreateGround("floor", { width: 20, height: 20 }, scene);
+  const floorMaterial = new PBRMaterial("floorMat", scene);
+  floorMaterial.albedoColor = new Color3(0.15, 0.15, 0.2);
+  floorMaterial.metallic = 0.1;
+  floorMaterial.roughness = 0.9;
+  floor.material = floorMaterial;
 
-    const pedestalMaterial = new PBRMaterial("pedestalMat", scene);
-    pedestalMaterial.albedoColor = new Color3(0.6, 0.6, 0.65);
-    pedestalMaterial.metallic = 0.3;
-    pedestalMaterial.roughness = 0.5;
+  const pedestalMaterial = new PBRMaterial("pedestalMat", scene);
+  pedestalMaterial.albedoColor = new Color3(0.6, 0.6, 0.65);
+  pedestalMaterial.metallic = 0.3;
+  pedestalMaterial.roughness = 0.5;
 
-    const positions = [new Vector3(-3, 0, 3), new Vector3(0, 0, 4), new Vector3(3, 0, 3), new Vector3(-3, 0, -3), new Vector3(3, 0, -3)];
+  const positions = [new Vector3(-3, 0, 3), new Vector3(0, 0, 4), new Vector3(3, 0, 3), new Vector3(-3, 0, -3), new Vector3(3, 0, -3)];
 
-    positions.forEach((position, index) => {
-        const pedestal = CreateCylinder(`pedestal${index}`, { diameter: 0.8, height: 1 }, scene);
-        pedestal.position = position.add(new Vector3(0, 0.5, 0));
-        pedestal.material = pedestalMaterial;
+  positions.forEach((position, index) => {
+    const pedestal = CreateCylinder(`pedestal${index}`, { diameter: 0.8, height: 1 }, scene);
+    pedestal.position = position.add(new Vector3(0, 0.5, 0));
+    pedestal.material = pedestalMaterial;
 
-        const object = index % 3 === 0 ? CreateSphere(`obj${index}`, { diameter: 0.5, segments: 32 }, scene) : index % 3 === 1 ? CreateTorus(`obj${index}`, { diameter: 0.5, thickness: 0.15 }, scene) : CreateBox(`obj${index}`, { size: 0.4 }, scene);
-        object.position = position.add(new Vector3(0, 1.3, 0));
+    const object = index % 3 === 0 ? CreateSphere(`obj${index}`, { diameter: 0.5, segments: 32 }, scene) : index % 3 === 1 ? CreateTorus(`obj${index}`, { diameter: 0.5, thickness: 0.15 }, scene) : CreateBox(`obj${index}`, { size: 0.4 }, scene);
+    object.position = position.add(new Vector3(0, 1.3, 0));
 
-        const objectMaterial = new StandardMaterial(`objMat${index}`, scene);
-        objectMaterial.emissiveColor = Color3.FromHSV((index / positions.length) * 360, 0.7, 0.9);
-        objectMaterial.disableLighting = true;
-        object.material = objectMaterial;
-    });
+    const objectMaterial = new StandardMaterial(`objMat${index}`, scene);
+    objectMaterial.emissiveColor = Color3.FromHSV((index / positions.length) * 360, 0.7, 0.9);
+    objectMaterial.disableLighting = true;
+    object.material = objectMaterial;
+  });
 
-    WebXRDefaultExperience.CreateAsync(scene, {
-        floorMeshes: [floor],
-        optionalFeatures: true,
-        disableNearInteraction: true,
-    }).then((xr) => {
-        xr.teleportation?.addFloorMesh(floor);
+  WebXRDefaultExperience.CreateAsync(scene, {
+    floorMeshes: [floor],
+    optionalFeatures: true,
+    disableNearInteraction: true,
+  }).then((xr) => {
+    xr.teleportation?.addFloorMesh(floor);
 
-        try {
-            xr.baseExperience.featuresManager.enableFeature(WebXRFeatureName.POINTER_SELECTION, "stable", {
-                xrInput: xr.input,
-                enablePointerSelectionOnAllControllers: true,
-                disablePointerUpOnTouchOut: false,
-                forceGazeMode: false,
-                disableScenePointerVectorUpdate: false,
-            } as any);
-        } catch {
-            // Pointer selection is not available on every browser or device.
-        }
-    });
+    try {
+      xr.baseExperience.featuresManager.enableFeature(WebXRFeatureName.POINTER_SELECTION, "stable", {
+        xrInput: xr.input,
+        enablePointerSelectionOnAllControllers: true,
+        disablePointerUpOnTouchOut: false,
+        forceGazeMode: false,
+        disableScenePointerVectorUpdate: false,
+      } as any);
+    } catch {
+      // Pointer selection is not available on every browser or device.
+    }
+  });
 
-    return scene;
+  return scene;
 }
 
 const canvas = document.getElementById("renderCanvas") as HTMLCanvasElement;


### PR DESCRIPTION
## Summary
- Add a new ES6/NPM Support child section for tree-shaking with pure imports
- Document the pure barrel workflow, explicit side-effect registration, troubleshooting, and contributor patterns
- Include complete pure-import examples for an animated glTF scene, Physics V2 with Havok, and WebXR

## Validation
- Parsed `configuration/structure.json`
- Ran `git diff --check`
- Checked VS Code diagnostics for the new tree-shaking docs pages

## Notes
- `CheckMissingImports` is documented with its direct diagnostic import path because it is not exported from `@babylonjs/core/pure`.
- Earlier full `npm run build` completed successfully during prep, with existing static generation warnings/timeouts that did not fail the build.