### PR TITLE
fix(getting-started): rotate wheels in car.glb village playground

### DIFF
--- a/content/features/introductionToFeatures/chap3/caranimation.md
+++ b/content/features/introductionToFeatures/chap3/caranimation.md
@@ -45,7 +45,7 @@ scene.beginAnimation(car, 0, 210, true);
 
 After adjusting the position of the car and its route so that it travels past the village houses we have 
 
-<Playground id="#KDPAQ9#17" title="Add the Car to the Village" description="Add the animating car back into the village." image="/img/playgroundsAndNMEs/gettingStartedCarAnimation2.webp"/>
+<Playground id="#KJ6XKH#0" title="Add the Car to the Village" description="Add the animating car back into the village." image="/img/playgroundsAndNMEs/gettingStartedCarAnimation2.webp"/>
 
 In this case we have built the car. Let's now look at a model character that we can import along with its built-in animation.
 


### PR DESCRIPTION
## Problem

Reported on the forum: [Car glb does not contain wheel rotation animations](https://forum.babylonjs.com/t/car-glb-does-not-contain-wheel-rotation-animations/63755).

In the Getting Started **Car Animation** page, the "Add the Car to the Village" playground used `car.glb`, whose wheels did **not** rotate — unlike the earlier `car.babylon` playground where they do.

Two root causes:
1. **`car.glb` contains zero animations**, whereas `car.babylon` has `rotation.y` wheel animations baked in. So `scene.beginAnimation(wheelRB, …)` had nothing to play.
2. **The GLB wheels import with a `rotationQuaternion`**, which overrides any Euler `rotation.y` change — so even after adding an animation the wheels stay frozen until the quaternion is nulled.

## Fix

Point the "Add the Car to the Village" playground at a corrected snippet (`#KJ6XKH#0`) that:
- Builds the wheel rotation animation in code (matching what the earlier *Wheel Animation* page teaches).
- Sets `rotationQuaternion = null` on the four wheels so the Euler animation is applied.
- Keeps the GLB, village, car positioning and driving animation identical to before.

Verified in-browser: the car drives through the village and all four wheels visibly spin about their axle with no wobble and no console errors.
