### PR TITLE
Avoid escaping HTML in inline code and blockquote markers (in MDX content)

### DIFF
--- a/__tests__/__snapshots__/babylon-lite-docs.test.ts.snap
+++ b/__tests__/__snapshots__/babylon-lite-docs.test.ts.snap
@@ -1,0 +1,33 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`Babylon Lite documentation integration > escapes HTML outside of code blocks and inline code, and doesn't escape the Markdown blockquote indicator 1`] = `
+"# Begin
+
+\`\`\`javascript
+const someJS = new BABYLON.Engine(canvas, true);
+const index = 3;
+if (index < 5 || index > 2) { }
+<div>some HTML as well</div>
+<script src="this_is_fine.js"></script>
+\`\`\`
+
+\`\`\`
+interface SomeTS {
+    name: string;
+}
+\`\`\`
+
+Some \`inline code\` to test the \`parsing\` of such code.
+\`And starting\` a line.
+Also \`containing <script src="this_is_also_fine.js"></script> HTML\` which
+shouldn't be a problem.
+
+&lt;div&gt;This HTML block should be escaped.
+It really should.&lt;/div&gt;
+
+&lt;script src="please_escape_this.js"&gt;&lt;/script&gt;
+
+> Also, don't escape the blockquote indicator.
+ > Really.
+"
+`;

--- a/__tests__/babylon-lite-docs.test.ts
+++ b/__tests__/babylon-lite-docs.test.ts
@@ -67,6 +67,49 @@ See the render loop.
         ]);
     });
 
+    it("escapes HTML outside of code blocks and inline code, and doesn't escape the Markdown blockquote indicator", async () => {
+        writeFixture(
+            "00-escaping-html.md",
+            `---
+title: Escaping HTML
+description: Exclude code and blockquote indicator
+---
+# Begin
+
+\`\`\`javascript
+const someJS = new BABYLON.Engine(canvas, true);
+const index = 3;
+if (index < 5 || index > 2) { }
+<div>some HTML as well</div>
+<script src="this_is_fine.js"></script>
+\`\`\`
+
+\`\`\`
+interface SomeTS {
+    name: string;
+}
+\`\`\`
+
+Some \`inline code\` to test the \`parsing\` of such code.
+\`And starting\` a line.
+Also \`containing <script src="this_is_also_fine.js"></script> HTML\` which
+shouldn't be a problem.
+
+<div>This HTML block should be escaped.
+It really should.</div>
+
+<script src="please_escape_this.js"></script>
+
+> Also, don't escape the blockquote indicator.
+ > Really.
+`
+        );
+
+        const graph = buildBabylonLiteContentGraphFromDocsRoot(fixtureRoot);
+        const documentationItems = createDocumentationSearchIndex(graph, "lite");
+        expect(documentationItems?.[0]?.content).toMatchSnapshot();
+    });
+
     it("keeps top-level menu items in folder and file name order", () => {
         const menuItems = buildBabylonLiteMenuItemsFromRelativeFiles([
             "00-welcome.md",

--- a/lib/babylonLiteDocs.ts
+++ b/lib/babylonLiteDocs.ts
@@ -112,7 +112,12 @@ const escapeMdxJsxOutsideCodeBlocks = (content: string) => {
             if (inFence) {
                 return line;
             }
-            return line.replace(/</g, "&lt;").replace(/>/g, "&gt;");
+
+            // Avoid escaping inlined code examples.
+            const escapedLine = line.split("`").map((text, index) => index % 2 ? text : text.replace(/</g, "&lt;").replace(/>/g, "&gt;")).join("`");
+
+            // Unescape blockquotes.
+            return escapedLine.replace(/^(\s*)&gt;/, "$1>");
         })
         .join("\n");
 };
@@ -486,10 +491,10 @@ const createBabylonLiteContentGraphFromDocsRoot = (docsRoot: string): ContentGra
         const fullPath = join(docsRoot, relativeFile);
         const rawMarkdown = readFileSync(fullPath, "utf-8");
         const { content: parsedContent, frontmatter } = parseMarkdownFrontmatter(rawMarkdown);
-        const content = rewriteBabylonLiteRelativeLinks(parsedContent, relativeFile, landingRelativeFile);
+        const normalizedContent = rewriteBabylonLiteRelativeLinks(parsedContent, relativeFile, landingRelativeFile);
         const effectiveIds = idsFromRelativeFile(relativeFile);
         const id = routeIdFromRelativeFile(relativeFile, landingRelativeFile);
-        const title = getTitleFromContent(content, titleFromSlug(basename(relativeFile, ".md")));
+        const title = getTitleFromContent(normalizedContent, titleFromSlug(basename(relativeFile, ".md")));
         const metadata = buildDefaultMetadata(title);
         applyFrontmatter(metadata, frontmatter);
 
@@ -499,7 +504,7 @@ const createBabylonLiteContentGraphFromDocsRoot = (docsRoot: string): ContentGra
             docItem: { friendlyName: metadata.title, content: relativeFile.replace(/\.md$/, "") },
             contentPath: relativeFile.replace(/\.md$/, ""),
             sourcePath: fullPath,
-            rawContent: content,
+            rawContent: escapeMdxJsxOutsideCodeBlocks(normalizedContent),
             frontmatter,
             metadata,
             breadcrumbs: [
@@ -513,8 +518,8 @@ const createBabylonLiteContentGraphFromDocsRoot = (docsRoot: string): ContentGra
             previousId: index > 0 ? routeIdFromRelativeFile(files[index - 1], landingRelativeFile) : undefined,
             nextId: index < files.length - 1 ? routeIdFromRelativeFile(files[index + 1], landingRelativeFile) : undefined,
             furtherReading: metadata.furtherReading,
-            internalLinks: extractInternalLinks(content),
-            examples: extractExampleReferences(content),
+            internalLinks: extractInternalLinks(normalizedContent),
+            examples: extractExampleReferences(normalizedContent),
             lastModified: statSync(fullPath).mtime,
             gitHubUrl: `${docsFlavors.lite.githubUrl}/blob/master/docs/lite/${relativeFile}`,
         };


### PR DESCRIPTION
* fix(lite): avoid escaping (in MDX) HTML in inline code and blockquote markers

    The fix only impacts the MDX escaping function used by the Babylon-Lite docs.
    HTML escaping of inline code between single back-ticks no longer occurs, and
    blockquote "greater-than" indicators are no longer escaped.

    A test has been added to cover the changes.

    The Lite content graph generator has also been modified to use the HTML
    escaping function. This is both for consistency and so the tests can use the
    generator to verify the escaping of HTML.

Closes #1602 

**Update:** Description changed after post-review changes.