### PR TITLE
Fix village streetlamp cloning in strict mode

### DIFF
--- a/content/features/introductionToFeatures/chap7/lights.md
+++ b/content/features/introductionToFeatures/chap7/lights.md
@@ -58,6 +58,6 @@ We export the lamp, of appropriate size, to use it in the village. As we need mo
 material.maxSimultaneousLights = 5;
 ```
 
-<Playground id="#KBS9I5#94" title="Add Street Lights" description="Add street lights to the village and adjust the lighting." image="/img/playgroundsAndNMEs/gettingStartedStreetLights2.webp"/>
+<Playground id="#KBS9I5#39688" title="Add Street Lights" description="Add street lights to the village and adjust the lighting." image="/img/playgroundsAndNMEs/gettingStartedStreetLights2.webp"/>
 
 It would be good if we could slide daylight into nightlight and vice-versa. We can when we add the Babylon.js GUI.


### PR DESCRIPTION
The village sample displayed only one streetlamp because the cloned lamp variables were assigned without being declared.

After the Babylon.js Playground switched to strict mode, this caused the following error and stopped the remaining streetlamps from being created:

index.js:21 Uncaught (in promise) ReferenceError: lamp3 is not defined

The sample URL has been updated to point to the corrected version.

Related forum thread:
https://forum.babylonjs.com/t/only-one-streetlamp-in-the-village-is-displayed/63775