### PR TITLE
chore(deps): pin dependencies to versions at least 7 days old

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,6 @@
+# Company policy: only install package versions published at least 7 days ago.
+# Requires npm >= 11.10.0 (older npm silently ignores this setting).
+min-release-age=7
+
+# Enforce the "engines" requirement in package.json (e.g. the npm version).
+engine-strict=true

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -12,7 +12,7 @@ pool:
   vmImage: ubuntu-latest
 
 variables:
-  NODE_VERSION: 22.x
+  NODE_VERSION: 24.x
   NPM_CONFIG_CACHE: $(Pipeline.Workspace)/.npm
   DOCS_ZIP: $(Build.ArtifactStagingDirectory)/docs.zip
   SNAPSHOT_BASE_URL: https://snapshots-cvgtc2eugrd3cgfd.z01.azurefd.net

--- a/package-lock.json
+++ b/package-lock.json
@@ -4745,9 +4745,9 @@
             }
         },
         "node_modules/baseline-browser-mapping": {
-            "version": "2.10.42",
-            "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.42.tgz",
-            "integrity": "sha512-c/jurFrDLyui7o1J86yLkRu4LMsTYcBohveus7/I2Hzdn9KIP2bdJPTue/lR1KH46enoPbD77GKeSYNdyPoD3Q==",
+            "version": "2.10.41",
+            "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.41.tgz",
+            "integrity": "sha512-WwS7MHhqGHHlaVsqRZnhvCEMS0owDX+SxRlve7JkuH7My1Ara3ZriTmCQupPfYjxMZ8I/tgxtJYr2t7taHaH4A==",
             "license": "Apache-2.0",
             "bin": {
                 "baseline-browser-mapping": "dist/cli.cjs"
@@ -5714,9 +5714,9 @@
             "license": "MIT"
         },
         "node_modules/electron-to-chromium": {
-            "version": "1.5.387",
-            "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.387.tgz",
-            "integrity": "sha512-TaxwufTFDufvPEoXdhwVrA3UdFWBeWGkYoJ1K8ldF1xe6gKfth6iRNS5lTQ5JPNOHdGQm8PT1QYKUqFLCiUefQ==",
+            "version": "1.5.385",
+            "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.385.tgz",
+            "integrity": "sha512-78sa/M08MNAYHQfjoWMvOlKQqZ0ElhSm/L5HNUc96VZ3b+KvDVnngFm8sYQy0XrhTRgAhggHr5abA7yTvRdo4Q==",
             "license": "ISC"
         },
         "node_modules/emoji-regex": {
@@ -13641,9 +13641,9 @@
             "license": "0BSD"
         },
         "node_modules/tsx": {
-            "version": "4.23.0",
-            "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.23.0.tgz",
-            "integrity": "sha512-eUdUIaCr963q2h5u3+QwvYp0+eqPvn+egeqZUm0hwERCqqx1E3kK5ehbGCvqSE5MQAULr67ww0cA3jKc3YkM1w==",
+            "version": "4.22.5",
+            "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.22.5.tgz",
+            "integrity": "sha512-F7JnSfPl5ASt6LqwWyUQ3T8BwN3q0eQEbFMYa2iRWaVQmmudo0d7fRmwM4O002gsvW1bs0yBYioutsAjqLJMvQ==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -14514,9 +14514,9 @@
             "license": "Apache-2.0"
         },
         "node_modules/webpack": {
-            "version": "5.108.4",
-            "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.108.4.tgz",
-            "integrity": "sha512-yur8LyJoeiWh47dErD+Ok7vlbmDsJ3UbbRPAoxbGJ54WpE2y5yVo5G/inUzujnYgw3tPmBRdn+G7PoxXaYC33w==",
+            "version": "5.108.3",
+            "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.108.3.tgz",
+            "integrity": "sha512-hOpaCHmQVVY66IVTjofnH14IgSdmod2aquSGHGuYig/OIdWge01Hk2Wt988DZcwXumFUT4+FvJY5N+ikl8o/ww==",
             "devOptional": true,
             "license": "MIT",
             "dependencies": {

--- a/package.json
+++ b/package.json
@@ -79,5 +79,8 @@
     },
     "overrides": {
         "postcss": "^8.5.10"
+    },
+    "engines": {
+        "npm": ">=11.10.0"
     }
 }


### PR DESCRIPTION
## What

Enforces the new company-wide policy that npm dependencies must be at least **7 days old**, and makes it automatic going forward.

### 1. Repin too-new locked versions
Four packages were resolved to versions published only 1–2 days ago; each is pinned back to the newest version published on or before the 7-day cutoff (2026-07-03), still satisfying its existing semver ranges.

| Package | Was | Now | Published |
|---|---|---|---|
| `baseline-browser-mapping` | 2.10.42 | 2.10.41 | Jul 2 |
| `electron-to-chromium` | 1.5.387 | 1.5.385 | Jul 2 |
| `tsx` | 4.23.0 | 4.22.5 | Jul 2 |
| `webpack` | 5.108.4 | 5.108.3 | Jun 29 |

### 2. Enforce the policy going forward
- `.npmrc`: `min-release-age=7` — npm will only install versions public for ≥ 7 days (npm **11.10.0+** feature; older npm silently ignores it).
- `.npmrc`: `engine-strict=true` — enforce the `engines` requirement below.
- `package.json` `engines.npm`: `>=11.10.0`, since older npm ignores `min-release-age`.

## How

- Scanned all 981 unique `name@version` entries in `package-lock.json` against npm registry publish times.
- Repinned the 4 too-new entries (version + resolved + integrity), then ran `npm install --package-lock-only` to reconcile (no sub-dependency changes, 0 vulnerabilities).
- Re-scanned: **0** packages remain under 7 days old.

> Note: `engine-strict=true` means `npm install` now fails on npm < 11.10.0. Developers/CI must be on npm ≥ 11.10.0.
