### PR TITLE
fix(lite): rewrite Babylon Lite relative markdown links to site routes

### DIFF
--- a/__tests__/babylon-lite-docs.test.ts
+++ b/__tests__/babylon-lite-docs.test.ts
@@ -78,4 +78,37 @@ See the render loop.
         expect(menuItems?.map((item) => item.name)).toEqual(["Welcome", "Porting Guide", "Architecture"]);
         expect(menuItems?.map((item) => item.url)).toEqual(["/lite", "/lite/01-porting-guide", "/lite/architecture/00-overview"]);
     });
+
+    it("rewrites GitHub-native relative links to absolute Lite routes", () => {
+        writeFixture("00-welcome.md", "# Welcome\n\n![Diagram](images/diagram.png)\n");
+        writeFixture(
+            "01-getting-started.md",
+            "# Getting Started\n\nSee [Overview](architecture/00-overview.md) and [Welcome](00-welcome.md#intro).\n",
+        );
+        writeFixture(
+            "architecture/00-overview.md",
+            "# Overview\n\nBack to [Getting Started](../01-getting-started.md), see [Scene](01-scene.md), the [external site](https://babylonjs.com), and a [code sample](example.md) escaping via `[x](../../outside.md)`.\n",
+        );
+        writeFixture("architecture/01-scene.md", "# Scene\n");
+
+        const graph = buildBabylonLiteContentGraphFromDocsRoot(fixtureRoot);
+
+        const gettingStarted = graph.pagesByRoute["/lite/01-getting-started"];
+        expect(gettingStarted.rawContent).toContain("[Overview](/lite/architecture/00-overview)");
+        // Landing file collapses to /lite and anchors are preserved.
+        expect(gettingStarted.rawContent).toContain("[Welcome](/lite#intro)");
+
+        const overview = graph.pagesByRoute["/lite/architecture/00-overview"];
+        expect(overview.rawContent).toContain("[Getting Started](/lite/01-getting-started)");
+        expect(overview.rawContent).toContain("[Scene](/lite/architecture/01-scene)");
+        // External links and paths escaping the docs root are left untouched.
+        expect(overview.rawContent).toContain("[external site](https://babylonjs.com)");
+        expect(overview.rawContent).toContain("[x](../../outside.md)");
+
+        // Relative image assets resolve to their served /lite path.
+        expect(graph.pagesByRoute["/lite"].rawContent).toContain("![Diagram](/lite/images/diagram.png)");
+
+        // Internal-link extraction now sees the resolved routes.
+        expect(overview.internalLinks).toEqual(expect.arrayContaining(["lite/01-getting-started", "lite/architecture/01-scene"]));
+    });
 });

--- a/lib/babylonLiteDocs.ts
+++ b/lib/babylonLiteDocs.ts
@@ -1,6 +1,6 @@
 import { execSync } from "child_process";
 import { copyFileSync, existsSync, mkdirSync, readFileSync, readdirSync, rmSync, statSync } from "fs";
-import { basename, join, relative, resolve } from "path";
+import { basename, join, posix, relative, resolve } from "path";
 
 import matter from "gray-matter";
 
@@ -118,6 +118,71 @@ const escapeMdxJsxOutsideCodeBlocks = (content: string) => {
 };
 
 const readJson = (filePath: string) => JSON.parse(readFileSync(filePath, "utf-8")) as Record<string, unknown>;
+
+// The Babylon Lite markdown sources use GitHub-native relative links that include the
+// `.md` extension (so they resolve correctly when the files are browsed directly on
+// GitHub). The docs website routes lite pages without the extension (e.g.
+// `/lite/architecture/11-scene-hierarchy-parenting`), so we rewrite the relative links
+// to absolute site routes at build time. This is done deterministically from the source
+// file path rather than relying on browser relative-URL resolution (the site uses
+// `trailingSlash: true`, which would otherwise resolve `./foo` against the wrong base).
+const babylonLiteAssetLinkPattern = /\.(png|jpe?g|gif|svg|webp|avif|mp4|webm|json|glb|gltf)$/i;
+
+const rewriteBabylonLiteRelativeLinkTarget = (target: string, relativeFile: string, landingContentPath: string): string | undefined => {
+    // Leave external, absolute, anchor-only and protocol links untouched.
+    if (/^(https?:|mailto:|tel:|#|\/)/i.test(target)) {
+        return undefined;
+    }
+
+    const splitIndex = target.search(/[#?]/);
+    const pathPart = splitIndex === -1 ? target : target.slice(0, splitIndex);
+    const suffix = splitIndex === -1 ? "" : target.slice(splitIndex);
+    if (!pathPart) {
+        return undefined;
+    }
+
+    const isMarkdown = /\.md$/i.test(pathPart);
+    const isAsset = babylonLiteAssetLinkPattern.test(pathPart);
+    if (!isMarkdown && !isAsset) {
+        return undefined;
+    }
+
+    const baseDir = posix.dirname(relativeFile.replace(/\\/g, "/"));
+    const resolved = posix.normalize(posix.join(baseDir, pathPart));
+    // A link that escapes the docs/lite root is not a lite route; leave it as-is.
+    if (resolved === ".." || resolved.startsWith("../")) {
+        return undefined;
+    }
+
+    if (isMarkdown) {
+        const contentPath = resolved.replace(/\.md$/i, "");
+        const route = contentPath === landingContentPath ? "/lite" : `/lite/${contentPath}`;
+        return `${route}${suffix}`;
+    }
+
+    return `/lite/${resolved}${suffix}`;
+};
+
+const rewriteBabylonLiteRelativeLinks = (content: string, relativeFile: string, landingRelativeFile: string): string => {
+    const landingContentPath = landingRelativeFile.replace(/\.md$/i, "");
+    let inFence = false;
+    return content
+        .split("\n")
+        .map((line) => {
+            if (line.trimStart().startsWith("```")) {
+                inFence = !inFence;
+                return line;
+            }
+            if (inFence) {
+                return line;
+            }
+            return line.replace(/\]\(([^)]+)\)/g, (match, rawTarget: string) => {
+                const rewritten = rewriteBabylonLiteRelativeLinkTarget(rawTarget.trim(), relativeFile, landingContentPath);
+                return rewritten ? `](${rewritten})` : match;
+            });
+        })
+        .join("\n");
+};
 
 const hasBabylonLiteDocs = (repositoryPath: string) => existsSync(join(repositoryPath, babylonLiteDocsRelativeRoot));
 
@@ -322,6 +387,7 @@ export const getBabylonLitePageData = async (id: string[]): Promise<IDocumentati
 
     const fileContents = readFileSync(fullPath, "utf-8");
     const parsed = matter(fileContents);
+    const normalizedContent = rewriteBabylonLiteRelativeLinks(parsed.content, relativeFile, landingRelativeFile);
     const flavorMenuItems = await getBabylonLiteMenuItems();
     const fallbackTitle = titleFromSlug(basename(relativeFile, ".md"));
     const title = typeof parsed.data.title === "string" ? parsed.data.title : getTitleFromContent(parsed.content, fallbackTitle);
@@ -346,7 +412,7 @@ export const getBabylonLitePageData = async (id: string[]): Promise<IDocumentati
             imageUrl: "",
             robots: "noindex, nofollow",
         },
-        content: escapeMdxJsxOutsideCodeBlocks(parsed.content),
+        content: escapeMdxJsxOutsideCodeBlocks(normalizedContent),
         childPages: {},
         relatedArticles: {},
         relatedExternalLinks: [],
@@ -419,7 +485,8 @@ const createBabylonLiteContentGraphFromDocsRoot = (docsRoot: string): ContentGra
     const pages: ContentGraphPage[] = files.map((relativeFile, index) => {
         const fullPath = join(docsRoot, relativeFile);
         const rawMarkdown = readFileSync(fullPath, "utf-8");
-        const { content, frontmatter } = parseMarkdownFrontmatter(rawMarkdown);
+        const { content: parsedContent, frontmatter } = parseMarkdownFrontmatter(rawMarkdown);
+        const content = rewriteBabylonLiteRelativeLinks(parsedContent, relativeFile, landingRelativeFile);
         const effectiveIds = idsFromRelativeFile(relativeFile);
         const id = routeIdFromRelativeFile(relativeFile, landingRelativeFile);
         const title = getTitleFromContent(content, titleFromSlug(basename(relativeFile, ".md")));


### PR DESCRIPTION
## Summary

Babylon Lite markdown sources use GitHub-native relative links that include the `.md` extension so they resolve correctly when browsed directly on GitHub. The docs website routes lite pages **without** the extension (e.g. `/lite/architecture/11-scene-hierarchy-parenting`), so relative links break on the site.

This rewrites relative links (both markdown pages and assets) to absolute `/lite/...` site routes at build time. Resolution is done **deterministically from the source file path** rather than relying on browser relative-URL resolution — the site uses `trailingSlash: true`, which would otherwise resolve `./foo` against the wrong base.

Details:
- New `rewriteBabylonLiteRelativeLinks` helper, applied in both `getBabylonLitePageData` and `createBabylonLiteContentGraphFromDocsRoot`.
- Skips external, absolute, anchor-only, and protocol links; skips links that escape the lite root.
- Handles `#`/`?` suffixes and preserves them.
- Fenced code blocks are left untouched.
- Landing page maps to `/lite`.

## Companion PR

Must land alongside **BabylonJS/Babylon-Lite#363**, which converts the lite docs to GitHub-native relative `.md` links (fixing BabylonJS/Babylon-Lite#360). This PR keeps the deployed website resolving those links to `/lite/...` routes. Neither PR is complete without the other.

## Testing
- `vitest run babylon-lite-docs` — 3/3 pass (includes new coverage for the link rewriting).

Co-authored-by: Copilot App <223556219+Copilot@users.noreply.github.com>
