### PR TITLE
chore: update Next.js to 16.2.10

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17,7 +17,7 @@
                 "@mui/system": "^5.15.20",
                 "@next/mdx": "^16.1.7",
                 "eslint-config-next": "^16.1.7",
-                "next": "^16.0.10",
+                "next": "^16.2.10",
                 "next-mdx-remote": "^6.0.0",
                 "node-html-parser": "^7.1.0",
                 "prism-react-renderer": "^2.4.1",
@@ -2165,9 +2165,9 @@
             }
         },
         "node_modules/@next/env": {
-            "version": "16.2.9",
-            "resolved": "https://registry.npmjs.org/@next/env/-/env-16.2.9.tgz",
-            "integrity": "sha512-ki5VxxXfzD/9TDe13wyeTKIjQTAwBVpnr8KhRDUr8ltMUq1/NBpWNT5tiPoxiGl+PHM4X2ahSOiPk6iAimIzPg==",
+            "version": "16.2.10",
+            "resolved": "https://registry.npmjs.org/@next/env/-/env-16.2.10.tgz",
+            "integrity": "sha512-zLPxg9M0MEHmygpj5OuxjQ+vHMiy/K7cSp74G8ecYolmgUWw0RwN02tF56npup/+qaI8JB97hQgS/r2Hb6QwVA==",
             "license": "MIT"
         },
         "node_modules/@next/eslint-plugin-next": {
@@ -2210,9 +2210,9 @@
             }
         },
         "node_modules/@next/swc-darwin-arm64": {
-            "version": "16.2.9",
-            "resolved": "https://registry.npmjs.org/@next/swc-darwin-arm64/-/swc-darwin-arm64-16.2.9.tgz",
-            "integrity": "sha512-HkfxNYUCmcct0Xsqib5KxqMSHV4AHJq857BNRchyBDs4YS19aHzVfn1kDuBYKqLLQBjXgnkIsjV2Kd4d2wzYhw==",
+            "version": "16.2.10",
+            "resolved": "https://registry.npmjs.org/@next/swc-darwin-arm64/-/swc-darwin-arm64-16.2.10.tgz",
+            "integrity": "sha512-v9IdJCa0H0mbo+8z5zwUpOk1Vj7RjkcI5uNYf5Ws1y6szf/p3Mzl9hLaST8SCt6L9h8NGnruZcd2+o0NTNwDhA==",
             "cpu": [
                 "arm64"
             ],
@@ -2226,9 +2226,9 @@
             }
         },
         "node_modules/@next/swc-darwin-x64": {
-            "version": "16.2.9",
-            "resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-16.2.9.tgz",
-            "integrity": "sha512-7IAtK4MeybpqRV9GRABWEhJ62mOS+rzWOzOTFie4cSEtm12xsoOMJRcECoZx3FHPzFAqN/IJtHqWAFOLfl152w==",
+            "version": "16.2.10",
+            "resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-16.2.10.tgz",
+            "integrity": "sha512-17IS0jJRViROGmA9uGdNR8VPJpfbnaVG7E9qhso5jDLkmyd0lSDORWxbcKINzcFqzZqGwGtMSnrFRxBpuUYjLQ==",
             "cpu": [
                 "x64"
             ],
@@ -2242,9 +2242,9 @@
             }
         },
         "node_modules/@next/swc-linux-arm64-gnu": {
-            "version": "16.2.9",
-            "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-16.2.9.tgz",
-            "integrity": "sha512-hBD75iWpUtkL9SmQmcRhmLomn9jgkPzCEkbOcLgHymPEKzv+6ONy13RRiIEz/iEObjkS2Jlb5gYS2XGoS3X4rw==",
+            "version": "16.2.10",
+            "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-16.2.10.tgz",
+            "integrity": "sha512-GRQRsRtuciNJvB54AvvuQTiq0oZtFwa1owQqtZD8wwnGpM2L39MV22kpI72YSXLKIyY40LC66EiLFv4PiicXxg==",
             "cpu": [
                 "arm64"
             ],
@@ -2258,9 +2258,9 @@
             }
         },
         "node_modules/@next/swc-linux-arm64-musl": {
-            "version": "16.2.9",
-            "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-16.2.9.tgz",
-            "integrity": "sha512-qZTI3pf9SGc/obr8NkQAekBxmp1QK+kVm+VAf3BALLfFAj+1kUhkTxmrWpVos9R/UYIA8AWX2p6cGI5WdwzVUA==",
+            "version": "16.2.10",
+            "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-16.2.10.tgz",
+            "integrity": "sha512-zkN9MQYS7UQBro+FnISUq1itaQjXI9xqISzuQ+2bc921NcJ1x4yPCqrn77tVN6/dOOXaaWVX3k6/bR07pPwK+A==",
             "cpu": [
                 "arm64"
             ],
@@ -2274,9 +2274,9 @@
             }
         },
         "node_modules/@next/swc-linux-x64-gnu": {
-            "version": "16.2.9",
-            "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-16.2.9.tgz",
-            "integrity": "sha512-xm0HfRNX+UkH4R3c18ynswjj5o5uEj/7iI9p9omdtTSIsRCzQqkGMA+10nzJ4EHnYC3as65IMhbbl5fWRUWHYg==",
+            "version": "16.2.10",
+            "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-16.2.10.tgz",
+            "integrity": "sha512-iCVJnwvrPYECvA6WM/7+oo+OiTvedIKLxtCLAZP4xZR3nXa1zmzZyLPbYCmWvpd4CvMYF1EMTafd0ii3DygLvA==",
             "cpu": [
                 "x64"
             ],
@@ -2290,9 +2290,9 @@
             }
         },
         "node_modules/@next/swc-linux-x64-musl": {
-            "version": "16.2.9",
-            "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-16.2.9.tgz",
-            "integrity": "sha512-QumimHkGEG6vM3PfEDWKyKen03NcqLOkeKB1EfcPe7VxzmEiCa4jNnMyBn/US5zcd/VE1CI+O8Ovb3lfjVHfGw==",
+            "version": "16.2.10",
+            "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-16.2.10.tgz",
+            "integrity": "sha512-ov2g4H0dHY9bPoOU83m91hWT7Iq5qy13bUnyyshLU3HGR1Ownn0X9QpmDPc5iIUaahTp7f7LeGAhV4DSFtackw==",
             "cpu": [
                 "x64"
             ],
@@ -2306,9 +2306,9 @@
             }
         },
         "node_modules/@next/swc-win32-arm64-msvc": {
-            "version": "16.2.9",
-            "resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-16.2.9.tgz",
-            "integrity": "sha512-hzQpKZvw8rAwI6A2uQh6SacCSvNAXaIkPNsWwzqqfRiIMiXMfH936skDhz1OO6KpvdKkJrgHHtqQOq5PIXOvdQ==",
+            "version": "16.2.10",
+            "resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-16.2.10.tgz",
+            "integrity": "sha512-DwAnhLX76HQiFFQNgWlcK+JzlnD1rZ+UK/WY0ZMI/deXpvgnesjNYrqcfo1JzBuz4Kf7o3brIBL0glI1junatA==",
             "cpu": [
                 "arm64"
             ],
@@ -2322,9 +2322,9 @@
             }
         },
         "node_modules/@next/swc-win32-x64-msvc": {
-            "version": "16.2.9",
-            "resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-16.2.9.tgz",
-            "integrity": "sha512-qr2VL3Ce5QrwgO2yh1ujSBawrimjVKX8FGF/cOynmdYKJY0BdHpGVNIRK1tqONB10Vkm25Ub1BD2bkjWs4+96w==",
+            "version": "16.2.10",
+            "resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-16.2.10.tgz",
+            "integrity": "sha512-0JXq3b85Jk9Jg4ntLUbXSPvoDw3gpZou7twuKdoFG2jOw635v7+IiXfTaa0TxVMyx78pUjnrVYwLgjKfX4e6/A==",
             "cpu": [
                 "x64"
             ],
@@ -10738,12 +10738,12 @@
             }
         },
         "node_modules/next": {
-            "version": "16.2.9",
-            "resolved": "https://registry.npmjs.org/next/-/next-16.2.9.tgz",
-            "integrity": "sha512-MEOJiq/UvuezAdqVSceHbqDgZt1kDw2tpGVOlsdIoJsQdbN2JY2hpVG4xnXGkbdJUOEWhnRfiu/O4Hpc9Juwww==",
+            "version": "16.2.10",
+            "resolved": "https://registry.npmjs.org/next/-/next-16.2.10.tgz",
+            "integrity": "sha512-2som5AVXb3kE6Yjine3/mNbBayYF58eguBWIVVUdr1y/L426xyVEgYxgBG+1QC34P2x5E+tcDup6XkuOAX3dCA==",
             "license": "MIT",
             "dependencies": {
-                "@next/env": "16.2.9",
+                "@next/env": "16.2.10",
                 "@swc/helpers": "0.5.15",
                 "baseline-browser-mapping": "^2.9.19",
                 "caniuse-lite": "^1.0.30001579",
@@ -10757,14 +10757,14 @@
                 "node": ">=20.9.0"
             },
             "optionalDependencies": {
-                "@next/swc-darwin-arm64": "16.2.9",
-                "@next/swc-darwin-x64": "16.2.9",
-                "@next/swc-linux-arm64-gnu": "16.2.9",
-                "@next/swc-linux-arm64-musl": "16.2.9",
-                "@next/swc-linux-x64-gnu": "16.2.9",
-                "@next/swc-linux-x64-musl": "16.2.9",
-                "@next/swc-win32-arm64-msvc": "16.2.9",
-                "@next/swc-win32-x64-msvc": "16.2.9",
+                "@next/swc-darwin-arm64": "16.2.10",
+                "@next/swc-darwin-x64": "16.2.10",
+                "@next/swc-linux-arm64-gnu": "16.2.10",
+                "@next/swc-linux-arm64-musl": "16.2.10",
+                "@next/swc-linux-x64-gnu": "16.2.10",
+                "@next/swc-linux-x64-musl": "16.2.10",
+                "@next/swc-win32-arm64-msvc": "16.2.10",
+                "@next/swc-win32-x64-msvc": "16.2.10",
                 "sharp": "^0.34.5"
             },
             "peerDependencies": {

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
         "@mui/system": "^5.15.20",
         "@next/mdx": "^16.1.7",
         "eslint-config-next": "^16.1.7",
-        "next": "^16.0.10",
+        "next": "^16.2.10",
         "next-mdx-remote": "^6.0.0",
         "node-html-parser": "^7.1.0",
         "prism-react-renderer": "^2.4.1",


### PR DESCRIPTION
## What

Updates Next.js from `^16.0.10` to `^16.2.10`.

## Why

Routine dependency maintenance to pick up the latest patch/minor releases.

## Version policy

Per the new 7-day dependency policy, only versions published at least 7 days ago are eligible. As of 2026-07-14 the cutoff is 2026-07-07:

- `next@16.2.10` was published **2026-07-01** ✅ (eligible)
- `16.3.0-canary.79`+ (2026-07-07 onward) were excluded as too recent, and canary/preview releases are skipped anyway.

`16.2.10` is the highest eligible **stable** semver.

## Verification

- `npm install` completed cleanly — **0 vulnerabilities**
- `npm run build` passed (content + typedoc + `next build`)

Co-authored-by: Copilot App <223556219+Copilot@users.noreply.github.com>