### PR TITLE
Update dependencies, refresh test snapshots, and bump node-html-parser to v9

### DIFF
--- a/__tests__/__snapshots__/markdown-parsing.test.ts.snap
+++ b/__tests__/__snapshots__/markdown-parsing.test.ts.snap
@@ -4504,7 +4504,7 @@ function _createMdxContent(props) {
       lineNumber: 4,
       columnNumber: 1
     }, this), "\\n", _jsxDEV(_components.p, {
-      children: "The HTML Mesh is a mesh that displays a webpage (or DOM element) in the scene, meaning that it can occlude other meshes and be occluded by other meshs."
+      children: "The HTML Mesh is a mesh that displays a webpage (or DOM element) in the scene, meaning that it can occlude other meshes and be occluded by other meshes."
     }, undefined, false, {
       fileName: "<source.js>",
       lineNumber: 6,
@@ -4528,7 +4528,7 @@ function _createMdxContent(props) {
       lineNumber: 10,
       columnNumber: 1
     }, this), "\\n", _jsxDEV(_components.p, {
-      children: "The following uses cases are supported by the HtmlMesh"
+      children: "The following use cases are supported by the HtmlMesh:"
     }, undefined, false, {
       fileName: "<source.js>",
       lineNumber: 12,
@@ -4553,7 +4553,7 @@ function _createMdxContent(props) {
         lineNumber: 16,
         columnNumber: 1
       }, this), "\\n", _jsxDEV(_components.li, {
-        children: "Create a rich UI that can leverage all of the capabilities of CSS and can be driven through a CMS"
+        children: "Create a rich UI that can leverage all of the capabilities of CSS and can be driven through a CMS."
       }, undefined, false, {
         fileName: "<source.js>",
         lineNumber: 17,
@@ -4564,26 +4564,26 @@ function _createMdxContent(props) {
       lineNumber: 14,
       columnNumber: 1
     }, this), "\\n", _jsxDEV(_components.p, {
-      children: "Note that the use of HtmlMesh requires that the experience be accessed through a browser so in it's\\ncurrent form, this will not work in native apps or in XR. If constructed outside of a browser context, the\\nHtmlMesh instances will not have any geometry and will be disabled. In the future, it might make sense to\\nhave them appear with placeholder content of perhaps even an option to view the raw HTML in a popup UI."
+      children: "Note that the use of HtmlMesh requires that the experience be accessed through a browser, so in its\\ncurrent form, this will not work in native apps or in XR. If constructed outside of a browser context, the\\nHtmlMesh instances will not have any geometry and will be disabled. In the future, it might make sense to\\nhave them appear with placeholder content or perhaps even an option to view the raw HTML in a popup UI."
     }, undefined, false, {
       fileName: "<source.js>",
       lineNumber: 19,
       columnNumber: 1
     }, this), "\\n", _jsxDEV(_components.p, {
-      children: "HtmlMesh instances by default are \\"in scene\\" meaning that they can be occluded by objects in scene and may occlude objects in scene when they are between the camera and the object. In scene HtmlMesh instances require that the scene clear color is transparent, and they must be rectangular. HttmlMesh instances can also be created as \\"overlays\\". In this case, they render in front of the scene, can be semi-transparent, and can be non-rectangular. However, overlays will render in front of all scene content, even content that is between the mesh and the camera. Overlays are a good choice when you want an HTML overlay to be attached to an object in the scene, as it eliminates the need to handle the projection and transforming of the HTML element yourself."
+      children: "By default, HtmlMesh instances are \\"in scene,\\" meaning that they can be occluded by objects in the scene and may occlude objects in the scene when they are between the camera and the object. In-scene HtmlMesh instances require the scene clear color to be transparent, and they must be rectangular. HtmlMesh instances can also be created as \\"overlays.\\" In this case, they render in front of the scene, can be semi-transparent, and can be non-rectangular. However, overlays will render in front of all scene content, even content that is between the mesh and the camera. Overlays are a good choice when you want an HTML overlay to be attached to an object in the scene, as they eliminate the need to handle projection and transformation of the HTML element yourself."
     }, undefined, false, {
       fileName: "<source.js>",
       lineNumber: 24,
       columnNumber: 1
     }, this), "\\n", _jsxDEV(_components.p, {
-      children: ["By default the HtmlMesh will capture pointer events as soon as the pointer enters. This is to facilitate the user's ability to interact with the site content without requiring an extra click or some other gesture. Note that pointer capture won't occur when a camera zoom causes the pointer to be over the mesh. This is to allow zooming in and out of the scene without the mesh capturing the pointer and preventing zoom as soon as the pointer enters. This behavior can be disabled as described in the ", _jsxDEV(_components.a, {
+      children: ["By default, the HtmlMesh will capture pointer events as soon as the pointer enters. This is meant to make it easier for users to interact with site content without requiring an extra click or other gesture. Note that pointer capture won't occur when a camera zoom causes the pointer to be over the mesh. This allows users to zoom in and out of the scene without the mesh capturing the pointer and preventing zoom as soon as the pointer enters. This behavior can be disabled as described in the ", _jsxDEV(_components.a, {
         href: "#pointer-capture",
         children: "pointer capture"
       }, undefined, false, {
         fileName: "<source.js>",
         lineNumber: 26,
-        columnNumber: 501
-      }, this), " section below, in which case you will need to provide a mechanism to trigger poiitner capture and release in your code. Note that on Android devices, the pointer will be captured and the event dispatched to the underlying element on first touch. However, due to the way iOS manages tuch events, on iOS, the user will need to touch the mesh in order to capture pointer events before the events will be sent to the element. E.g. to play a YouTube video, 2 touches will be required."]
+        columnNumber: 495
+      }, this), " section below, in which case you will need to provide a mechanism to trigger pointer capture and release in your code. Note that on Android devices, the pointer will be captured and the event dispatched to the underlying element on first touch. However, due to the way iOS manages touch events, on iOS the user will need to touch the mesh to capture pointer events before the events will be sent to the element. For example, to play a YouTube video, two touches will be required."]
     }, undefined, true, {
       fileName: "<source.js>",
       lineNumber: 26,
@@ -4596,7 +4596,7 @@ function _createMdxContent(props) {
       lineNumber: 28,
       columnNumber: 1
     }, this), "\\n", _jsxDEV(_components.p, {
-      children: "HtmlMesh is available as an UMD NPM package"
+      children: "HtmlMesh is available as a UMD NPM package"
     }, undefined, false, {
       fileName: "<source.js>",
       lineNumber: 30,
@@ -4647,7 +4647,7 @@ function _createMdxContent(props) {
         fileName: "<source.js>",
         lineNumber: 43,
         columnNumber: 44
-      }, this), ". Pass this the scene, and optionally an options object containing:"]
+      }, this), ". Pass the scene, and optionally an options object containing:"]
     }, undefined, true, {
       fileName: "<source.js>",
       lineNumber: 43,
@@ -4809,49 +4809,49 @@ function _createMdxContent(props) {
       lineNumber: 45,
       columnNumber: 1
     }, this), "\\n", _jsxDEV(_components.p, {
-      children: ["Next, create the DOM element for your content. This can be any HTML element though most of the time, it should either be a ", _jsxDEV(_components.code, {
+      children: ["Next, create the DOM element for your content. This can be any HTML element, though most of the time it should either be a ", _jsxDEV(_components.code, {
         children: "div"
       }, undefined, false, {
         fileName: "<source.js>",
         lineNumber: 50,
         columnNumber: 124
-      }, this), " for DOM content in the same app, or an ", _jsxDEV(_components.code, {
+      }, this), " for DOM content in the same app or an ", _jsxDEV(_components.code, {
         children: "iframe"
       }, undefined, false, {
         fileName: "<source.js>",
         lineNumber: 50,
-        columnNumber: 169
-      }, this), " for external dom content. You should not add this element to your document; ", _jsxDEV(_components.code, {
+        columnNumber: 168
+      }, this), " for external DOM content. You should not add this element to your document; ", _jsxDEV(_components.code, {
         children: "HtmlMesh"
       }, undefined, false, {
         fileName: "<source.js>",
         lineNumber: 50,
-        columnNumber: 254
-      }, this), " will do this for you. Set any attribute and style values that you want; however, be advised that the width and height styles will be replaced by the ", _jsxDEV(_components.code, {
+        columnNumber: 253
+      }, this), " will do this for you. Set any attribute and style values that you want; however, be aware that the width and height styles will be replaced by the ", _jsxDEV(_components.code, {
         children: "HtmlMesh"
       }, undefined, false, {
         fileName: "<source.js>",
         lineNumber: 50,
-        columnNumber: 414
+        columnNumber: 411
       }, this), "."]
     }, undefined, true, {
       fileName: "<source.js>",
       lineNumber: 50,
       columnNumber: 1
     }, this), "\\n", _jsxDEV(_components.p, {
-      children: ["One thing to be aware of is that the way the scale is determined can sometimes result in the elment being larger than the mesh if the mesh has a substantal difference in the world min and max z values. If this is the case, you may want to wrap your element in an outer div that is a bit larger with a background color. This will ensure that any gaps between the mesh and the element are filled with the background color and the user can access the entire portion of the element that needs to be accessible. A future update may add suport for this to ", _jsxDEV(_components.code, {
+      children: ["One thing to be aware of is that the way the scale is determined can sometimes result in the element being larger than the mesh if the mesh has a substantial difference between its world min and max z values. If this is the case, you may want to wrap your element in an outer div that is slightly larger and has a background color. This will ensure that any gaps between the mesh and the element are filled with the background color, and the user can access the entire portion of the element that needs to be accessible. A future update may add support for this to ", _jsxDEV(_components.code, {
         children: "setContent"
       }, undefined, false, {
         fileName: "<source.js>",
         lineNumber: 52,
-        columnNumber: 551
+        columnNumber: 566
       }, this), "."]
     }, undefined, true, {
       fileName: "<source.js>",
       lineNumber: 52,
       columnNumber: 1
     }, this), "\\n", _jsxDEV(_components.p, {
-      children: "Create your HtmlMesh instance specifying the id, and an and optionally an options object containing:"
+      children: "Create your HtmlMesh instance by specifying the id and, optionally, an options object containing:"
     }, undefined, false, {
       fileName: "<source.js>",
       lineNumber: 54,
@@ -4865,7 +4865,7 @@ function _createMdxContent(props) {
             fileName: "<source.js>",
             lineNumber: 56,
             columnNumber: 3
-          }, this), " - Specifies if the HtmlMesh should capture pointer events whenever the pointer is over the mesh. Defauts to true. if false, you wil need to manually capture and release pointer events for the\\nHtmlMesh using the ", _jsxDEV(_components.code, {
+          }, this), " - Specifies whether the HtmlMesh should capture pointer events whenever the pointer is over the mesh. Defaults to true. If false, you will need to manually capture and release pointer events for the\\nHtmlMesh using the ", _jsxDEV(_components.code, {
             children: "capturePointerEvents"
           }, undefined, false, {
             fileName: "<source.js>",
@@ -4979,26 +4979,32 @@ function _createMdxContent(props) {
             fileName: "<source.js>",
             lineNumber: 72,
             columnNumber: 3
-          }, this), " - Specifies how the HTML element should scale to fit the HtmlMesh's size. Fit behavior is like css background-size"]
+          }, this), " - Specifies how the HTML element should scale to fit the HtmlMesh's size. Fit behavior is like CSS ", _jsxDEV(_components.code, {
+            children: "background-size"
+          }, undefined, false, {
+            fileName: "<source.js>",
+            lineNumber: 72,
+            columnNumber: 116
+          }, this), "."]
         }, undefined, true, {
           fileName: "<source.js>",
           lineNumber: 72,
           columnNumber: 3
         }, this), "\\n", _jsxDEV(_components.ul, {
           children: ["\\n", _jsxDEV(_components.li, {
-            children: ["FitStrategy.NONE Default. By default the HTML element will have a width and height that fill the viewport while respecting the aspect ratio of the element and then will be scaled down to fit the HtmlMesh size specified in ", _jsxDEV(_components.code, {
+            children: ["FitStrategy.NONE Default. By default, the HTML element will have a width and height that fill the viewport while respecting the aspect ratio of the element, and it will then be scaled down to fit the HtmlMesh size specified in ", _jsxDEV(_components.code, {
               children: "setContent"
             }, undefined, false, {
               fileName: "<source.js>",
               lineNumber: 73,
-              columnNumber: 227
-            }, this), ". This provides the best possible text quality when using iframes and is the reccommended strategy for iframes."]
+              columnNumber: 232
+            }, this), ". This provides the best possible text quality when using iframes and is the recommended strategy for iframes."]
           }, undefined, true, {
             fileName: "<source.js>",
             lineNumber: 73,
             columnNumber: 3
           }, this), "\\n", _jsxDEV(_components.li, {
-            children: "FitStrategy.CONTAIN Scales the HTML element as large as possible within its container without cropping or stretching (i.e. changing the element aspect ratio). The main difference between this and none is that this strategy (and all strategies other than none) will wrap the element with a sizing and scaling container that will fill the mesh. This allows the element to be sized and aligned independent of the mesh. The downside to this and all strategies other than none is that it can result in upscaling at some zooms which can impact text quality for iframes. For non-iframes, this should not be an issue as the font size can be asjusted to maximize text clarity."
+            children: "FitStrategy.CONTAIN Scales the HTML element as large as possible within its container without cropping or stretching (i.e. changing the element aspect ratio). The main difference between this and none is that this strategy (and all strategies other than none) will wrap the element with a sizing and scaling container that fills the mesh. This allows the element to be sized and aligned independently of the mesh. The downside to this and all strategies other than none is that it can result in upscaling at some zoom levels, which can impact text quality for iframes. For non-iframes, this should not be an issue because the font size can be adjusted to maximize text clarity."
           }, undefined, false, {
             fileName: "<source.js>",
             lineNumber: 74,
@@ -5037,24 +5043,24 @@ function _createMdxContent(props) {
         fileName: "<source.js>",
         lineNumber: 78,
         columnNumber: 15
-      }, this), " passing in the element and the mesh width and height in BabylonJS units. Be advised that any scaling done after ", _jsxDEV(_components.code, {
+      }, this), ", passing in the element and the mesh width and height in BabylonJS units. Be aware that any scaling done after ", _jsxDEV(_components.code, {
         children: "setContent"
       }, undefined, false, {
         fileName: "<source.js>",
         lineNumber: 78,
-        columnNumber: 140
+        columnNumber: 139
       }, this), " will not be preserved on the next call to ", _jsxDEV(_components.code, {
         children: "setContent"
       }, undefined, false, {
         fileName: "<source.js>",
         lineNumber: 78,
-        columnNumber: 195
-      }, this), ". You should grab any scaling you want preserved and pass the scale values through ", _jsxDEV(_components.code, {
+        columnNumber: 194
+      }, this), ". You should capture any scaling you want preserved and pass the scale values through ", _jsxDEV(_components.code, {
         children: "setContent"
       }, undefined, false, {
         fileName: "<source.js>",
         lineNumber: 78,
-        columnNumber: 290
+        columnNumber: 292
       }, this), ". See ", _jsxDEV(_components.a, {
         href: "#scaling-htmlmesh-instances",
         children: ["Scaling ", _jsxDEV(_components.code, {
@@ -5062,25 +5068,25 @@ function _createMdxContent(props) {
         }, undefined, false, {
           fileName: "<source.js>",
           lineNumber: 78,
-          columnNumber: 317
+          columnNumber: 319
         }, this), " Instances"]
       }, undefined, true, {
         fileName: "<source.js>",
         lineNumber: 78,
-        columnNumber: 308
-      }, this), " for an expalantion on why this is the case. You can set attributes and styles after calling ", _jsxDEV(_components.code, {
+        columnNumber: 310
+      }, this), " for an explanation of why this is the case. You can set attributes and styles after calling ", _jsxDEV(_components.code, {
         children: "setContent"
       }, undefined, false, {
         fileName: "<source.js>",
         lineNumber: 78,
-        columnNumber: 460
+        columnNumber: 462
       }, this), " using a query selector on the id. The ", _jsxDEV(_components.code, {
         children: "HtmlMesh"
       }, undefined, false, {
         fileName: "<source.js>",
         lineNumber: 78,
-        columnNumber: 511
-      }, this), " can be positioned, oriented, parented, shown or hidden like any other mesh. You can even use pointer drag behavior and gizmos to allow users to position and move the mesh, subject to the caveats of scaling below."]
+        columnNumber: 513
+      }, this), " can be positioned, oriented, parented, shown, or hidden like any other mesh. You can even use pointer drag behavior and gizmos to allow users to position and move the mesh, subject to the caveats about scaling below."]
     }, undefined, true, {
       fileName: "<source.js>",
       lineNumber: 78,
@@ -5112,19 +5118,25 @@ function _createMdxContent(props) {
       lineNumber: 266,
       columnNumber: 1
     }, this), "\\n", _jsxDEV(_components.p, {
-      children: ["In order to keep the dom content and mesh size synched, the dom content size will be adjusted avery frame using CSS transforms to match the mesh. This means that if the mesh is scaled (using, say, a bounding box gizmo) the content will be scaled as well. Since the content is set after the mesh is created, the mesh initially starts as a place of size 1. Once the content is set, we need to scale the mesh to match. We can't just scale the mesh, because that would then scale the content. So we compute a scaling transform, and we bake it into the mesh vertices, effectively rewriting the mesh size. We also store an inverse scale matrix that can back out the scale. The next time ", _jsxDEV(_components.code, {
+      children: ["In order to keep the DOM content and mesh size synced, the DOM content size will be adjusted every frame using CSS transforms to match the mesh. This means that if the mesh is scaled (using, say, a bounding box gizmo), the content will be scaled as well. Since the content is set after the mesh is created, the mesh initially starts as a plane of size 1. Once the content is set, we need to scale the mesh to match. We can't just scale the mesh, because that would then scale the content. So we compute a scaling transform and bake it into the mesh vertices, effectively rewriting the mesh size. We also store an inverse scale matrix that can reverse the scale. The next time ", _jsxDEV(_components.code, {
         children: "setContent"
       }, undefined, false, {
         fileName: "<source.js>",
         lineNumber: 268,
-        columnNumber: 682
-      }, this), " is called, we will back the scale out to bring the mesh back to 1 and then compute a new scale transform (and inverse) and bake it into the mesh vertices. The consequence of this is that any scaling applied (via, say, the bounding box gizmo) will be reverted on the next call to ", _jsxDEV(_components.code, {
+        columnNumber: 677
+      }, this), " is called, we will reverse the scale to bring the mesh back to 1 and then compute a new scale transform (and inverse) and bake it into the mesh vertices. The consequence of this is that any scaling applied (via, say, the bounding box gizmo) will be reverted on the next call to ", _jsxDEV(_components.code, {
         children: "setContent"
       }, undefined, false, {
         fileName: "<source.js>",
         lineNumber: 268,
-        columnNumber: 974
-      }, this), ". So if you are storing info to recreate HtmlMesh instances on a server, you will want to make sure that you update the original size with any scaling changes so the next time you call setContent, they will be preserved."]
+        columnNumber: 968
+      }, this), ". So if you are storing information to recreate HtmlMesh instances on a server, you will want to make sure that you update the original size with any scaling changes so that the next time you call ", _jsxDEV(_components.code, {
+        children: "setContent"
+      }, undefined, false, {
+        fileName: "<source.js>",
+        lineNumber: 268,
+        columnNumber: 1177
+      }, this), ", they will be preserved."]
     }, undefined, true, {
       fileName: "<source.js>",
       lineNumber: 268,
@@ -5150,7 +5162,7 @@ function _createMdxContent(props) {
       lineNumber: 274,
       columnNumber: 1
     }, this), "\\n", _jsxDEV(_components.p, {
-      children: "An HtmlMesh instance can be configured to automatically capture the pointer on entry. This allows for \\"one-click\\" behavior where the user can interact directly with the content. For example, the user can click the play button directly on a YouTube video. Iframes are problematic, however; because we cannot detect pointer movement within a cross-origin iframe (an iframe that originates from a different site than the one that is hosting it). Simply put, we can capture the pointer, but releasing it requires that the pointer leaves the iframe completely. This requirement means that we cannot detect when the pointer is over a mesh that is in front of the HtmlMesh containing the iframe; only when the pointer has fully left the iframe will the pointer be detected. In practice, since BabylonJS relies on pointer events on the canvas, this means that no actions, pointer obeservables, or scene picking will work correctly if the pointer entered the iframe first until the pointer has left the iframe. Therefore, if you have mesh content that needs to be pickable (respond in some way to pointer events) that could potentially be in front of an HtmlMesh containing an iframe (either due to camera orientation of movement of the either mesh), we recommend one of the following:"
+      children: "An HtmlMesh instance can be configured to automatically capture the pointer on entry. This allows for \\"one-click\\" behavior where the user can interact directly with the content. For example, the user can click the play button directly on a YouTube video. Iframes are problematic, however, because we cannot detect pointer movement within a cross-origin iframe (an iframe that originates from a different site than the one hosting it). Simply put, we can capture the pointer, but releasing it requires the pointer to leave the iframe completely. This requirement means that we cannot detect when the pointer is over a mesh that is in front of the HtmlMesh containing the iframe; only when the pointer has fully left the iframe will the pointer be detected. In practice, since BabylonJS relies on pointer events on the canvas, this means that no actions, pointer observables, or scene picking will work correctly if the pointer entered the iframe first, until the pointer has left the iframe. Therefore, if you have mesh content that needs to be pickable (respond in some way to pointer events) and could potentially be in front of an HtmlMesh containing an iframe (either due to camera orientation or movement of either mesh), we recommend one of the following:"
     }, undefined, false, {
       fileName: "<source.js>",
       lineNumber: 276,
@@ -5187,7 +5199,7 @@ function _createMdxContent(props) {
           fileName: "<source.js>",
           lineNumber: 279,
           columnNumber: 294
-        }, this), ". This can be done in response to whatever gesture seems appropriate such as clicking of double clicking the HtmlMesh."]
+        }, this), ". This can be done in response to whatever gesture seems appropriate, such as clicking or double-clicking the HtmlMesh."]
       }, undefined, true, {
         fileName: "<source.js>",
         lineNumber: 279,
@@ -5211,7 +5223,7 @@ function _createMdxContent(props) {
       lineNumber: 283,
       columnNumber: 1
     }, this), "\\n", _jsxDEV(_components.p, {
-      children: "The HtmlMesh takes measures to provide the best possible text quality. Specifically, it makes the content as large as possible to fit within the screen and then scales it down to fit the mesh at the current zoom, and it turns off backface rendering for the HtmlContent (which can cause some aliasing). However, the biggest contributor to poor text quality when using CSS transfroms is subpixel rendering. This occurs when the content is sized and positioned over a partial pixel. When rendering normally, this is avoided by always choosing even numbers of pixels for the size of the content and always making sure that any positioning attributes (such as top, left, padding, etc...) are whole pixel values. Unfortunately, when using CSS transforms, as soon as perspective is added (even if the camera is not rotated), the transform could result in subpixel rendering. Once rotation is allowed it is gauranteed that subpixel rendering will occur at some point. This effect can be noticed when viewing the example as soon as the camera moves off of a +z orientation as the shimmering of the text in the PDF and the BJS site. The effect is much less pronounced with larger text sizes."
+      children: "The HtmlMesh takes measures to provide the best possible text quality. Specifically, it makes the content as large as possible to fit within the screen and then scales it down to fit the mesh at the current zoom, and it turns off backface rendering for the HtmlContent (which can cause some aliasing). However, the biggest contributor to poor text quality when using CSS transforms is subpixel rendering. This occurs when the content is sized and positioned over a partial pixel. When rendering normally, this is avoided by always choosing even numbers of pixels for the size of the content and always making sure that any positioning attributes (such as top, left, padding, etc.) are whole-pixel values. Unfortunately, when using CSS transforms, as soon as perspective is added (even if the camera is not rotated), the transform could result in subpixel rendering. Once rotation is allowed, it is guaranteed that subpixel rendering will occur at some point. This effect can be noticed when viewing the example as soon as the camera moves off a +z orientation, as shown by the shimmering text in the PDF and the BJS site. The effect is much less pronounced with larger text sizes."
     }, undefined, false, {
       fileName: "<source.js>",
       lineNumber: 285,
@@ -5224,7 +5236,7 @@ function _createMdxContent(props) {
       lineNumber: 287,
       columnNumber: 1
     }, this), "\\n", _jsxDEV(_components.p, {
-      children: "PDFs can be displayed in scene using HtmlMesh. Aside from the text quality issue noted above, PDFs with embedded links will navigate the current tab/window when one of the links is selected. Sandboxing the iframe can prevent sites from navigating the current tab/window, but on Chrome sandboxed iframes cannot load PDFs."
+      children: "PDFs can be displayed in a scene using HtmlMesh. Aside from the text quality issue noted above, PDFs with embedded links will navigate the current tab/window when one of the links is selected. Sandboxing the iframe can prevent sites from navigating the current tab/window, but on Chrome, sandboxed iframes cannot load PDFs."
     }, undefined, false, {
       fileName: "<source.js>",
       lineNumber: 289,
@@ -5263,7 +5275,7 @@ function _missingMdxReference(id, component, place) {
 
 exports[`Real Content File Regression > should serialize content/addons/htmlMesh.md correctly > frontmatter 1`] = `
 {
-  "description": "The HTML Mesh is a mesh that displays a webpage (or DOM element) in the scene, meaning that it can occlude other meshes and be occluded by other meshs.",
+  "description": "The HTML Mesh is a mesh that displays a webpage (or DOM element) in the scene, meaning that it can occlude other meshes and be occluded by other meshes.",
   "further-reading": null,
   "image": "public/img/playgroundsAndNMEs/htmlMeshPG.webp",
   "title": "HtmlMesh",
@@ -5358,7 +5370,7 @@ function _createMdxContent(props) {
       lineNumber: 2,
       columnNumber: 1
     }, this), "\\n", _jsxDEV(_components.p, {
-      children: "This section provides support about the workflow required to create a 3D web app from getting started, by downloading a complete webpage from a simple playground, to building a large application, using an IDE and other developmental frameworks and packages."
+      children: "This section provides guidance on the workflow required to create a 3D web app, from getting started by downloading a complete webpage from a simple playground to building a large application using an IDE and other development frameworks and packages."
     }, undefined, false, {
       fileName: "<source.js>",
       lineNumber: 3,
@@ -5394,7 +5406,7 @@ return {
 
 exports[`Real Content File Regression > should serialize content/setup.md correctly > frontmatter 1`] = `
 {
-  "description": "The workflow from simple webpage to complete app with IDE and developmental frameworks.",
+  "description": "The workflow from a simple webpage to a complete app with an IDE and development frameworks.",
   "further-reading": null,
   "image": null,
   "keywords": "workflow, babylon.js",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1234,7 +1234,6 @@
             "cpu": [
                 "arm64"
             ],
-            "dev": true,
             "license": "Apache-2.0",
             "optional": true,
             "os": [
@@ -1257,7 +1256,6 @@
             "cpu": [
                 "x64"
             ],
-            "dev": true,
             "license": "Apache-2.0",
             "optional": true,
             "os": [
@@ -1277,7 +1275,6 @@
             "version": "0.35.3",
             "resolved": "https://registry.npmjs.org/@img/sharp-freebsd-wasm32/-/sharp-freebsd-wasm32-0.35.3.tgz",
             "integrity": "sha512-lUxcqWIj2wMQ9BrwNjngcr1gWUr5xgaGThBRqPPalIC2n67Cqj1uPh8NnA/ZhAg8hUbKl+kVHKwgUIwe6ZYPrg==",
-            "dev": true,
             "license": "Apache-2.0",
             "optional": true,
             "os": [
@@ -1300,7 +1297,6 @@
             "cpu": [
                 "arm64"
             ],
-            "dev": true,
             "license": "LGPL-3.0-or-later",
             "optional": true,
             "os": [
@@ -1317,7 +1313,6 @@
             "cpu": [
                 "x64"
             ],
-            "dev": true,
             "license": "LGPL-3.0-or-later",
             "optional": true,
             "os": [
@@ -1334,7 +1329,6 @@
             "cpu": [
                 "arm"
             ],
-            "dev": true,
             "license": "LGPL-3.0-or-later",
             "optional": true,
             "os": [
@@ -1351,7 +1345,6 @@
             "cpu": [
                 "arm64"
             ],
-            "dev": true,
             "license": "LGPL-3.0-or-later",
             "optional": true,
             "os": [
@@ -1368,7 +1361,6 @@
             "cpu": [
                 "ppc64"
             ],
-            "dev": true,
             "license": "LGPL-3.0-or-later",
             "optional": true,
             "os": [
@@ -1385,7 +1377,6 @@
             "cpu": [
                 "riscv64"
             ],
-            "dev": true,
             "license": "LGPL-3.0-or-later",
             "optional": true,
             "os": [
@@ -1402,7 +1393,6 @@
             "cpu": [
                 "s390x"
             ],
-            "dev": true,
             "license": "LGPL-3.0-or-later",
             "optional": true,
             "os": [
@@ -1419,7 +1409,6 @@
             "cpu": [
                 "x64"
             ],
-            "dev": true,
             "license": "LGPL-3.0-or-later",
             "optional": true,
             "os": [
@@ -1436,7 +1425,6 @@
             "cpu": [
                 "arm64"
             ],
-            "dev": true,
             "license": "LGPL-3.0-or-later",
             "optional": true,
             "os": [
@@ -1453,7 +1441,6 @@
             "cpu": [
                 "x64"
             ],
-            "dev": true,
             "license": "LGPL-3.0-or-later",
             "optional": true,
             "os": [
@@ -1470,7 +1457,6 @@
             "cpu": [
                 "arm"
             ],
-            "dev": true,
             "license": "Apache-2.0",
             "optional": true,
             "os": [
@@ -1493,7 +1479,6 @@
             "cpu": [
                 "arm64"
             ],
-            "dev": true,
             "license": "Apache-2.0",
             "optional": true,
             "os": [
@@ -1516,7 +1501,6 @@
             "cpu": [
                 "ppc64"
             ],
-            "dev": true,
             "license": "Apache-2.0",
             "optional": true,
             "os": [
@@ -1539,7 +1523,6 @@
             "cpu": [
                 "riscv64"
             ],
-            "dev": true,
             "license": "Apache-2.0",
             "optional": true,
             "os": [
@@ -1562,7 +1545,6 @@
             "cpu": [
                 "s390x"
             ],
-            "dev": true,
             "license": "Apache-2.0",
             "optional": true,
             "os": [
@@ -1585,7 +1567,6 @@
             "cpu": [
                 "x64"
             ],
-            "dev": true,
             "license": "Apache-2.0",
             "optional": true,
             "os": [
@@ -1608,7 +1589,6 @@
             "cpu": [
                 "arm64"
             ],
-            "dev": true,
             "license": "Apache-2.0",
             "optional": true,
             "os": [
@@ -1631,7 +1611,6 @@
             "cpu": [
                 "x64"
             ],
-            "dev": true,
             "license": "Apache-2.0",
             "optional": true,
             "os": [
@@ -1651,7 +1630,6 @@
             "version": "0.35.3",
             "resolved": "https://registry.npmjs.org/@img/sharp-wasm32/-/sharp-wasm32-0.35.3.tgz",
             "integrity": "sha512-cZ0XkcYGpHZkqW6iCkqTcmUC0CD9DhD5d/qeZlZkfRBn6GnHniZXLUo5+9xw8Iv76YE6LQFN9YNBlKREcCG76w==",
-            "dev": true,
             "license": "Apache-2.0 AND LGPL-3.0-or-later AND MIT",
             "optional": true,
             "dependencies": {
@@ -1671,7 +1649,6 @@
             "cpu": [
                 "wasm32"
             ],
-            "dev": true,
             "license": "Apache-2.0",
             "optional": true,
             "dependencies": {
@@ -1691,7 +1668,6 @@
             "cpu": [
                 "arm64"
             ],
-            "dev": true,
             "license": "Apache-2.0 AND LGPL-3.0-or-later",
             "optional": true,
             "os": [
@@ -1711,7 +1687,6 @@
             "cpu": [
                 "ia32"
             ],
-            "dev": true,
             "license": "Apache-2.0 AND LGPL-3.0-or-later",
             "optional": true,
             "os": [
@@ -1731,7 +1706,6 @@
             "cpu": [
                 "x64"
             ],
-            "dev": true,
             "license": "Apache-2.0 AND LGPL-3.0-or-later",
             "optional": true,
             "os": [
@@ -10696,520 +10670,6 @@
                 "next": ">=10"
             }
         },
-        "node_modules/next/node_modules/@img/sharp-darwin-arm64": {
-            "version": "0.34.5",
-            "resolved": "https://registry.npmjs.org/@img/sharp-darwin-arm64/-/sharp-darwin-arm64-0.34.5.tgz",
-            "integrity": "sha512-imtQ3WMJXbMY4fxb/Ndp6HBTNVtWCUI0WdobyheGf5+ad6xX8VIDO8u2xE4qc/fr08CKG/7dDseFtn6M6g/r3w==",
-            "cpu": [
-                "arm64"
-            ],
-            "license": "Apache-2.0",
-            "optional": true,
-            "os": [
-                "darwin"
-            ],
-            "engines": {
-                "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
-            },
-            "funding": {
-                "url": "https://opencollective.com/libvips"
-            },
-            "optionalDependencies": {
-                "@img/sharp-libvips-darwin-arm64": "1.2.4"
-            }
-        },
-        "node_modules/next/node_modules/@img/sharp-darwin-x64": {
-            "version": "0.34.5",
-            "resolved": "https://registry.npmjs.org/@img/sharp-darwin-x64/-/sharp-darwin-x64-0.34.5.tgz",
-            "integrity": "sha512-YNEFAF/4KQ/PeW0N+r+aVVsoIY0/qxxikF2SWdp+NRkmMB7y9LBZAVqQ4yhGCm/H3H270OSykqmQMKLBhBJDEw==",
-            "cpu": [
-                "x64"
-            ],
-            "license": "Apache-2.0",
-            "optional": true,
-            "os": [
-                "darwin"
-            ],
-            "engines": {
-                "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
-            },
-            "funding": {
-                "url": "https://opencollective.com/libvips"
-            },
-            "optionalDependencies": {
-                "@img/sharp-libvips-darwin-x64": "1.2.4"
-            }
-        },
-        "node_modules/next/node_modules/@img/sharp-libvips-darwin-arm64": {
-            "version": "1.2.4",
-            "resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-arm64/-/sharp-libvips-darwin-arm64-1.2.4.tgz",
-            "integrity": "sha512-zqjjo7RatFfFoP0MkQ51jfuFZBnVE2pRiaydKJ1G/rHZvnsrHAOcQALIi9sA5co5xenQdTugCvtb1cuf78Vf4g==",
-            "cpu": [
-                "arm64"
-            ],
-            "license": "LGPL-3.0-or-later",
-            "optional": true,
-            "os": [
-                "darwin"
-            ],
-            "funding": {
-                "url": "https://opencollective.com/libvips"
-            }
-        },
-        "node_modules/next/node_modules/@img/sharp-libvips-darwin-x64": {
-            "version": "1.2.4",
-            "resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-x64/-/sharp-libvips-darwin-x64-1.2.4.tgz",
-            "integrity": "sha512-1IOd5xfVhlGwX+zXv2N93k0yMONvUlANylbJw1eTah8K/Jtpi15KC+WSiaX/nBmbm2HxRM1gZ0nSdjSsrZbGKg==",
-            "cpu": [
-                "x64"
-            ],
-            "license": "LGPL-3.0-or-later",
-            "optional": true,
-            "os": [
-                "darwin"
-            ],
-            "funding": {
-                "url": "https://opencollective.com/libvips"
-            }
-        },
-        "node_modules/next/node_modules/@img/sharp-libvips-linux-arm": {
-            "version": "1.2.4",
-            "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm/-/sharp-libvips-linux-arm-1.2.4.tgz",
-            "integrity": "sha512-bFI7xcKFELdiNCVov8e44Ia4u2byA+l3XtsAj+Q8tfCwO6BQ8iDojYdvoPMqsKDkuoOo+X6HZA0s0q11ANMQ8A==",
-            "cpu": [
-                "arm"
-            ],
-            "license": "LGPL-3.0-or-later",
-            "optional": true,
-            "os": [
-                "linux"
-            ],
-            "funding": {
-                "url": "https://opencollective.com/libvips"
-            }
-        },
-        "node_modules/next/node_modules/@img/sharp-libvips-linux-arm64": {
-            "version": "1.2.4",
-            "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm64/-/sharp-libvips-linux-arm64-1.2.4.tgz",
-            "integrity": "sha512-excjX8DfsIcJ10x1Kzr4RcWe1edC9PquDRRPx3YVCvQv+U5p7Yin2s32ftzikXojb1PIFc/9Mt28/y+iRklkrw==",
-            "cpu": [
-                "arm64"
-            ],
-            "license": "LGPL-3.0-or-later",
-            "optional": true,
-            "os": [
-                "linux"
-            ],
-            "funding": {
-                "url": "https://opencollective.com/libvips"
-            }
-        },
-        "node_modules/next/node_modules/@img/sharp-libvips-linux-ppc64": {
-            "version": "1.2.4",
-            "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-ppc64/-/sharp-libvips-linux-ppc64-1.2.4.tgz",
-            "integrity": "sha512-FMuvGijLDYG6lW+b/UvyilUWu5Ayu+3r2d1S8notiGCIyYU/76eig1UfMmkZ7vwgOrzKzlQbFSuQfgm7GYUPpA==",
-            "cpu": [
-                "ppc64"
-            ],
-            "license": "LGPL-3.0-or-later",
-            "optional": true,
-            "os": [
-                "linux"
-            ],
-            "funding": {
-                "url": "https://opencollective.com/libvips"
-            }
-        },
-        "node_modules/next/node_modules/@img/sharp-libvips-linux-riscv64": {
-            "version": "1.2.4",
-            "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-riscv64/-/sharp-libvips-linux-riscv64-1.2.4.tgz",
-            "integrity": "sha512-oVDbcR4zUC0ce82teubSm+x6ETixtKZBh/qbREIOcI3cULzDyb18Sr/Wcyx7NRQeQzOiHTNbZFF1UwPS2scyGA==",
-            "cpu": [
-                "riscv64"
-            ],
-            "license": "LGPL-3.0-or-later",
-            "optional": true,
-            "os": [
-                "linux"
-            ],
-            "funding": {
-                "url": "https://opencollective.com/libvips"
-            }
-        },
-        "node_modules/next/node_modules/@img/sharp-libvips-linux-s390x": {
-            "version": "1.2.4",
-            "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-s390x/-/sharp-libvips-linux-s390x-1.2.4.tgz",
-            "integrity": "sha512-qmp9VrzgPgMoGZyPvrQHqk02uyjA0/QrTO26Tqk6l4ZV0MPWIW6LTkqOIov+J1yEu7MbFQaDpwdwJKhbJvuRxQ==",
-            "cpu": [
-                "s390x"
-            ],
-            "license": "LGPL-3.0-or-later",
-            "optional": true,
-            "os": [
-                "linux"
-            ],
-            "funding": {
-                "url": "https://opencollective.com/libvips"
-            }
-        },
-        "node_modules/next/node_modules/@img/sharp-libvips-linux-x64": {
-            "version": "1.2.4",
-            "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-x64/-/sharp-libvips-linux-x64-1.2.4.tgz",
-            "integrity": "sha512-tJxiiLsmHc9Ax1bz3oaOYBURTXGIRDODBqhveVHonrHJ9/+k89qbLl0bcJns+e4t4rvaNBxaEZsFtSfAdquPrw==",
-            "cpu": [
-                "x64"
-            ],
-            "license": "LGPL-3.0-or-later",
-            "optional": true,
-            "os": [
-                "linux"
-            ],
-            "funding": {
-                "url": "https://opencollective.com/libvips"
-            }
-        },
-        "node_modules/next/node_modules/@img/sharp-libvips-linuxmusl-arm64": {
-            "version": "1.2.4",
-            "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-arm64/-/sharp-libvips-linuxmusl-arm64-1.2.4.tgz",
-            "integrity": "sha512-FVQHuwx1IIuNow9QAbYUzJ+En8KcVm9Lk5+uGUQJHaZmMECZmOlix9HnH7n1TRkXMS0pGxIJokIVB9SuqZGGXw==",
-            "cpu": [
-                "arm64"
-            ],
-            "license": "LGPL-3.0-or-later",
-            "optional": true,
-            "os": [
-                "linux"
-            ],
-            "funding": {
-                "url": "https://opencollective.com/libvips"
-            }
-        },
-        "node_modules/next/node_modules/@img/sharp-libvips-linuxmusl-x64": {
-            "version": "1.2.4",
-            "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-x64/-/sharp-libvips-linuxmusl-x64-1.2.4.tgz",
-            "integrity": "sha512-+LpyBk7L44ZIXwz/VYfglaX/okxezESc6UxDSoyo2Ks6Jxc4Y7sGjpgU9s4PMgqgjj1gZCylTieNamqA1MF7Dg==",
-            "cpu": [
-                "x64"
-            ],
-            "license": "LGPL-3.0-or-later",
-            "optional": true,
-            "os": [
-                "linux"
-            ],
-            "funding": {
-                "url": "https://opencollective.com/libvips"
-            }
-        },
-        "node_modules/next/node_modules/@img/sharp-linux-arm": {
-            "version": "0.34.5",
-            "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm/-/sharp-linux-arm-0.34.5.tgz",
-            "integrity": "sha512-9dLqsvwtg1uuXBGZKsxem9595+ujv0sJ6Vi8wcTANSFpwV/GONat5eCkzQo/1O6zRIkh0m/8+5BjrRr7jDUSZw==",
-            "cpu": [
-                "arm"
-            ],
-            "license": "Apache-2.0",
-            "optional": true,
-            "os": [
-                "linux"
-            ],
-            "engines": {
-                "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
-            },
-            "funding": {
-                "url": "https://opencollective.com/libvips"
-            },
-            "optionalDependencies": {
-                "@img/sharp-libvips-linux-arm": "1.2.4"
-            }
-        },
-        "node_modules/next/node_modules/@img/sharp-linux-arm64": {
-            "version": "0.34.5",
-            "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm64/-/sharp-linux-arm64-0.34.5.tgz",
-            "integrity": "sha512-bKQzaJRY/bkPOXyKx5EVup7qkaojECG6NLYswgktOZjaXecSAeCWiZwwiFf3/Y+O1HrauiE3FVsGxFg8c24rZg==",
-            "cpu": [
-                "arm64"
-            ],
-            "license": "Apache-2.0",
-            "optional": true,
-            "os": [
-                "linux"
-            ],
-            "engines": {
-                "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
-            },
-            "funding": {
-                "url": "https://opencollective.com/libvips"
-            },
-            "optionalDependencies": {
-                "@img/sharp-libvips-linux-arm64": "1.2.4"
-            }
-        },
-        "node_modules/next/node_modules/@img/sharp-linux-ppc64": {
-            "version": "0.34.5",
-            "resolved": "https://registry.npmjs.org/@img/sharp-linux-ppc64/-/sharp-linux-ppc64-0.34.5.tgz",
-            "integrity": "sha512-7zznwNaqW6YtsfrGGDA6BRkISKAAE1Jo0QdpNYXNMHu2+0dTrPflTLNkpc8l7MUP5M16ZJcUvysVWWrMefZquA==",
-            "cpu": [
-                "ppc64"
-            ],
-            "license": "Apache-2.0",
-            "optional": true,
-            "os": [
-                "linux"
-            ],
-            "engines": {
-                "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
-            },
-            "funding": {
-                "url": "https://opencollective.com/libvips"
-            },
-            "optionalDependencies": {
-                "@img/sharp-libvips-linux-ppc64": "1.2.4"
-            }
-        },
-        "node_modules/next/node_modules/@img/sharp-linux-riscv64": {
-            "version": "0.34.5",
-            "resolved": "https://registry.npmjs.org/@img/sharp-linux-riscv64/-/sharp-linux-riscv64-0.34.5.tgz",
-            "integrity": "sha512-51gJuLPTKa7piYPaVs8GmByo7/U7/7TZOq+cnXJIHZKavIRHAP77e3N2HEl3dgiqdD/w0yUfiJnII77PuDDFdw==",
-            "cpu": [
-                "riscv64"
-            ],
-            "license": "Apache-2.0",
-            "optional": true,
-            "os": [
-                "linux"
-            ],
-            "engines": {
-                "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
-            },
-            "funding": {
-                "url": "https://opencollective.com/libvips"
-            },
-            "optionalDependencies": {
-                "@img/sharp-libvips-linux-riscv64": "1.2.4"
-            }
-        },
-        "node_modules/next/node_modules/@img/sharp-linux-s390x": {
-            "version": "0.34.5",
-            "resolved": "https://registry.npmjs.org/@img/sharp-linux-s390x/-/sharp-linux-s390x-0.34.5.tgz",
-            "integrity": "sha512-nQtCk0PdKfho3eC5MrbQoigJ2gd1CgddUMkabUj+rBevs8tZ2cULOx46E7oyX+04WGfABgIwmMC0VqieTiR4jg==",
-            "cpu": [
-                "s390x"
-            ],
-            "license": "Apache-2.0",
-            "optional": true,
-            "os": [
-                "linux"
-            ],
-            "engines": {
-                "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
-            },
-            "funding": {
-                "url": "https://opencollective.com/libvips"
-            },
-            "optionalDependencies": {
-                "@img/sharp-libvips-linux-s390x": "1.2.4"
-            }
-        },
-        "node_modules/next/node_modules/@img/sharp-linux-x64": {
-            "version": "0.34.5",
-            "resolved": "https://registry.npmjs.org/@img/sharp-linux-x64/-/sharp-linux-x64-0.34.5.tgz",
-            "integrity": "sha512-MEzd8HPKxVxVenwAa+JRPwEC7QFjoPWuS5NZnBt6B3pu7EG2Ge0id1oLHZpPJdn3OQK+BQDiw9zStiHBTJQQQQ==",
-            "cpu": [
-                "x64"
-            ],
-            "license": "Apache-2.0",
-            "optional": true,
-            "os": [
-                "linux"
-            ],
-            "engines": {
-                "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
-            },
-            "funding": {
-                "url": "https://opencollective.com/libvips"
-            },
-            "optionalDependencies": {
-                "@img/sharp-libvips-linux-x64": "1.2.4"
-            }
-        },
-        "node_modules/next/node_modules/@img/sharp-linuxmusl-arm64": {
-            "version": "0.34.5",
-            "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-arm64/-/sharp-linuxmusl-arm64-0.34.5.tgz",
-            "integrity": "sha512-fprJR6GtRsMt6Kyfq44IsChVZeGN97gTD331weR1ex1c1rypDEABN6Tm2xa1wE6lYb5DdEnk03NZPqA7Id21yg==",
-            "cpu": [
-                "arm64"
-            ],
-            "license": "Apache-2.0",
-            "optional": true,
-            "os": [
-                "linux"
-            ],
-            "engines": {
-                "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
-            },
-            "funding": {
-                "url": "https://opencollective.com/libvips"
-            },
-            "optionalDependencies": {
-                "@img/sharp-libvips-linuxmusl-arm64": "1.2.4"
-            }
-        },
-        "node_modules/next/node_modules/@img/sharp-linuxmusl-x64": {
-            "version": "0.34.5",
-            "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-x64/-/sharp-linuxmusl-x64-0.34.5.tgz",
-            "integrity": "sha512-Jg8wNT1MUzIvhBFxViqrEhWDGzqymo3sV7z7ZsaWbZNDLXRJZoRGrjulp60YYtV4wfY8VIKcWidjojlLcWrd8Q==",
-            "cpu": [
-                "x64"
-            ],
-            "license": "Apache-2.0",
-            "optional": true,
-            "os": [
-                "linux"
-            ],
-            "engines": {
-                "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
-            },
-            "funding": {
-                "url": "https://opencollective.com/libvips"
-            },
-            "optionalDependencies": {
-                "@img/sharp-libvips-linuxmusl-x64": "1.2.4"
-            }
-        },
-        "node_modules/next/node_modules/@img/sharp-wasm32": {
-            "version": "0.34.5",
-            "resolved": "https://registry.npmjs.org/@img/sharp-wasm32/-/sharp-wasm32-0.34.5.tgz",
-            "integrity": "sha512-OdWTEiVkY2PHwqkbBI8frFxQQFekHaSSkUIJkwzclWZe64O1X4UlUjqqqLaPbUpMOQk6FBu/HtlGXNblIs0huw==",
-            "cpu": [
-                "wasm32"
-            ],
-            "license": "Apache-2.0 AND LGPL-3.0-or-later AND MIT",
-            "optional": true,
-            "dependencies": {
-                "@emnapi/runtime": "^1.7.0"
-            },
-            "engines": {
-                "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
-            },
-            "funding": {
-                "url": "https://opencollective.com/libvips"
-            }
-        },
-        "node_modules/next/node_modules/@img/sharp-win32-arm64": {
-            "version": "0.34.5",
-            "resolved": "https://registry.npmjs.org/@img/sharp-win32-arm64/-/sharp-win32-arm64-0.34.5.tgz",
-            "integrity": "sha512-WQ3AgWCWYSb2yt+IG8mnC6Jdk9Whs7O0gxphblsLvdhSpSTtmu69ZG1Gkb6NuvxsNACwiPV6cNSZNzt0KPsw7g==",
-            "cpu": [
-                "arm64"
-            ],
-            "license": "Apache-2.0 AND LGPL-3.0-or-later",
-            "optional": true,
-            "os": [
-                "win32"
-            ],
-            "engines": {
-                "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
-            },
-            "funding": {
-                "url": "https://opencollective.com/libvips"
-            }
-        },
-        "node_modules/next/node_modules/@img/sharp-win32-ia32": {
-            "version": "0.34.5",
-            "resolved": "https://registry.npmjs.org/@img/sharp-win32-ia32/-/sharp-win32-ia32-0.34.5.tgz",
-            "integrity": "sha512-FV9m/7NmeCmSHDD5j4+4pNI8Cp3aW+JvLoXcTUo0IqyjSfAZJ8dIUmijx1qaJsIiU+Hosw6xM5KijAWRJCSgNg==",
-            "cpu": [
-                "ia32"
-            ],
-            "license": "Apache-2.0 AND LGPL-3.0-or-later",
-            "optional": true,
-            "os": [
-                "win32"
-            ],
-            "engines": {
-                "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
-            },
-            "funding": {
-                "url": "https://opencollective.com/libvips"
-            }
-        },
-        "node_modules/next/node_modules/@img/sharp-win32-x64": {
-            "version": "0.34.5",
-            "resolved": "https://registry.npmjs.org/@img/sharp-win32-x64/-/sharp-win32-x64-0.34.5.tgz",
-            "integrity": "sha512-+29YMsqY2/9eFEiW93eqWnuLcWcufowXewwSNIT6UwZdUUCrM3oFjMWH/Z6/TMmb4hlFenmfAVbpWeup2jryCw==",
-            "cpu": [
-                "x64"
-            ],
-            "license": "Apache-2.0 AND LGPL-3.0-or-later",
-            "optional": true,
-            "os": [
-                "win32"
-            ],
-            "engines": {
-                "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
-            },
-            "funding": {
-                "url": "https://opencollective.com/libvips"
-            }
-        },
-        "node_modules/next/node_modules/semver": {
-            "version": "7.8.5",
-            "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
-            "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
-            "license": "ISC",
-            "optional": true,
-            "bin": {
-                "semver": "bin/semver.js"
-            },
-            "engines": {
-                "node": ">=10"
-            }
-        },
-        "node_modules/next/node_modules/sharp": {
-            "version": "0.34.5",
-            "resolved": "https://registry.npmjs.org/sharp/-/sharp-0.34.5.tgz",
-            "integrity": "sha512-Ou9I5Ft9WNcCbXrU9cMgPBcCK8LiwLqcbywW3t4oDV37n1pzpuNLsYiAV8eODnjbtQlSDwZ2cUEeQz4E54Hltg==",
-            "hasInstallScript": true,
-            "license": "Apache-2.0",
-            "optional": true,
-            "dependencies": {
-                "@img/colour": "^1.0.0",
-                "detect-libc": "^2.1.2",
-                "semver": "^7.7.3"
-            },
-            "engines": {
-                "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
-            },
-            "funding": {
-                "url": "https://opencollective.com/libvips"
-            },
-            "optionalDependencies": {
-                "@img/sharp-darwin-arm64": "0.34.5",
-                "@img/sharp-darwin-x64": "0.34.5",
-                "@img/sharp-libvips-darwin-arm64": "1.2.4",
-                "@img/sharp-libvips-darwin-x64": "1.2.4",
-                "@img/sharp-libvips-linux-arm": "1.2.4",
-                "@img/sharp-libvips-linux-arm64": "1.2.4",
-                "@img/sharp-libvips-linux-ppc64": "1.2.4",
-                "@img/sharp-libvips-linux-riscv64": "1.2.4",
-                "@img/sharp-libvips-linux-s390x": "1.2.4",
-                "@img/sharp-libvips-linux-x64": "1.2.4",
-                "@img/sharp-libvips-linuxmusl-arm64": "1.2.4",
-                "@img/sharp-libvips-linuxmusl-x64": "1.2.4",
-                "@img/sharp-linux-arm": "0.34.5",
-                "@img/sharp-linux-arm64": "0.34.5",
-                "@img/sharp-linux-ppc64": "0.34.5",
-                "@img/sharp-linux-riscv64": "0.34.5",
-                "@img/sharp-linux-s390x": "0.34.5",
-                "@img/sharp-linux-x64": "0.34.5",
-                "@img/sharp-linuxmusl-arm64": "0.34.5",
-                "@img/sharp-linuxmusl-x64": "0.34.5",
-                "@img/sharp-wasm32": "0.34.5",
-                "@img/sharp-win32-arm64": "0.34.5",
-                "@img/sharp-win32-ia32": "0.34.5",
-                "@img/sharp-win32-x64": "0.34.5"
-            }
-        },
         "node_modules/node-addon-api": {
             "version": "7.1.1",
             "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-7.1.1.tgz",
@@ -12882,7 +12342,7 @@
             "version": "0.35.3",
             "resolved": "https://registry.npmjs.org/sharp/-/sharp-0.35.3.tgz",
             "integrity": "sha512-ej0zVHuZGHCiABXcNxeYhpRnPNPAcvbG8RMdBAhDAxLKkCRVSpK3Iyu7qbqw3JMzoj0REeM6f3tJLtVwl0023Q==",
-            "dev": true,
+            "devOptional": true,
             "license": "Apache-2.0",
             "dependencies": {
                 "@img/colour": "^1.1.0",
@@ -12932,7 +12392,7 @@
             "version": "7.8.5",
             "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
             "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
-            "dev": true,
+            "devOptional": true,
             "license": "ISC",
             "bin": {
                 "semver": "bin/semver.js"

--- a/package-lock.json
+++ b/package-lock.json
@@ -58,6 +58,9 @@
                 "unist-util-visit": "^5.1.0",
                 "vitest": "^4.1.0",
                 "webpack": "^5.76.0"
+            },
+            "engines": {
+                "npm": ">=11.10.0"
             }
         },
         "node_modules/@babel/code-frame": {
@@ -311,9 +314,9 @@
             }
         },
         "node_modules/@emnapi/runtime": {
-            "version": "1.11.2",
-            "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.11.2.tgz",
-            "integrity": "sha512-kyOl3X0DuTiT1h2ft8r2fYO8JYtU9a9Xis/zBSiGArNaagCOWx90N1k2wxp18czFDH+OgcWGb5ZP/XMt3dcyPA==",
+            "version": "1.11.3",
+            "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.11.3.tgz",
+            "integrity": "sha512-Xz4Tpyki7XyrpbUK1jR1AhdAdaXyhhY4lZ3neLodmhpuWfy2PAQN5B46sAiU4liOXGLkHypn/qU+jvfWSCYYLA==",
             "license": "MIT",
             "optional": true,
             "dependencies": {
@@ -919,9 +922,9 @@
             }
         },
         "node_modules/@eslint-community/eslint-utils": {
-            "version": "4.9.1",
-            "resolved": "https://registry.npmjs.org/@eslint-community/eslint-utils/-/eslint-utils-4.9.1.tgz",
-            "integrity": "sha512-phrYmNiYppR7znFEdqgfWHXR6NCkZEK7hwWDHZUjit/2/U0r6XvkDl0SYnoM51Hq7FhCGdLDT6zxCCOY1hexsQ==",
+            "version": "4.10.1",
+            "resolved": "https://registry.npmjs.org/@eslint-community/eslint-utils/-/eslint-utils-4.10.1.tgz",
+            "integrity": "sha512-cuadcxVFE8sDK6iWJbs8Sn0av2Nrh2QSGQhVlBW9AaAHqHwjWsZHT8LJ4hFGPh7ASBV2deFdM7H/DPjulmh8rg==",
             "license": "MIT",
             "dependencies": {
                 "eslint-visitor-keys": "^3.4.3"
@@ -980,9 +983,9 @@
             "peer": true
         },
         "node_modules/@eslint/config-array/node_modules/brace-expansion": {
-            "version": "1.1.15",
-            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.15.tgz",
-            "integrity": "sha512-EwOCDEex4quD37XhqM3omwtMoJjr//isUZz1JopUNWms+4Z2ViyM/k1YIRePpoVNnQhENnxtFjLaxNHrT7xIUg==",
+            "version": "1.1.16",
+            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.16.tgz",
+            "integrity": "sha512-IDw48K2/2kRkg9LdJxurvq3lV3aBgq0REY89duEqFRthjlPdXHKMj7EnQOXVckxzgisinf3nHfrcE2FufFLXMw==",
             "license": "MIT",
             "peer": true,
             "dependencies": {
@@ -1030,9 +1033,9 @@
             }
         },
         "node_modules/@eslint/eslintrc": {
-            "version": "3.3.5",
-            "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-3.3.5.tgz",
-            "integrity": "sha512-4IlJx0X0qftVsN5E+/vGujTRIFtwuLbNsVUe7TO6zYPDR1O6nFwvwhIKEKSrl6dZchmYBITazxKoUYOjdtjlRg==",
+            "version": "3.3.6",
+            "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-3.3.6.tgz",
+            "integrity": "sha512-l2Ul9PrHsPCKcEY/ac7VgFj9D80C7S68sOKc618SyHDPK36s1XcFebXY0iTzUVn4Yq+YbwvSnDmCz9yxjX+QrA==",
             "license": "MIT",
             "peer": true,
             "dependencies": {
@@ -1042,7 +1045,7 @@
                 "globals": "^14.0.0",
                 "ignore": "^5.2.0",
                 "import-fresh": "^3.2.1",
-                "js-yaml": "^4.1.1",
+                "js-yaml": "^4.3.0",
                 "minimatch": "^3.1.5",
                 "strip-json-comments": "^3.1.1"
             },
@@ -1061,9 +1064,9 @@
             "peer": true
         },
         "node_modules/@eslint/eslintrc/node_modules/brace-expansion": {
-            "version": "1.1.15",
-            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.15.tgz",
-            "integrity": "sha512-EwOCDEex4quD37XhqM3omwtMoJjr//isUZz1JopUNWms+4Z2ViyM/k1YIRePpoVNnQhENnxtFjLaxNHrT7xIUg==",
+            "version": "1.1.16",
+            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.16.tgz",
+            "integrity": "sha512-IDw48K2/2kRkg9LdJxurvq3lV3aBgq0REY89duEqFRthjlPdXHKMj7EnQOXVckxzgisinf3nHfrcE2FufFLXMw==",
             "license": "MIT",
             "peer": true,
             "dependencies": {
@@ -1098,9 +1101,9 @@
             }
         },
         "node_modules/@eslint/js": {
-            "version": "9.39.4",
-            "resolved": "https://registry.npmjs.org/@eslint/js/-/js-9.39.4.tgz",
-            "integrity": "sha512-nE7DEIchvtiFTwBw4Lfbu59PG+kCofhjsKaCWzxTpt4lfRjRMqG6uMBzKXuEcyXhOHoUp9riAm7/aWYGhXZ9cw==",
+            "version": "9.39.5",
+            "resolved": "https://registry.npmjs.org/@eslint/js/-/js-9.39.5.tgz",
+            "integrity": "sha512-QywQuszQh77pIXCsq998c8hbhSTI/azTty1Z6N53dmAudKHhy573j3yvRLsX2BSp8YpLtoCEG8E9DJe+8zUh4A==",
             "license": "MIT",
             "peer": true,
             "engines": {
@@ -2134,25 +2137,25 @@
             }
         },
         "node_modules/@mux/mux-player": {
-            "version": "3.13.0",
-            "resolved": "https://registry.npmjs.org/@mux/mux-player/-/mux-player-3.13.0.tgz",
-            "integrity": "sha512-vh4CIMahUa29gys+mlfsOFKYKAKXxE07jSWk9WZxkdpGBW1fKfCQXlNxBoAIQlPa9Uk4MZuM3HVgqdW6aTuaZg==",
+            "version": "3.13.2",
+            "resolved": "https://registry.npmjs.org/@mux/mux-player/-/mux-player-3.13.2.tgz",
+            "integrity": "sha512-qYOYK4/vAr0VEs5SoC8KRieKm3VSgXJpyuERvOIDYvomIVGVpeqGzhjeDeZ7XKQBH3swg0RdAT3kZaTWXe5s9Q==",
             "license": "MIT",
             "dependencies": {
-                "@mux/mux-video": "0.31.0",
-                "@mux/playback-core": "0.35.0",
+                "@mux/mux-video": "0.31.2",
+                "@mux/playback-core": "0.35.2",
                 "media-chrome": "~4.19.0",
                 "player.style": "^0.3.0"
             }
         },
         "node_modules/@mux/mux-player-react": {
-            "version": "3.13.0",
-            "resolved": "https://registry.npmjs.org/@mux/mux-player-react/-/mux-player-react-3.13.0.tgz",
-            "integrity": "sha512-7IkImo1H3rUYeuWHI/L0L7sGUqBvZCvptx3+4igc+P/V3WgqNFjOyQlcyxzxgXNtNNhGmkn5NaF3TU9DPbOmAQ==",
+            "version": "3.13.2",
+            "resolved": "https://registry.npmjs.org/@mux/mux-player-react/-/mux-player-react-3.13.2.tgz",
+            "integrity": "sha512-yjAmiqVPYTKi88LAuHxSwKiYrZUDy1ofUYjrDP91mvPfz8BfTvUanzpyE8+a6pRIZFp55rmiAnWyjWKuqSGASw==",
             "license": "MIT",
             "dependencies": {
-                "@mux/mux-player": "3.13.0",
-                "@mux/playback-core": "0.35.0",
+                "@mux/mux-player": "3.13.2",
+                "@mux/playback-core": "0.35.2",
                 "prop-types": "^15.8.1"
             },
             "peerDependencies": {
@@ -2170,22 +2173,23 @@
             }
         },
         "node_modules/@mux/mux-video": {
-            "version": "0.31.0",
-            "resolved": "https://registry.npmjs.org/@mux/mux-video/-/mux-video-0.31.0.tgz",
-            "integrity": "sha512-DvO2GynIJhPDc0LMuWvC144lCF+E07NI+chrg/vcRQlCf2fPdNNqCSMoaRdWu2S2v/Orsc85giT9K6GRbjbzgA==",
+            "version": "0.31.2",
+            "resolved": "https://registry.npmjs.org/@mux/mux-video/-/mux-video-0.31.2.tgz",
+            "integrity": "sha512-waahxlrat1PpRzcY2pwMQJ5Gyhos+D6iRyKnYzF0wBf4SESfBtunSBj3EuKuljypm8bamh9gWnlA0LSzm5Pz1w==",
             "license": "MIT",
             "dependencies": {
                 "@mux/mux-data-google-ima": "^0.3.4",
-                "@mux/playback-core": "0.35.0",
+                "@mux/playback-core": "0.35.2",
+                "@types/google_interactive_media_ads_types": "^3.697.0",
                 "castable-video": "~1.1.13",
                 "custom-media-element": "~1.4.6",
                 "media-tracks": "~0.3.5"
             }
         },
         "node_modules/@mux/playback-core": {
-            "version": "0.35.0",
-            "resolved": "https://registry.npmjs.org/@mux/playback-core/-/playback-core-0.35.0.tgz",
-            "integrity": "sha512-7Zi1EJ9sQNIUlQVBjJCXV0CB+rUVEsU3vNRElRV4xnD7dbpoioIAhe1SjZNBifjnK5aBKLDwQHypbnL3Cw3a5A==",
+            "version": "0.35.2",
+            "resolved": "https://registry.npmjs.org/@mux/playback-core/-/playback-core-0.35.2.tgz",
+            "integrity": "sha512-AsMV0LMwJm9T1ig6BBYSddeMlkzz+2RGcd6dkOgYk+L5Hx477ovbTxJZJ/vTW+rZjNWHcG3BvgNbSLgiubyZhw==",
             "license": "MIT",
             "dependencies": {
                 "hls.js": "~1.6.15",
@@ -2211,24 +2215,24 @@
             }
         },
         "node_modules/@next/env": {
-            "version": "16.2.10",
-            "resolved": "https://registry.npmjs.org/@next/env/-/env-16.2.10.tgz",
-            "integrity": "sha512-zLPxg9M0MEHmygpj5OuxjQ+vHMiy/K7cSp74G8ecYolmgUWw0RwN02tF56npup/+qaI8JB97hQgS/r2Hb6QwVA==",
+            "version": "16.2.12",
+            "resolved": "https://registry.npmjs.org/@next/env/-/env-16.2.12.tgz",
+            "integrity": "sha512-d0Z5Bc13Fa4nR8pFAKx2jay2yhJM16vlfHbTzYnUQAxlNb6B6lmn4hjt69lYNt4kRtyYP6gEM49lPRHNbIyneg==",
             "license": "MIT"
         },
         "node_modules/@next/eslint-plugin-next": {
-            "version": "16.2.10",
-            "resolved": "https://registry.npmjs.org/@next/eslint-plugin-next/-/eslint-plugin-next-16.2.10.tgz",
-            "integrity": "sha512-Gs8D2m21VnJeFo9qvYIIqJH94frWerWYu41BprU1pLtRVF7PCQNLiFZZ3fG+iPuj3K83Cwv/rt+msLOy8Qgu3Q==",
+            "version": "16.2.12",
+            "resolved": "https://registry.npmjs.org/@next/eslint-plugin-next/-/eslint-plugin-next-16.2.12.tgz",
+            "integrity": "sha512-uF2z/qAK2q7B5/6CpnFcBRX6jOq5iCO+Uqh1UkJhXljX1JwLarLYhhoJadO6dPb6moTprOKewMXheBcbIoSbug==",
             "license": "MIT",
             "dependencies": {
                 "fast-glob": "3.3.1"
             }
         },
         "node_modules/@next/mdx": {
-            "version": "16.2.10",
-            "resolved": "https://registry.npmjs.org/@next/mdx/-/mdx-16.2.10.tgz",
-            "integrity": "sha512-r6T32AyQ0xy6p0vKd1lNbz6RUXuVXdGYSAI0dRrpbnqGnTWQXefADZGui4PlwjqROj0XQBMqVwot9ntPWao9PA==",
+            "version": "16.2.12",
+            "resolved": "https://registry.npmjs.org/@next/mdx/-/mdx-16.2.12.tgz",
+            "integrity": "sha512-bbKvq/7SIJZgQFRYL3wwnzLwCBviQfWi5UR61RDWwaMX3fV6iSqKfVr5SErRNA/PhMer/ylvErX4SVaGNrwKcw==",
             "license": "MIT",
             "dependencies": {
                 "source-map": "^0.7.0"
@@ -2256,9 +2260,9 @@
             }
         },
         "node_modules/@next/swc-darwin-arm64": {
-            "version": "16.2.10",
-            "resolved": "https://registry.npmjs.org/@next/swc-darwin-arm64/-/swc-darwin-arm64-16.2.10.tgz",
-            "integrity": "sha512-v9IdJCa0H0mbo+8z5zwUpOk1Vj7RjkcI5uNYf5Ws1y6szf/p3Mzl9hLaST8SCt6L9h8NGnruZcd2+o0NTNwDhA==",
+            "version": "16.2.12",
+            "resolved": "https://registry.npmjs.org/@next/swc-darwin-arm64/-/swc-darwin-arm64-16.2.12.tgz",
+            "integrity": "sha512-0W1R0teHWJrqKX0FH20IzzIWAOuGtBxPGuObrxy1lE8hQvCFj49KE8a3WUg0D7sq6rn6zkM4c7YGUnhudBS6oA==",
             "cpu": [
                 "arm64"
             ],
@@ -2272,9 +2276,9 @@
             }
         },
         "node_modules/@next/swc-darwin-x64": {
-            "version": "16.2.10",
-            "resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-16.2.10.tgz",
-            "integrity": "sha512-17IS0jJRViROGmA9uGdNR8VPJpfbnaVG7E9qhso5jDLkmyd0lSDORWxbcKINzcFqzZqGwGtMSnrFRxBpuUYjLQ==",
+            "version": "16.2.12",
+            "resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-16.2.12.tgz",
+            "integrity": "sha512-Hy5Ls099+aFUmOLmIgPfLqNi6iCwhL3uQCssz5rWk+5Nkc6TUKCE83DY5BbNylfm3+mfwcSFnLRfrZDJhVxdtw==",
             "cpu": [
                 "x64"
             ],
@@ -2288,9 +2292,9 @@
             }
         },
         "node_modules/@next/swc-linux-arm64-gnu": {
-            "version": "16.2.10",
-            "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-16.2.10.tgz",
-            "integrity": "sha512-GRQRsRtuciNJvB54AvvuQTiq0oZtFwa1owQqtZD8wwnGpM2L39MV22kpI72YSXLKIyY40LC66EiLFv4PiicXxg==",
+            "version": "16.2.12",
+            "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-16.2.12.tgz",
+            "integrity": "sha512-+YqU2h1cQkHsGfvjAsrSmst8UIFBibBGm5x3Xgel8NLMiDQtNOM4sM2GOEMvG5YiOBNeN/Ykk8cQC2S0Xrqljg==",
             "cpu": [
                 "arm64"
             ],
@@ -2304,9 +2308,9 @@
             }
         },
         "node_modules/@next/swc-linux-arm64-musl": {
-            "version": "16.2.10",
-            "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-16.2.10.tgz",
-            "integrity": "sha512-zkN9MQYS7UQBro+FnISUq1itaQjXI9xqISzuQ+2bc921NcJ1x4yPCqrn77tVN6/dOOXaaWVX3k6/bR07pPwK+A==",
+            "version": "16.2.12",
+            "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-16.2.12.tgz",
+            "integrity": "sha512-0qjhiYBaKAqF63LA1ZWAAnKTzFUguAaZiRa5etMLGGPj/B6uEVjtIZldIzFEp3wHlB0koK6aTzqPtSdplTCjoA==",
             "cpu": [
                 "arm64"
             ],
@@ -2320,9 +2324,9 @@
             }
         },
         "node_modules/@next/swc-linux-x64-gnu": {
-            "version": "16.2.10",
-            "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-16.2.10.tgz",
-            "integrity": "sha512-iCVJnwvrPYECvA6WM/7+oo+OiTvedIKLxtCLAZP4xZR3nXa1zmzZyLPbYCmWvpd4CvMYF1EMTafd0ii3DygLvA==",
+            "version": "16.2.12",
+            "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-16.2.12.tgz",
+            "integrity": "sha512-7A3q26W+h7gnA15uqBToNuDqBEFZZcqh0mW2mn4AJh/G5pdg2RVE3n4slzLEliASZFG3NmsbEzng/x2Sh09mBg==",
             "cpu": [
                 "x64"
             ],
@@ -2336,9 +2340,9 @@
             }
         },
         "node_modules/@next/swc-linux-x64-musl": {
-            "version": "16.2.10",
-            "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-16.2.10.tgz",
-            "integrity": "sha512-ov2g4H0dHY9bPoOU83m91hWT7Iq5qy13bUnyyshLU3HGR1Ownn0X9QpmDPc5iIUaahTp7f7LeGAhV4DSFtackw==",
+            "version": "16.2.12",
+            "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-16.2.12.tgz",
+            "integrity": "sha512-qSjL/uppm+cbh21s72Ss8gkiOhQ4dExWHNGOWy6eZV7STj5WsKehgxT61beSsOj+YYQuTplL376lOCdMQU5T8w==",
             "cpu": [
                 "x64"
             ],
@@ -2352,9 +2356,9 @@
             }
         },
         "node_modules/@next/swc-win32-arm64-msvc": {
-            "version": "16.2.10",
-            "resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-16.2.10.tgz",
-            "integrity": "sha512-DwAnhLX76HQiFFQNgWlcK+JzlnD1rZ+UK/WY0ZMI/deXpvgnesjNYrqcfo1JzBuz4Kf7o3brIBL0glI1junatA==",
+            "version": "16.2.12",
+            "resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-16.2.12.tgz",
+            "integrity": "sha512-X6hzsOUJac/e7AWSbn9gQ9nzHld1xWP5iyjHpYWvud8pufB679O1xg4JDyKr8Xd69Jvd+kM2Der6uftiZCmjYA==",
             "cpu": [
                 "arm64"
             ],
@@ -2368,9 +2372,9 @@
             }
         },
         "node_modules/@next/swc-win32-x64-msvc": {
-            "version": "16.2.10",
-            "resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-16.2.10.tgz",
-            "integrity": "sha512-0JXq3b85Jk9Jg4ntLUbXSPvoDw3gpZou7twuKdoFG2jOw635v7+IiXfTaa0TxVMyx78pUjnrVYwLgjKfX4e6/A==",
+            "version": "16.2.12",
+            "resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-16.2.12.tgz",
+            "integrity": "sha512-F6fakeHuFTLOPt0bslQJdf+xtT+WIP9DVn/m4y1w1mRnVPyh3D/cNvzlRkxM444xfm+IvvYNSOrKiA2CDJ0Uxw==",
             "cpu": [
                 "x64"
             ],
@@ -2428,9 +2432,9 @@
             }
         },
         "node_modules/@oxc-project/types": {
-            "version": "0.138.0",
-            "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.138.0.tgz",
-            "integrity": "sha512-1a7ZKmrRTCoN1XMZ4L0PyyqrMnrNlLyPuOkdSX2MZg7IiIGRUyurNhAm73ptDOraoBcIordsIGKNPKUzy3ZmfA==",
+            "version": "0.139.0",
+            "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.139.0.tgz",
+            "integrity": "sha512-r9gHphtCs+1M7J0pw6Sn/hh/Wpa/iQrOOkrNAlVLF/gHq+/CJmHIWKKUUhdWjcD6CIa8idarspCsASiXCXvFUw==",
             "dev": true,
             "license": "MIT",
             "funding": {
@@ -2438,10 +2442,9 @@
             }
         },
         "node_modules/@parcel/watcher": {
-            "version": "2.5.6",
-            "resolved": "https://registry.npmjs.org/@parcel/watcher/-/watcher-2.5.6.tgz",
-            "integrity": "sha512-tmmZ3lQxAe/k/+rNnXQRawJ4NjxO2hqiOLTHvWchtGZULp4RyFeh6aU4XdOYBFe2KE1oShQTv4AblOs2iOrNnQ==",
-            "dev": true,
+            "version": "2.6.0",
+            "resolved": "https://registry.npmjs.org/@parcel/watcher/-/watcher-2.6.0.tgz",
+            "integrity": "sha512-7FNeNl8NCE7aINx7WXiKQrPYZWC/hvrTsmk6zmxbI7LTXE7hVek/n8AfVgpe2y82zl3w0HvCHN0bVKMBoJcC0w==",
             "hasInstallScript": true,
             "license": "MIT",
             "optional": true,
@@ -2449,7 +2452,7 @@
                 "detect-libc": "^2.0.3",
                 "is-glob": "^4.0.3",
                 "node-addon-api": "^7.0.0",
-                "picomatch": "^4.0.3"
+                "picomatch": "^4.0.4"
             },
             "engines": {
                 "node": ">= 10.0.0"
@@ -2459,29 +2462,27 @@
                 "url": "https://opencollective.com/parcel"
             },
             "optionalDependencies": {
-                "@parcel/watcher-android-arm64": "2.5.6",
-                "@parcel/watcher-darwin-arm64": "2.5.6",
-                "@parcel/watcher-darwin-x64": "2.5.6",
-                "@parcel/watcher-freebsd-x64": "2.5.6",
-                "@parcel/watcher-linux-arm-glibc": "2.5.6",
-                "@parcel/watcher-linux-arm-musl": "2.5.6",
-                "@parcel/watcher-linux-arm64-glibc": "2.5.6",
-                "@parcel/watcher-linux-arm64-musl": "2.5.6",
-                "@parcel/watcher-linux-x64-glibc": "2.5.6",
-                "@parcel/watcher-linux-x64-musl": "2.5.6",
-                "@parcel/watcher-win32-arm64": "2.5.6",
-                "@parcel/watcher-win32-ia32": "2.5.6",
-                "@parcel/watcher-win32-x64": "2.5.6"
+                "@parcel/watcher-android-arm64": "2.6.0",
+                "@parcel/watcher-darwin-arm64": "2.6.0",
+                "@parcel/watcher-darwin-x64": "2.6.0",
+                "@parcel/watcher-freebsd-x64": "2.6.0",
+                "@parcel/watcher-linux-arm-glibc": "2.6.0",
+                "@parcel/watcher-linux-arm-musl": "2.6.0",
+                "@parcel/watcher-linux-arm64-glibc": "2.6.0",
+                "@parcel/watcher-linux-arm64-musl": "2.6.0",
+                "@parcel/watcher-linux-x64-glibc": "2.6.0",
+                "@parcel/watcher-linux-x64-musl": "2.6.0",
+                "@parcel/watcher-win32-arm64": "2.6.0",
+                "@parcel/watcher-win32-x64": "2.6.0"
             }
         },
         "node_modules/@parcel/watcher-android-arm64": {
-            "version": "2.5.6",
-            "resolved": "https://registry.npmjs.org/@parcel/watcher-android-arm64/-/watcher-android-arm64-2.5.6.tgz",
-            "integrity": "sha512-YQxSS34tPF/6ZG7r/Ih9xy+kP/WwediEUsqmtf0cuCV5TPPKw/PQHRhueUo6JdeFJaqV3pyjm0GdYjZotbRt/A==",
+            "version": "2.6.0",
+            "resolved": "https://registry.npmjs.org/@parcel/watcher-android-arm64/-/watcher-android-arm64-2.6.0.tgz",
+            "integrity": "sha512-trgpLSCKRC/huFjXX/Smh+0sWe4+YtKfktIToiMl59ghz7z+qkH6kMvNnUbLyRs9N11t8l4svSCs1+5B3rOAhA==",
             "cpu": [
                 "arm64"
             ],
-            "dev": true,
             "license": "MIT",
             "optional": true,
             "os": [
@@ -2496,13 +2497,12 @@
             }
         },
         "node_modules/@parcel/watcher-darwin-arm64": {
-            "version": "2.5.6",
-            "resolved": "https://registry.npmjs.org/@parcel/watcher-darwin-arm64/-/watcher-darwin-arm64-2.5.6.tgz",
-            "integrity": "sha512-Z2ZdrnwyXvvvdtRHLmM4knydIdU9adO3D4n/0cVipF3rRiwP+3/sfzpAwA/qKFL6i1ModaabkU7IbpeMBgiVEA==",
+            "version": "2.6.0",
+            "resolved": "https://registry.npmjs.org/@parcel/watcher-darwin-arm64/-/watcher-darwin-arm64-2.6.0.tgz",
+            "integrity": "sha512-Y3QV0gl7Q1zbfueunkWIERICbEojQFCgpyG7YqOGNFLsckXyI1xu9mAIUpKY9QBYzBtSkN8dBPwd3yiAO9ovMw==",
             "cpu": [
                 "arm64"
             ],
-            "dev": true,
             "license": "MIT",
             "optional": true,
             "os": [
@@ -2517,13 +2517,12 @@
             }
         },
         "node_modules/@parcel/watcher-darwin-x64": {
-            "version": "2.5.6",
-            "resolved": "https://registry.npmjs.org/@parcel/watcher-darwin-x64/-/watcher-darwin-x64-2.5.6.tgz",
-            "integrity": "sha512-HgvOf3W9dhithcwOWX9uDZyn1lW9R+7tPZ4sug+NGrGIo4Rk1hAXLEbcH1TQSqxts0NYXXlOWqVpvS1SFS4fRg==",
+            "version": "2.6.0",
+            "resolved": "https://registry.npmjs.org/@parcel/watcher-darwin-x64/-/watcher-darwin-x64-2.6.0.tgz",
+            "integrity": "sha512-Ohv6OpzhUfKYD7Beb8kDvG0jbIxORCYY1JRdZnaBtnjjkJxgD7ZVL0nw2sCYd0yTMKTvz3nnTnOF3cDifK+kvw==",
             "cpu": [
                 "x64"
             ],
-            "dev": true,
             "license": "MIT",
             "optional": true,
             "os": [
@@ -2538,13 +2537,12 @@
             }
         },
         "node_modules/@parcel/watcher-freebsd-x64": {
-            "version": "2.5.6",
-            "resolved": "https://registry.npmjs.org/@parcel/watcher-freebsd-x64/-/watcher-freebsd-x64-2.5.6.tgz",
-            "integrity": "sha512-vJVi8yd/qzJxEKHkeemh7w3YAn6RJCtYlE4HPMoVnCpIXEzSrxErBW5SJBgKLbXU3WdIpkjBTeUNtyBVn8TRng==",
+            "version": "2.6.0",
+            "resolved": "https://registry.npmjs.org/@parcel/watcher-freebsd-x64/-/watcher-freebsd-x64-2.6.0.tgz",
+            "integrity": "sha512-5HmXvDgs8VK+74jF9y9/2FE3/OnlcKmc56tjmSrEuZjpSZOGL+fvAu+HKJBdPs9uwoP2hE6TlSUpXZ/C5jUFmQ==",
             "cpu": [
                 "x64"
             ],
-            "dev": true,
             "license": "MIT",
             "optional": true,
             "os": [
@@ -2559,13 +2557,12 @@
             }
         },
         "node_modules/@parcel/watcher-linux-arm-glibc": {
-            "version": "2.5.6",
-            "resolved": "https://registry.npmjs.org/@parcel/watcher-linux-arm-glibc/-/watcher-linux-arm-glibc-2.5.6.tgz",
-            "integrity": "sha512-9JiYfB6h6BgV50CCfasfLf/uvOcJskMSwcdH1PHH9rvS1IrNy8zad6IUVPVUfmXr+u+Km9IxcfMLzgdOudz9EQ==",
+            "version": "2.6.0",
+            "resolved": "https://registry.npmjs.org/@parcel/watcher-linux-arm-glibc/-/watcher-linux-arm-glibc-2.6.0.tgz",
+            "integrity": "sha512-Ps/hui3A+vMbjdqlqAowK2ZL8+BO8dBjxeWXj6npTBs3jx4wWmbPpaLuqwrQrSqIVMCnpWo238bJ1U37GhQOYg==",
             "cpu": [
                 "arm"
             ],
-            "dev": true,
             "license": "MIT",
             "optional": true,
             "os": [
@@ -2580,13 +2577,12 @@
             }
         },
         "node_modules/@parcel/watcher-linux-arm-musl": {
-            "version": "2.5.6",
-            "resolved": "https://registry.npmjs.org/@parcel/watcher-linux-arm-musl/-/watcher-linux-arm-musl-2.5.6.tgz",
-            "integrity": "sha512-Ve3gUCG57nuUUSyjBq/MAM0CzArtuIOxsBdQ+ftz6ho8n7s1i9E1Nmk/xmP323r2YL0SONs1EuwqBp2u1k5fxg==",
+            "version": "2.6.0",
+            "resolved": "https://registry.npmjs.org/@parcel/watcher-linux-arm-musl/-/watcher-linux-arm-musl-2.6.0.tgz",
+            "integrity": "sha512-9c6AUHgHoG+IY88MRIHupztQiQnrbqHYQjkM2btA+Bf/wQnQMuiD0Wfk1EVv3TlNT3x41uU71rn6E4xh/+zvkw==",
             "cpu": [
                 "arm"
             ],
-            "dev": true,
             "license": "MIT",
             "optional": true,
             "os": [
@@ -2601,13 +2597,12 @@
             }
         },
         "node_modules/@parcel/watcher-linux-arm64-glibc": {
-            "version": "2.5.6",
-            "resolved": "https://registry.npmjs.org/@parcel/watcher-linux-arm64-glibc/-/watcher-linux-arm64-glibc-2.5.6.tgz",
-            "integrity": "sha512-f2g/DT3NhGPdBmMWYoxixqYr3v/UXcmLOYy16Bx0TM20Tchduwr4EaCbmxh1321TABqPGDpS8D/ggOTaljijOA==",
+            "version": "2.6.0",
+            "resolved": "https://registry.npmjs.org/@parcel/watcher-linux-arm64-glibc/-/watcher-linux-arm64-glibc-2.6.0.tgz",
+            "integrity": "sha512-yHRqS2owEXe6Hic9z6Mh1ECsCd+ODVOGvZDyciqRd21+v+o+DnXMOrw50DSpIG2sb8GPEaPPmfeCAWKPJdq46g==",
             "cpu": [
                 "arm64"
             ],
-            "dev": true,
             "license": "MIT",
             "optional": true,
             "os": [
@@ -2622,13 +2617,12 @@
             }
         },
         "node_modules/@parcel/watcher-linux-arm64-musl": {
-            "version": "2.5.6",
-            "resolved": "https://registry.npmjs.org/@parcel/watcher-linux-arm64-musl/-/watcher-linux-arm64-musl-2.5.6.tgz",
-            "integrity": "sha512-qb6naMDGlbCwdhLj6hgoVKJl2odL34z2sqkC7Z6kzir8b5W65WYDpLB6R06KabvZdgoHI/zxke4b3zR0wAbDTA==",
+            "version": "2.6.0",
+            "resolved": "https://registry.npmjs.org/@parcel/watcher-linux-arm64-musl/-/watcher-linux-arm64-musl-2.6.0.tgz",
+            "integrity": "sha512-WhB2e/V7rqdHHWZusBSPuy5Ei8S6lSz6FE5TKKQz5h3a0O+C+mhY7vxU9b/stqvMb8beLnPY82ZrFTLKs+SrKA==",
             "cpu": [
                 "arm64"
             ],
-            "dev": true,
             "license": "MIT",
             "optional": true,
             "os": [
@@ -2643,13 +2637,12 @@
             }
         },
         "node_modules/@parcel/watcher-linux-x64-glibc": {
-            "version": "2.5.6",
-            "resolved": "https://registry.npmjs.org/@parcel/watcher-linux-x64-glibc/-/watcher-linux-x64-glibc-2.5.6.tgz",
-            "integrity": "sha512-kbT5wvNQlx7NaGjzPFu8nVIW1rWqV780O7ZtkjuWaPUgpv2NMFpjYERVi0UYj1msZNyCzGlaCWEtzc+exjMGbQ==",
+            "version": "2.6.0",
+            "resolved": "https://registry.npmjs.org/@parcel/watcher-linux-x64-glibc/-/watcher-linux-x64-glibc-2.6.0.tgz",
+            "integrity": "sha512-ulGE6x6Oz6iAwg75T8YQSoguBWasniIbX+QWpaYPcCnDOpdWX3k+4xbEYPZVLxOuoJI+svJJPD3sEj8G7lrQ3A==",
             "cpu": [
                 "x64"
             ],
-            "dev": true,
             "license": "MIT",
             "optional": true,
             "os": [
@@ -2664,13 +2657,12 @@
             }
         },
         "node_modules/@parcel/watcher-linux-x64-musl": {
-            "version": "2.5.6",
-            "resolved": "https://registry.npmjs.org/@parcel/watcher-linux-x64-musl/-/watcher-linux-x64-musl-2.5.6.tgz",
-            "integrity": "sha512-1JRFeC+h7RdXwldHzTsmdtYR/Ku8SylLgTU/reMuqdVD7CtLwf0VR1FqeprZ0eHQkO0vqsbvFLXUmYm/uNKJBg==",
+            "version": "2.6.0",
+            "resolved": "https://registry.npmjs.org/@parcel/watcher-linux-x64-musl/-/watcher-linux-x64-musl-2.6.0.tgz",
+            "integrity": "sha512-tkBYKt7YQrjIJWYDnto2YgO8MRkjlMTSNoRHzsXinBqbLdeOM3L32wPZJvIZxqaLMfSlS/4sUjH/6STVP/XDLw==",
             "cpu": [
                 "x64"
             ],
-            "dev": true,
             "license": "MIT",
             "optional": true,
             "os": [
@@ -2685,34 +2677,12 @@
             }
         },
         "node_modules/@parcel/watcher-win32-arm64": {
-            "version": "2.5.6",
-            "resolved": "https://registry.npmjs.org/@parcel/watcher-win32-arm64/-/watcher-win32-arm64-2.5.6.tgz",
-            "integrity": "sha512-3ukyebjc6eGlw9yRt678DxVF7rjXatWiHvTXqphZLvo7aC5NdEgFufVwjFfY51ijYEWpXbqF5jtrK275z52D4Q==",
+            "version": "2.6.0",
+            "resolved": "https://registry.npmjs.org/@parcel/watcher-win32-arm64/-/watcher-win32-arm64-2.6.0.tgz",
+            "integrity": "sha512-gIZAP23jaHjGWasY/TY6yL7NHFClf0Ga7FN+iINvk+KN94rhm94lYZhFsbYFNcA04/onvGD9kKmiJLJB2HbNwQ==",
             "cpu": [
                 "arm64"
             ],
-            "dev": true,
-            "license": "MIT",
-            "optional": true,
-            "os": [
-                "win32"
-            ],
-            "engines": {
-                "node": ">= 10.0.0"
-            },
-            "funding": {
-                "type": "opencollective",
-                "url": "https://opencollective.com/parcel"
-            }
-        },
-        "node_modules/@parcel/watcher-win32-ia32": {
-            "version": "2.5.6",
-            "resolved": "https://registry.npmjs.org/@parcel/watcher-win32-ia32/-/watcher-win32-ia32-2.5.6.tgz",
-            "integrity": "sha512-k35yLp1ZMwwee3Ez/pxBi5cf4AoBKYXj00CZ80jUz5h8prpiaQsiRPKQMxoLstNuqe2vR4RNPEAEcjEFzhEz/g==",
-            "cpu": [
-                "ia32"
-            ],
-            "dev": true,
             "license": "MIT",
             "optional": true,
             "os": [
@@ -2727,13 +2697,12 @@
             }
         },
         "node_modules/@parcel/watcher-win32-x64": {
-            "version": "2.5.6",
-            "resolved": "https://registry.npmjs.org/@parcel/watcher-win32-x64/-/watcher-win32-x64-2.5.6.tgz",
-            "integrity": "sha512-hbQlYcCq5dlAX9Qx+kFb0FHue6vbjlf0FrNzSKdYK2APUf7tGfGxQCk2ihEREmbR6ZMc0MVAD5RIX/41gpUzTw==",
+            "version": "2.6.0",
+            "resolved": "https://registry.npmjs.org/@parcel/watcher-win32-x64/-/watcher-win32-x64-2.6.0.tgz",
+            "integrity": "sha512-cA+/pXV2YkfxlIcXOQ5fSWqAzzPyD78/x5qbK/I0vUkrlYHA8TIz+MXjAbGouguKVSI4bOmkTSJ1/poVSsgt+A==",
             "cpu": [
                 "x64"
             ],
-            "dev": true,
             "license": "MIT",
             "optional": true,
             "os": [
@@ -2751,7 +2720,6 @@
             "version": "4.0.5",
             "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.5.tgz",
             "integrity": "sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==",
-            "dev": true,
             "license": "MIT",
             "optional": true,
             "engines": {
@@ -2801,9 +2769,9 @@
             }
         },
         "node_modules/@rolldown/binding-android-arm64": {
-            "version": "1.1.4",
-            "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.1.4.tgz",
-            "integrity": "sha512-EZLpf/8y7GXkkra90ML47kzik/GMP3EMcE9bPyHmRfxLC6z9+aW5A8poCsoxjrT5GfEcNAAvWwUHjvP1pUQkfw==",
+            "version": "1.1.5",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.1.5.tgz",
+            "integrity": "sha512-lZg8fqIv2v7FF237bwMgzGZEJvGL79/s5knJ/i6FmsGF4XXlzccZ4jb+TrFIxtSSxFtIpdsgrPZeMk1I9AFcyQ==",
             "cpu": [
                 "arm64"
             ],
@@ -2818,9 +2786,9 @@
             }
         },
         "node_modules/@rolldown/binding-darwin-arm64": {
-            "version": "1.1.4",
-            "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-arm64/-/binding-darwin-arm64-1.1.4.tgz",
-            "integrity": "sha512-aUi+HBvmYb7j8krl1+qJgkG8C17fO79gk3c+jPw4S8glRFc1DTija9S3EyaTSQUm5GJXYKDAsugBEhFHH2vYiQ==",
+            "version": "1.1.5",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-arm64/-/binding-darwin-arm64-1.1.5.tgz",
+            "integrity": "sha512-51Bnx9pNiMRKSUNtBfySkNJ9vMU9Hh3I1ozDd6gyPPYzaXCfnptUcEZxXGYFn+ul2dtcMUiqGR1Yai2K10uoTw==",
             "cpu": [
                 "arm64"
             ],
@@ -2835,9 +2803,9 @@
             }
         },
         "node_modules/@rolldown/binding-darwin-x64": {
-            "version": "1.1.4",
-            "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.1.4.tgz",
-            "integrity": "sha512-F7hHC3gwY11+vByKPRWqwGbeXWVgKmL+pTGCinaEhdihzBV2aQ0fvZOch9cXYUOKuKKq429HeYXOqQLc7wFCEg==",
+            "version": "1.1.5",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.1.5.tgz",
+            "integrity": "sha512-Tm+gbfC0aHu1tBA/JvKQh32S0K6YgCHkiAF4/W6xX0K0RmNuc94VeK419dJoE65R5aRxmo+noZQSWrAMF6yb6g==",
             "cpu": [
                 "x64"
             ],
@@ -2852,9 +2820,9 @@
             }
         },
         "node_modules/@rolldown/binding-freebsd-x64": {
-            "version": "1.1.4",
-            "resolved": "https://registry.npmjs.org/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.1.4.tgz",
-            "integrity": "sha512-sI5yw+7s92SK6odiEhD5lKCBlWcpjHS5qyqpVQbZAJ0fIzEUXrmbl3DH2ybR3PZogulNJF+COLtmA8hUfvkCCQ==",
+            "version": "1.1.5",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.1.5.tgz",
+            "integrity": "sha512-JMzDKCCXq93YccG5gz3hvOs1oXRKAf0XYpfOS88e+wZrC8Iugj6j68867vrYZkvpDDpKn/KoKORThmchMpF6TA==",
             "cpu": [
                 "x64"
             ],
@@ -2869,9 +2837,9 @@
             }
         },
         "node_modules/@rolldown/binding-linux-arm-gnueabihf": {
-            "version": "1.1.4",
-            "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.1.4.tgz",
-            "integrity": "sha512-mCi0OKgEieFircrtVYmQAFGszRtMnZ6fpZAXrxanXAu7lqZcsK1E1RAaZNG0uKAnxox3B1f4EyQNnoyMfN1vAA==",
+            "version": "1.1.5",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.1.5.tgz",
+            "integrity": "sha512-uML21j2K5TfPGutKxub+M+nLjZIrWjXQ5Grx4lCe/nimTj9B4L63zHpjXLl4y0L3mcm2htEQIb06oCG/szerNw==",
             "cpu": [
                 "arm"
             ],
@@ -2886,9 +2854,9 @@
             }
         },
         "node_modules/@rolldown/binding-linux-arm64-gnu": {
-            "version": "1.1.4",
-            "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.1.4.tgz",
-            "integrity": "sha512-B9Ial3Kv5sh0SHnB1g/QWcUQCEvCF6QKGAl4zXypYj65mVI+B4AhFBwPtSN7pDrJeIx8Z7zdy4ntx+wQABom7w==",
+            "version": "1.1.5",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.1.5.tgz",
+            "integrity": "sha512-navSiuTMogvnQoZoM/v+l3ZWo50/NTwSHSzheABx/RCnmUPaKwq9qSo4Br2OYRs21+Fz8uFqITZM3H4opOB0/Q==",
             "cpu": [
                 "arm64"
             ],
@@ -2903,9 +2871,9 @@
             }
         },
         "node_modules/@rolldown/binding-linux-arm64-musl": {
-            "version": "1.1.4",
-            "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.1.4.tgz",
-            "integrity": "sha512-lZVym0PuHE1KZ22gmFTC15lAkrg9iTszR617oYRB/iPY1A56ywoJzVKOJBKaot5RiikCObmur6pogpse3gRcng==",
+            "version": "1.1.5",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.1.5.tgz",
+            "integrity": "sha512-lAryqH7IteztmCXQXk0etKj4wBQ7Gx5S6LjKhsgp9zb8I5bsuvU/2llH1hDQcjsFeqIsovMVN339/8pUDDBXxA==",
             "cpu": [
                 "arm64"
             ],
@@ -2920,9 +2888,9 @@
             }
         },
         "node_modules/@rolldown/binding-linux-ppc64-gnu": {
-            "version": "1.1.4",
-            "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.1.4.tgz",
-            "integrity": "sha512-t2DNiLJWNTbnEHyUzTumldML6ET4/g16467LZoDDJ3tSxGvguL5/NyC2lCsNKuyRycg9XeDQF5SSv+TNOhQEXg==",
+            "version": "1.1.5",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.1.5.tgz",
+            "integrity": "sha512-fsK/sNBnxzBlL4O1JNrZakVQxPspqpED5dLtNsZS9oOKmtSpdNIzxH2kkol5HYTWJN47sE20ztMJPxfZ89qGOg==",
             "cpu": [
                 "ppc64"
             ],
@@ -2937,9 +2905,9 @@
             }
         },
         "node_modules/@rolldown/binding-linux-s390x-gnu": {
-            "version": "1.1.4",
-            "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.1.4.tgz",
-            "integrity": "sha512-0WIRnL1Uw4BvTZRLQt+PVgo6ZKTJadlC2btP+/EOXv2f/DWbY0rEgl+y834mIVwP1FkTlWVTrGGJXf12lru7EQ==",
+            "version": "1.1.5",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.1.5.tgz",
+            "integrity": "sha512-gLYb4BIadlfTOYT5gO503n8zQjXflgzpD0FcyKh0Mzx3rqCZKnHoJWV9xe1KXUJ5lx2JfcSHr/mhzS0PC/McAA==",
             "cpu": [
                 "s390x"
             ],
@@ -2954,9 +2922,9 @@
             }
         },
         "node_modules/@rolldown/binding-linux-x64-gnu": {
-            "version": "1.1.4",
-            "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.1.4.tgz",
-            "integrity": "sha512-JWtGshGfX+oENAKonoNkqEJX+7hC8yfhi9GUyPX1VX4mdh1y5r+ZiJLR5XzAB0aoP6s/PcILsGjKq8O0mm24bw==",
+            "version": "1.1.5",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.1.5.tgz",
+            "integrity": "sha512-FjcpEKUyJygHgs1o50VYNvkt5+7Le/VEdYt0AkRpkL33MnyQfwr8l5mXwMmfmTbyMPr5vJLC+8/Gd9gXnwU1QQ==",
             "cpu": [
                 "x64"
             ],
@@ -2971,9 +2939,9 @@
             }
         },
         "node_modules/@rolldown/binding-linux-x64-musl": {
-            "version": "1.1.4",
-            "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.1.4.tgz",
-            "integrity": "sha512-rT6yQcxUuXs4CnbofqwHRRV0iem349rLMYpTjkgQGLjrY4ado/eDzwPZPTCgTOlF6Nkp8NEv70yLMTn6qkWxsQ==",
+            "version": "1.1.5",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.1.5.tgz",
+            "integrity": "sha512-Me+PfPI2TMeOQk0gYWfLQZtTktrmzbr8cDboqX83XKc7UrgAi55gF+2dUkWdxd19n55Essp2yeca+O9N5rBxHg==",
             "cpu": [
                 "x64"
             ],
@@ -2988,9 +2956,9 @@
             }
         },
         "node_modules/@rolldown/binding-openharmony-arm64": {
-            "version": "1.1.4",
-            "resolved": "https://registry.npmjs.org/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.1.4.tgz",
-            "integrity": "sha512-KXMGoboq5cyaCQjDA4GLuRiOwBQ0EyFnJoVViLeZ45/3rFItRODEr+NdsBcVpll40hhNArlm/speWGRvj08LzA==",
+            "version": "1.1.5",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.1.5.tgz",
+            "integrity": "sha512-yc5WrLzXks6zCQfn9Oxr8pORKyl/pF+QjHmW/Qx3qu0oyrrNC+y2JLTU1E2rcWYAmzlnqngWXHQjy51VzW70Vw==",
             "cpu": [
                 "arm64"
             ],
@@ -3005,9 +2973,9 @@
             }
         },
         "node_modules/@rolldown/binding-wasm32-wasi": {
-            "version": "1.1.4",
-            "resolved": "https://registry.npmjs.org/@rolldown/binding-wasm32-wasi/-/binding-wasm32-wasi-1.1.4.tgz",
-            "integrity": "sha512-5K83rb36oJiY7BCyE9zLZtGcPV4g5wvq+xwdO0XPIwDVZI8cyB/AUjkNXGb92/rnmezEkjMOpgY61rtwjQtFwg==",
+            "version": "1.1.5",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-wasm32-wasi/-/binding-wasm32-wasi-1.1.5.tgz",
+            "integrity": "sha512-VbQGPX2b4r48TAMIM2cjgluIM1HYutm4pcTEJsle7iEP7sB1dFqtPLBVbdLAZCxy1txCcPxf4QFf4v8uvltPqA==",
             "cpu": [
                 "wasm32"
             ],
@@ -3058,9 +3026,9 @@
             }
         },
         "node_modules/@rolldown/binding-win32-arm64-msvc": {
-            "version": "1.1.4",
-            "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.1.4.tgz",
-            "integrity": "sha512-PnWBtw3TV5KOg69HQQDR0mnQuyCmSGR2pAB4DC1rPF808fgKeTUMj2EOEyKATpgiuxuR5APQmiDO7PDgEjTFSA==",
+            "version": "1.1.5",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.1.5.tgz",
+            "integrity": "sha512-gHv82k63z4qpV5+Q1y/12KrK0ltWBukVDI8nZcbT7Tt/ZlOIVwppazneq0F93oDxTo3IgAMEDIoQh3E2n6mVsw==",
             "cpu": [
                 "arm64"
             ],
@@ -3075,9 +3043,9 @@
             }
         },
         "node_modules/@rolldown/binding-win32-x64-msvc": {
-            "version": "1.1.4",
-            "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.1.4.tgz",
-            "integrity": "sha512-M1lpniBePobTfsa7Ks9a199e1akxsXn+GYBUKsEzv3YFzOm1HJAMNwKI3qr0Zq+mxwx9gOZoTdP1yXRYsZUocQ==",
+            "version": "1.1.5",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.1.5.tgz",
+            "integrity": "sha512-tTZuDBPw85tEN5PQi1pnEBzDy0Z49HtScLAbD5t6hyeU92A95pRWaSMw1GZZi/RwgSgUIl0xrSlXIT/9QzvYSA==",
             "cpu": [
                 "x64"
             ],
@@ -3374,10 +3342,16 @@
                 "@types/estree": "*"
             }
         },
+        "node_modules/@types/google_interactive_media_ads_types": {
+            "version": "3.697.1",
+            "resolved": "https://registry.npmjs.org/@types/google_interactive_media_ads_types/-/google_interactive_media_ads_types-3.697.1.tgz",
+            "integrity": "sha512-gRjJoPKQRjjTuySHqZe8Pnu6a5B0bKbTUD2ioDLPSWlEuBaAc2p1mzUzy42SCeWkyYffo2Mnv+blUGuvVvx3dQ==",
+            "license": "MIT"
+        },
         "node_modules/@types/hast": {
-            "version": "3.0.4",
-            "resolved": "https://registry.npmjs.org/@types/hast/-/hast-3.0.4.tgz",
-            "integrity": "sha512-WPs+bbQw5aCj+x6laNGWLH3wviHtoCv/P3+otBhbOhJgG8qtpdAMlTCxLtsTWA7LH1Oh/bFCHsBn0TPS5m30EQ==",
+            "version": "3.0.5",
+            "resolved": "https://registry.npmjs.org/@types/hast/-/hast-3.0.5.tgz",
+            "integrity": "sha512-rp/ezSWaD1m44dPKICGhiskI13nVr7qTloFwDa/IYkhhf5nzwP+zIQcIJh3WIFSBOy/H1PzB40jPjMDksN4F+g==",
             "license": "MIT",
             "dependencies": {
                 "@types/unist": "*"
@@ -3431,9 +3405,9 @@
             "license": "MIT"
         },
         "node_modules/@types/node": {
-            "version": "26.1.0",
-            "resolved": "https://registry.npmjs.org/@types/node/-/node-26.1.0.tgz",
-            "integrity": "sha512-O0A1G3xPGy4w7AgQdAQYUlQ+BKk2Oovw8eRpofyp5KdBZULnbe+WqaOVNrm705SHphCiG4XHsACrSmPu1f+Kgw==",
+            "version": "26.1.1",
+            "resolved": "https://registry.npmjs.org/@types/node/-/node-26.1.1.tgz",
+            "integrity": "sha512-nxAkRSVkN1Y0JC1W8ky/fTfkGsMmcrRsbx+3XoZE+rMOX71kLYTV7fLXpqud1GpbpP5TuffXFqfX7fH2GgZREw==",
             "devOptional": true,
             "license": "MIT",
             "dependencies": {
@@ -3493,16 +3467,16 @@
             "license": "MIT"
         },
         "node_modules/@typescript-eslint/eslint-plugin": {
-            "version": "8.62.1",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.62.1.tgz",
-            "integrity": "sha512-4EQM77WgVNxj7OkL/5b/D/xZsw00G577+UriYTC7JF5opcF3T2AuoeY7ueLaZgSVjSgCS6yOAJB5bRGLPSJUzA==",
+            "version": "8.65.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.65.0.tgz",
+            "integrity": "sha512-IEgob78X12rHpUmtcwFsXhZdVGJtwTVP8FiCLZkR6GlYVrl2PcuB+KhCE5BlVC/eQpQnu8WXRtkHZuPar+gCRA==",
             "license": "MIT",
             "dependencies": {
                 "@eslint-community/regexpp": "^4.12.2",
-                "@typescript-eslint/scope-manager": "8.62.1",
-                "@typescript-eslint/type-utils": "8.62.1",
-                "@typescript-eslint/utils": "8.62.1",
-                "@typescript-eslint/visitor-keys": "8.62.1",
+                "@typescript-eslint/scope-manager": "8.65.0",
+                "@typescript-eslint/type-utils": "8.65.0",
+                "@typescript-eslint/utils": "8.65.0",
+                "@typescript-eslint/visitor-keys": "8.65.0",
                 "ignore": "^7.0.5",
                 "natural-compare": "^1.4.0",
                 "ts-api-utils": "^2.5.0"
@@ -3515,30 +3489,30 @@
                 "url": "https://opencollective.com/typescript-eslint"
             },
             "peerDependencies": {
-                "@typescript-eslint/parser": "^8.62.1",
+                "@typescript-eslint/parser": "^8.65.0",
                 "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
                 "typescript": ">=4.8.4 <6.1.0"
             }
         },
         "node_modules/@typescript-eslint/eslint-plugin/node_modules/ignore": {
-            "version": "7.0.5",
-            "resolved": "https://registry.npmjs.org/ignore/-/ignore-7.0.5.tgz",
-            "integrity": "sha512-Hs59xBNfUIunMFgWAbGX5cq6893IbWg4KnrjbYwX3tx0ztorVgTDA6B2sxf8ejHJ4wz8BqGUMYlnzNBer5NvGg==",
+            "version": "7.0.6",
+            "resolved": "https://registry.npmjs.org/ignore/-/ignore-7.0.6.tgz",
+            "integrity": "sha512-BAg6QkE8W+TuQLrrw0Ugr7HegXduRuuj8/ti2kSOc+jz1dmx8/WNcjr6XGnq5YpDWxFwwaavqD0+jIUOKelTsw==",
             "license": "MIT",
             "engines": {
                 "node": ">= 4"
             }
         },
         "node_modules/@typescript-eslint/parser": {
-            "version": "8.62.1",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.62.1.tgz",
-            "integrity": "sha512-sPhE4iHuJDSvoAiec+Ro8JyXw8f0ql13HFR82P99nCm9GwTEKG0KYLvDe6REk8BCXuit6vJAv/Yxg5ABaNS2rA==",
+            "version": "8.65.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.65.0.tgz",
+            "integrity": "sha512-CZ4nMxWwgu1HEEFNkeaCptra9QCtkmKdgf3sWh1rl1trIhmxLilgTV4cwcbQ4wemnT4sWQN8CaKOmdYx+g2gMA==",
             "license": "MIT",
             "dependencies": {
-                "@typescript-eslint/scope-manager": "8.62.1",
-                "@typescript-eslint/types": "8.62.1",
-                "@typescript-eslint/typescript-estree": "8.62.1",
-                "@typescript-eslint/visitor-keys": "8.62.1",
+                "@typescript-eslint/scope-manager": "8.65.0",
+                "@typescript-eslint/types": "8.65.0",
+                "@typescript-eslint/typescript-estree": "8.65.0",
+                "@typescript-eslint/visitor-keys": "8.65.0",
                 "debug": "^4.4.3"
             },
             "engines": {
@@ -3554,13 +3528,13 @@
             }
         },
         "node_modules/@typescript-eslint/project-service": {
-            "version": "8.62.1",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/project-service/-/project-service-8.62.1.tgz",
-            "integrity": "sha512-yQ3RgY5RkSBpsNS1Bx/JQEcA24FOSdfGktoyprAr5u18390UQdtVcfnEv4nIrIshNnavlVyZBKxQwT1fIAE6cg==",
+            "version": "8.65.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/project-service/-/project-service-8.65.0.tgz",
+            "integrity": "sha512-SxnPhbTsGahizDgbu7oqFH/xVtzIqMd/s+WtnSxNxJZJpLbdT5IPdzg8EZxO3+PoKahXmwJLeNQOpKJb3/bi7Q==",
             "license": "MIT",
             "dependencies": {
-                "@typescript-eslint/tsconfig-utils": "^8.62.1",
-                "@typescript-eslint/types": "^8.62.1",
+                "@typescript-eslint/tsconfig-utils": "^8.65.0",
+                "@typescript-eslint/types": "^8.65.0",
                 "debug": "^4.4.3"
             },
             "engines": {
@@ -3575,13 +3549,13 @@
             }
         },
         "node_modules/@typescript-eslint/scope-manager": {
-            "version": "8.62.1",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.62.1.tgz",
-            "integrity": "sha512-r4d249KbQ1SFdpeStvob8Ih6aPPIzfqllPVOtvhve6ZcpuVcYo5/7zUWckKpHE7StASX4kTKZTLf0WQm/wPkcg==",
+            "version": "8.65.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.65.0.tgz",
+            "integrity": "sha512-Esbl8OSYiVxBokYgWPf7VVWg/BE798wXhimnn9ML9Pt5qoDf8bfQlgjlKXR/k98+AcNzlLKYrpCcrcuZ9DZLgg==",
             "license": "MIT",
             "dependencies": {
-                "@typescript-eslint/types": "8.62.1",
-                "@typescript-eslint/visitor-keys": "8.62.1"
+                "@typescript-eslint/types": "8.65.0",
+                "@typescript-eslint/visitor-keys": "8.65.0"
             },
             "engines": {
                 "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -3592,9 +3566,9 @@
             }
         },
         "node_modules/@typescript-eslint/tsconfig-utils": {
-            "version": "8.62.1",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.62.1.tgz",
-            "integrity": "sha512-xadytJqX9vJVQ2fdQjkcIVigwaOJNWkpjdLt6cEQ+xPnrI1fkp+/jZE/I97k9KUjqtpd25i0HeyZf3T6dutv2g==",
+            "version": "8.65.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.65.0.tgz",
+            "integrity": "sha512-j6GzGqCiRdA7Qhur2VVmKZAkBLfnHFQfx4TaJGL9RMveZqCo48jSHHO0DTgizEnGhtWnqmbtCUSrqSkdiY/0Hg==",
             "license": "MIT",
             "engines": {
                 "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -3608,14 +3582,14 @@
             }
         },
         "node_modules/@typescript-eslint/type-utils": {
-            "version": "8.62.1",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.62.1.tgz",
-            "integrity": "sha512-aXM5xlqXiTxPibXB93cLAURfT3rlizf7uMXISCXy66Isr/9hISJx3yDsKl0L7lKa51b8JpFuNKby0/O0pEm9jg==",
+            "version": "8.65.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.65.0.tgz",
+            "integrity": "sha512-YjaZ7PRI5qY7ax2L3PbvX0rRyGtipAReCWs0mhhDBHjH/vl0g0BonaGXrKdKpMbIIsMIwDgbk/xzkBTyAltS5g==",
             "license": "MIT",
             "dependencies": {
-                "@typescript-eslint/types": "8.62.1",
-                "@typescript-eslint/typescript-estree": "8.62.1",
-                "@typescript-eslint/utils": "8.62.1",
+                "@typescript-eslint/types": "8.65.0",
+                "@typescript-eslint/typescript-estree": "8.65.0",
+                "@typescript-eslint/utils": "8.65.0",
                 "debug": "^4.4.3",
                 "ts-api-utils": "^2.5.0"
             },
@@ -3632,9 +3606,9 @@
             }
         },
         "node_modules/@typescript-eslint/types": {
-            "version": "8.62.1",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.62.1.tgz",
-            "integrity": "sha512-ooCzJFaf+Hg+uG6fA3NRFGuFjlfNlDhBthbv4ZPU/0elCAFUfnyXUvf/WOpHz/jYwSmvU2GkR2LtyUfy1AxZ1Q==",
+            "version": "8.65.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.65.0.tgz",
+            "integrity": "sha512-JSSwWNy+H0E/01jJEM+hrX6N0OFDzFzeIhHFSAS01tlVaevpG8cFyYRPhS5yjGOvBUx3sqQHVMjCL1CAZZMxBg==",
             "license": "MIT",
             "engines": {
                 "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -3645,15 +3619,15 @@
             }
         },
         "node_modules/@typescript-eslint/typescript-estree": {
-            "version": "8.62.1",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.62.1.tgz",
-            "integrity": "sha512-xMcW9oP9u7fAMXYs9A65CVmtLQe2r//oXINHfi8HV+oiqhih17sbLdhXr4540YWlgpDKQdY854OL5ZrdCiQsAA==",
+            "version": "8.65.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.65.0.tgz",
+            "integrity": "sha512-JboAE2swaYt4tb1fHhHTABE2K+OLy09XfcTbhnk4Pw96f9dd2e9iYsJ28gBggHlo5z5x1rkyWvcPoTuNTd4oGg==",
             "license": "MIT",
             "dependencies": {
-                "@typescript-eslint/project-service": "8.62.1",
-                "@typescript-eslint/tsconfig-utils": "8.62.1",
-                "@typescript-eslint/types": "8.62.1",
-                "@typescript-eslint/visitor-keys": "8.62.1",
+                "@typescript-eslint/project-service": "8.65.0",
+                "@typescript-eslint/tsconfig-utils": "8.65.0",
+                "@typescript-eslint/types": "8.65.0",
+                "@typescript-eslint/visitor-keys": "8.65.0",
                 "debug": "^4.4.3",
                 "minimatch": "^10.2.2",
                 "semver": "^7.7.3",
@@ -3684,15 +3658,15 @@
             }
         },
         "node_modules/@typescript-eslint/utils": {
-            "version": "8.62.1",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.62.1.tgz",
-            "integrity": "sha512-sHtbPfuKNZCG+ih8SyjjucqRntSVmp8XgL5u6o9mAhiSn8ds5o/M/XdM0abweme2Tln3szOstOrZ9OXitvPh0g==",
+            "version": "8.65.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.65.0.tgz",
+            "integrity": "sha512-gXiwIHsYreboxeJucHKPvgwl7dXt50mF8s1/c00cP/WoVTyWKFdtfhRWwZiXYFU5H2O8vVoSLNrexFZjYS/SGA==",
             "license": "MIT",
             "dependencies": {
                 "@eslint-community/eslint-utils": "^4.9.1",
-                "@typescript-eslint/scope-manager": "8.62.1",
-                "@typescript-eslint/types": "8.62.1",
-                "@typescript-eslint/typescript-estree": "8.62.1"
+                "@typescript-eslint/scope-manager": "8.65.0",
+                "@typescript-eslint/types": "8.65.0",
+                "@typescript-eslint/typescript-estree": "8.65.0"
             },
             "engines": {
                 "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -3707,12 +3681,12 @@
             }
         },
         "node_modules/@typescript-eslint/visitor-keys": {
-            "version": "8.62.1",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.62.1.tgz",
-            "integrity": "sha512-4g3BLxfdTMy8iZG0MaBkadnlRrCJ74cQiFbyEVMrkwIoqdyaXXQM22cotDvrl4x28wgIZ9rEJRoM+mmhSJpJ1g==",
+            "version": "8.65.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.65.0.tgz",
+            "integrity": "sha512-8C71BQkGjiMmXtop7pHVJu1l2NNShFdkCyD6a2ezzs5vU/L3LRtb69EtcteFwz0mYMPzIgOw0n6OV4VBUWZd7A==",
             "license": "MIT",
             "dependencies": {
-                "@typescript-eslint/types": "8.62.1",
+                "@typescript-eslint/types": "8.65.0",
                 "eslint-visitor-keys": "^5.0.0"
             },
             "engines": {
@@ -3736,9 +3710,9 @@
             }
         },
         "node_modules/@ungap/structured-clone": {
-            "version": "1.3.2",
-            "resolved": "https://registry.npmjs.org/@ungap/structured-clone/-/structured-clone-1.3.2.tgz",
-            "integrity": "sha512-5jsZFwgR5rTdKwidH9Qmat75RKwqfpKlWWB1frDkljN127mwqBu8K0PYo7/hFpF03IEJpfVPpCQDY/eDx3iHvA==",
+            "version": "1.3.3",
+            "resolved": "https://registry.npmjs.org/@ungap/structured-clone/-/structured-clone-1.3.3.tgz",
+            "integrity": "sha512-60YRaenCQcVjYEKOcG824+DRGGIQ3VKErcBoAEDJZz5bKIs2ZG+X/H9Nk+Q6EVkwJk5QNApxbrc5QtBSwtrXAg==",
             "license": "ISC"
         },
         "node_modules/@unrs/resolver-binding-android-arm-eabi": {
@@ -4053,16 +4027,16 @@
             }
         },
         "node_modules/@vitest/expect": {
-            "version": "4.1.9",
-            "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.9.tgz",
-            "integrity": "sha512-vl/rYsUKcBr3SnQn166+XR5ZQcgMx3DQhFWdfli/cWpLnLUmbxZvyrJZotLFUryib+LtArYMSTJ5RbQ57ZqrlA==",
+            "version": "4.1.10",
+            "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.10.tgz",
+            "integrity": "sha512-YsCn+qAk1GWjQOWFEsEcL2gNQ0zmVmQu3T03qP6UyjhtmdtwtbuI+DASn/7iQB3HGTXkdBwGddzxPlmiql5vlA==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
                 "@standard-schema/spec": "^1.1.0",
                 "@types/chai": "^5.2.2",
-                "@vitest/spy": "4.1.9",
-                "@vitest/utils": "4.1.9",
+                "@vitest/spy": "4.1.10",
+                "@vitest/utils": "4.1.10",
                 "chai": "^6.2.2",
                 "tinyrainbow": "^3.1.0"
             },
@@ -4071,9 +4045,9 @@
             }
         },
         "node_modules/@vitest/pretty-format": {
-            "version": "4.1.9",
-            "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.9.tgz",
-            "integrity": "sha512-s0iufns3iIFitdgm+YR7g1whCAaGtXz459VS9/PqyKDEEFgYIhsHOQmXgIgDuYCt7DeQmiZT0Qe2OA2p4ZPu5A==",
+            "version": "4.1.10",
+            "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.10.tgz",
+            "integrity": "sha512-W1HsjSH4MXQ9YfmmhLAoIYf1HRfekQCGngeIgcei6MP5QQGWUe0gkopdZQaVCFO+JDJMrAJGwa5pRpNpvy4P8Q==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -4084,13 +4058,13 @@
             }
         },
         "node_modules/@vitest/runner": {
-            "version": "4.1.9",
-            "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.1.9.tgz",
-            "integrity": "sha512-KXLMDtc7oe70+3mJfGrPUWPesswH+3sTxAMAMl8DG7I8IUQT4XW718dY5ID3vPUcmlu27CcKfY4P3h3I29SLJg==",
+            "version": "4.1.10",
+            "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.1.10.tgz",
+            "integrity": "sha512-IKI6kpIH+LmpROplyLwBBaCfMgOZOMsygVa6BARD6ahA04VRuJSa6OaVG7kRvSEMD870Vd91rSSw0eegtWyLGg==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@vitest/utils": "4.1.9",
+                "@vitest/utils": "4.1.10",
                 "pathe": "^2.0.3"
             },
             "funding": {
@@ -4098,14 +4072,14 @@
             }
         },
         "node_modules/@vitest/snapshot": {
-            "version": "4.1.9",
-            "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.1.9.tgz",
-            "integrity": "sha512-Jc7RKGNBo8Z28WYIm0Niej4xdSPByRf6mU58VpHQkd6Zh05rlnA+twjbK5HyeIGHxrzsc3mJgS43uM0CZKzaIA==",
+            "version": "4.1.10",
+            "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.1.10.tgz",
+            "integrity": "sha512-xRkfOT1qpTAi/Ti4Y1LtfRc3kEuqxGw59eN2jN9pRWMtS/XDevekhcFSqvQqjUNGksfjMJu3Y+oJ+4Ypn2OaJw==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@vitest/pretty-format": "4.1.9",
-                "@vitest/utils": "4.1.9",
+                "@vitest/pretty-format": "4.1.10",
+                "@vitest/utils": "4.1.10",
                 "magic-string": "^0.30.21",
                 "pathe": "^2.0.3"
             },
@@ -4114,9 +4088,9 @@
             }
         },
         "node_modules/@vitest/spy": {
-            "version": "4.1.9",
-            "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.1.9.tgz",
-            "integrity": "sha512-fHpsS6mIi+PiEW+vcRVOMkX1oSaPKne3VOclSFICPcGOmfKgXPU5iAah+wcNcj2xPrCCmfq99IDGf+EojhhvhA==",
+            "version": "4.1.10",
+            "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.1.10.tgz",
+            "integrity": "sha512-PLf/Ugvoq5wO/b4rwYCR1h2PSIdXz7wnkQFMiUpLdtM7l6pqVFcQIBEHyT1+l+cj7mNwAfZHzqXqDyjvOuwbDw==",
             "dev": true,
             "license": "MIT",
             "funding": {
@@ -4124,13 +4098,13 @@
             }
         },
         "node_modules/@vitest/utils": {
-            "version": "4.1.9",
-            "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.1.9.tgz",
-            "integrity": "sha512-A51o8ymO5PpqlWNnBP9ZHPXDIpuMtTLlGSjN7la4US+LJzoUMyhwjA5QXlm39JexgwHKW4Xjs8Z2d3dLCXOeuA==",
+            "version": "4.1.10",
+            "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.1.10.tgz",
+            "integrity": "sha512-fy9am/HWxbaGt/Sawrp90vt6Y6jQwf1RX77cz3uwoJwJVMli/e1IEwRPnMNJ7vKfPTwo0diXifkpPvwH9v7nGA==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@vitest/pretty-format": "4.1.9",
+                "@vitest/pretty-format": "4.1.10",
                 "convert-source-map": "^2.0.0",
                 "tinyrainbow": "^3.1.0"
             },
@@ -4344,19 +4318,6 @@
             },
             "engines": {
                 "node": ">=0.4.0"
-            }
-        },
-        "node_modules/acorn-import-phases": {
-            "version": "1.0.4",
-            "resolved": "https://registry.npmjs.org/acorn-import-phases/-/acorn-import-phases-1.0.4.tgz",
-            "integrity": "sha512-wKmbr/DDiIXzEOiWrTTUcDm24kQ2vGfZQvM2fwg2vXqR5uW6aapr7ObPtj1th32b9u90/Pf4AItvdTh42fBmVQ==",
-            "devOptional": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">=10.13.0"
-            },
-            "peerDependencies": {
-                "acorn": "^8.14.0"
             }
         },
         "node_modules/acorn-jsx": {
@@ -4745,9 +4706,9 @@
             }
         },
         "node_modules/baseline-browser-mapping": {
-            "version": "2.10.41",
-            "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.41.tgz",
-            "integrity": "sha512-WwS7MHhqGHHlaVsqRZnhvCEMS0owDX+SxRlve7JkuH7My1Ara3ZriTmCQupPfYjxMZ8I/tgxtJYr2t7taHaH4A==",
+            "version": "2.11.4",
+            "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.11.4.tgz",
+            "integrity": "sha512-s4+sLr9mZ/CyqeRritFeYV/Zx73OAtmaHn6kkBS1XRoJn1hrg3xIDUcpicAEX68tkcIN0iBCgti31C8zxtkhsQ==",
             "license": "Apache-2.0",
             "bin": {
                 "baseline-browser-mapping": "dist/cli.cjs"
@@ -4780,9 +4741,9 @@
             }
         },
         "node_modules/body-parser": {
-            "version": "1.20.5",
-            "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.20.5.tgz",
-            "integrity": "sha512-3grm+/2tUOvu2cjJkvsIxrv/wVpfXQW4PsQHYm7yk4vfpu7Ekl6nEsYBoJUL6qDwZUx8wUhQ8tR2qz+ad9c9OA==",
+            "version": "1.20.6",
+            "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.20.6.tgz",
+            "integrity": "sha512-p5tAzS57i5MV9fZFDj9LeIiTZEufbSe2eDozP+ElheSUq1m74CRq1jI4mYNDdVs9vQztXFLuk/Gd6BWTdwRJ5g==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -4828,15 +4789,15 @@
             "license": "ISC"
         },
         "node_modules/brace-expansion": {
-            "version": "5.0.7",
-            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.7.tgz",
-            "integrity": "sha512-7oFy703dxfY3/NLxC1fh2SUCQ0H9rmAY+5EpDVfXjUTTs+HEwR2nYaqLv+GWcTsumwxPfiz6CzCNkwXwBUwqCA==",
+            "version": "5.0.8",
+            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.8.tgz",
+            "integrity": "sha512-JZyDyq3D4AUifKTPOB7DELf6XsB3WdPuNxCtob1vFXPsSXhdAiHBWJ/tJ8HAc9aH84BK+5JFZLNkJKx3G9kzQg==",
             "license": "MIT",
             "dependencies": {
                 "balanced-match": "^4.0.2"
             },
             "engines": {
-                "node": "18 || 20 || >=22"
+                "node": "20 || >=22"
             }
         },
         "node_modules/braces": {
@@ -4852,9 +4813,9 @@
             }
         },
         "node_modules/browserslist": {
-            "version": "4.28.4",
-            "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.28.4.tgz",
-            "integrity": "sha512-MTc8i/x9jBQd1iMw2CFGS+rwMa07eYjLR0CCTLDACl9xhxy+nIs3KeML/biicXtk9JrZ6dnnTatmc7ErPXIxqw==",
+            "version": "4.28.7",
+            "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.28.7.tgz",
+            "integrity": "sha512-JxV13hNrFxqjOc8alRbq9dK1MM79NEXYpma2B2J4wAtpWS5zIEIKqWPGCl7N4o7Uc7B7itylh7SuDujATRyyTw==",
             "funding": [
                 {
                     "type": "opencollective",
@@ -4871,10 +4832,10 @@
             ],
             "license": "MIT",
             "dependencies": {
-                "baseline-browser-mapping": "^2.10.38",
-                "caniuse-lite": "^1.0.30001799",
-                "electron-to-chromium": "^1.5.376",
-                "node-releases": "^2.0.48",
+                "baseline-browser-mapping": "^2.10.44",
+                "caniuse-lite": "^1.0.30001806",
+                "electron-to-chromium": "^1.5.393",
+                "node-releases": "^2.0.51",
                 "update-browserslist-db": "^1.2.3"
             },
             "bin": {
@@ -4958,9 +4919,9 @@
             }
         },
         "node_modules/caniuse-lite": {
-            "version": "1.0.30001800",
-            "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001800.tgz",
-            "integrity": "sha512-MMHtuAz9Ys840zAY5F4k6fV5GaivZ9sPk+nz0mY+GYVzRBnYkN0mpqkSR92oWRQ19yQWo4HvBV/FnC16AJX8MA==",
+            "version": "1.0.30001806",
+            "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001806.tgz",
+            "integrity": "sha512-72Cuvd95zbSYPKq6Fhg8eDJRlzgWDf7/mtoZv6Qe/DYNCEBdNxoA3+rZAU2ZhGCpZlns3EssFavaZomckT5Uuw==",
             "funding": [
                 {
                     "type": "opencollective",
@@ -5165,6 +5126,31 @@
             },
             "engines": {
                 "node": ">=20"
+            }
+        },
+        "node_modules/cliui/node_modules/emoji-regex": {
+            "version": "10.6.0",
+            "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-10.6.0.tgz",
+            "integrity": "sha512-toUI84YS5YmxW219erniWD0CIVOo46xGKColeNQRgOzDorgBi1v4D71/OFzgD9GO2UGKIv1C3Sp8DAn0+j5w7A==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/cliui/node_modules/string-width": {
+            "version": "7.2.0",
+            "resolved": "https://registry.npmjs.org/string-width/-/string-width-7.2.0.tgz",
+            "integrity": "sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "emoji-regex": "^10.3.0",
+                "get-east-asian-width": "^1.0.0",
+                "strip-ansi": "^7.1.0"
+            },
+            "engines": {
+                "node": ">=18"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
             }
         },
         "node_modules/cloudflare-video-element": {
@@ -5714,9 +5700,9 @@
             "license": "MIT"
         },
         "node_modules/electron-to-chromium": {
-            "version": "1.5.385",
-            "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.385.tgz",
-            "integrity": "sha512-78sa/M08MNAYHQfjoWMvOlKQqZ0ElhSm/L5HNUc96VZ3b+KvDVnngFm8sYQy0XrhTRgAhggHr5abA7yTvRdo4Q==",
+            "version": "1.5.396",
+            "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.396.tgz",
+            "integrity": "sha512-yHiw2Y3C3H9U6TMbOfoWK/BPreiOPXRfTWPBwQBoZG6/8TB6eOPnsy5oaRYuatR7Fw2SJ4kKforgufeo7fq0EQ==",
             "license": "ISC"
         },
         "node_modules/emoji-regex": {
@@ -5736,9 +5722,9 @@
             }
         },
         "node_modules/enhanced-resolve": {
-            "version": "5.24.1",
-            "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.24.1.tgz",
-            "integrity": "sha512-7DdUaTjmNwMcH2gLr1qycesKII3BK4RLy/mdAb7x10Lq7bR4aNKHt1BR1ZALSv0rPM/hF5wYF0PhGop/rJm8vw==",
+            "version": "5.24.3",
+            "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.24.3.tgz",
+            "integrity": "sha512-PwKooW9JUzh5chmYfHM3IQl5OkK2u2Nm011MgeZrss3JmFraUx/fqrf78kk8GUMYoibx/14MdwTl/1WKkG7TpQ==",
             "devOptional": true,
             "license": "MIT",
             "dependencies": {
@@ -5875,9 +5861,9 @@
             }
         },
         "node_modules/es-iterator-helpers": {
-            "version": "1.3.3",
-            "resolved": "https://registry.npmjs.org/es-iterator-helpers/-/es-iterator-helpers-1.3.3.tgz",
-            "integrity": "sha512-0PuBxFi+4uPanB97iDxCLWuHeYud2FALrw5HFZGtAF38UpJDbDC8frwp2cnDyae692CQ0dou60UwWfhgsa4U/g==",
+            "version": "1.4.0",
+            "resolved": "https://registry.npmjs.org/es-iterator-helpers/-/es-iterator-helpers-1.4.0.tgz",
+            "integrity": "sha512-c/A0P0oxkACDc+cKWw8evLXK83oBKgn0qPOqCYT4x9uolpCIJAcYvJC9QYKNDRPsTeGyCrQ326jrvgZWdCdK5Q==",
             "license": "MIT",
             "dependencies": {
                 "call-bind": "^1.0.9",
@@ -5902,9 +5888,9 @@
             }
         },
         "node_modules/es-module-lexer": {
-            "version": "2.3.0",
-            "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.3.0.tgz",
-            "integrity": "sha512-KLdwQm2NvGLDkQDCGvmiQrhkd0JbMzXthwQAUgWjQuQdBLFa3eiBP5arXZyA+f8x+x7OXgud6bq2rxjGtHV2tw==",
+            "version": "2.3.1",
+            "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.3.1.tgz",
+            "integrity": "sha512-shc1dbU90Yl/xq1QrC7QRtfcwURZuVRfPhZbDoldJ1cn1gzDvBaBWlv0eFolj5+0znnPJz5TXLxsN77X/12KTA==",
             "devOptional": true,
             "license": "MIT"
         },
@@ -6070,9 +6056,9 @@
             }
         },
         "node_modules/eslint": {
-            "version": "9.39.4",
-            "resolved": "https://registry.npmjs.org/eslint/-/eslint-9.39.4.tgz",
-            "integrity": "sha512-XoMjdBOwe/esVgEvLmNsD3IRHkm7fbKIUGvrleloJXUZgDHig2IPWNniv+GwjyJXzuNqVjlr5+4yVUZjycJwfQ==",
+            "version": "9.39.5",
+            "resolved": "https://registry.npmjs.org/eslint/-/eslint-9.39.5.tgz",
+            "integrity": "sha512-DgZS62aPLXKlnxILS/AYCoRvHaZeXceIzlXPkkGGzJWSow1aEk0lbTlxUSlyjC8jcaKxAdOnTDz+o1JFSBsyjw==",
             "license": "MIT",
             "peer": true,
             "dependencies": {
@@ -6081,8 +6067,8 @@
                 "@eslint/config-array": "^0.21.2",
                 "@eslint/config-helpers": "^0.4.2",
                 "@eslint/core": "^0.17.0",
-                "@eslint/eslintrc": "^3.3.5",
-                "@eslint/js": "9.39.4",
+                "@eslint/eslintrc": "^3.3.6",
+                "@eslint/js": "9.39.5",
                 "@eslint/plugin-kit": "^0.4.1",
                 "@humanfs/node": "^0.16.6",
                 "@humanwhocodes/module-importer": "^1.0.1",
@@ -6130,12 +6116,12 @@
             }
         },
         "node_modules/eslint-config-next": {
-            "version": "16.2.10",
-            "resolved": "https://registry.npmjs.org/eslint-config-next/-/eslint-config-next-16.2.10.tgz",
-            "integrity": "sha512-HSybLOY0QKf39i4FWUqPN0xWiNDi6A6UqJmZtgDkS3zMqjXTqULvj/sueXx3cdCG0mVG+qH6k5/qdegklH1d1w==",
+            "version": "16.2.12",
+            "resolved": "https://registry.npmjs.org/eslint-config-next/-/eslint-config-next-16.2.12.tgz",
+            "integrity": "sha512-iaaf4vvKo5h2LBdGt0JuRv7t0Ysqr9FMCiFxbptDg8LqOE//mIKR80DdpOnSVM7qjLH3jT8P0aFiwXxBEGZRXw==",
             "license": "MIT",
             "dependencies": {
-                "@next/eslint-plugin-next": "16.2.10",
+                "@next/eslint-plugin-next": "16.2.12",
                 "eslint-import-resolver-node": "^0.3.6",
                 "eslint-import-resolver-typescript": "^3.5.2",
                 "eslint-plugin-import": "^2.32.0",
@@ -6298,9 +6284,9 @@
             "license": "MIT"
         },
         "node_modules/eslint-plugin-import/node_modules/brace-expansion": {
-            "version": "1.1.15",
-            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.15.tgz",
-            "integrity": "sha512-EwOCDEex4quD37XhqM3omwtMoJjr//isUZz1JopUNWms+4Z2ViyM/k1YIRePpoVNnQhENnxtFjLaxNHrT7xIUg==",
+            "version": "1.1.16",
+            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.16.tgz",
+            "integrity": "sha512-IDw48K2/2kRkg9LdJxurvq3lV3aBgq0REY89duEqFRthjlPdXHKMj7EnQOXVckxzgisinf3nHfrcE2FufFLXMw==",
             "license": "MIT",
             "dependencies": {
                 "balanced-match": "^1.0.0",
@@ -6364,9 +6350,9 @@
             "license": "MIT"
         },
         "node_modules/eslint-plugin-jsx-a11y/node_modules/brace-expansion": {
-            "version": "1.1.15",
-            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.15.tgz",
-            "integrity": "sha512-EwOCDEex4quD37XhqM3omwtMoJjr//isUZz1JopUNWms+4Z2ViyM/k1YIRePpoVNnQhENnxtFjLaxNHrT7xIUg==",
+            "version": "1.1.16",
+            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.16.tgz",
+            "integrity": "sha512-IDw48K2/2kRkg9LdJxurvq3lV3aBgq0REY89duEqFRthjlPdXHKMj7EnQOXVckxzgisinf3nHfrcE2FufFLXMw==",
             "license": "MIT",
             "dependencies": {
                 "balanced-match": "^1.0.0",
@@ -6443,9 +6429,9 @@
             "license": "MIT"
         },
         "node_modules/eslint-plugin-react/node_modules/brace-expansion": {
-            "version": "1.1.15",
-            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.15.tgz",
-            "integrity": "sha512-EwOCDEex4quD37XhqM3omwtMoJjr//isUZz1JopUNWms+4Z2ViyM/k1YIRePpoVNnQhENnxtFjLaxNHrT7xIUg==",
+            "version": "1.1.16",
+            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.16.tgz",
+            "integrity": "sha512-IDw48K2/2kRkg9LdJxurvq3lV3aBgq0REY89duEqFRthjlPdXHKMj7EnQOXVckxzgisinf3nHfrcE2FufFLXMw==",
             "license": "MIT",
             "dependencies": {
                 "balanced-match": "^1.0.0",
@@ -6525,9 +6511,9 @@
             "peer": true
         },
         "node_modules/eslint/node_modules/brace-expansion": {
-            "version": "1.1.15",
-            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.15.tgz",
-            "integrity": "sha512-EwOCDEex4quD37XhqM3omwtMoJjr//isUZz1JopUNWms+4Z2ViyM/k1YIRePpoVNnQhENnxtFjLaxNHrT7xIUg==",
+            "version": "1.1.16",
+            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.16.tgz",
+            "integrity": "sha512-IDw48K2/2kRkg9LdJxurvq3lV3aBgq0REY89duEqFRthjlPdXHKMj7EnQOXVckxzgisinf3nHfrcE2FufFLXMw==",
             "license": "MIT",
             "peer": true,
             "dependencies": {
@@ -6885,9 +6871,9 @@
             "peer": true
         },
         "node_modules/fast-uri": {
-            "version": "3.1.3",
-            "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.3.tgz",
-            "integrity": "sha512-i70LwGWUduXqzicKXWshooq+sWL1K3WUU5rKZNG/0i3a1OSoX3HqhH5WbWwTmqWfor4urUakGPiRQcleRZTwOg==",
+            "version": "3.1.4",
+            "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.4.tgz",
+            "integrity": "sha512-8JnbkQ4juDyvYs4mgFGQqg4yCYtFDtUtmp2QIQq11ZZe5CFQ5wcqm1rqDgAh/QdMySuBnPzMUiJUNZG5N/AiQw==",
             "devOptional": true,
             "funding": [
                 {
@@ -7009,9 +6995,9 @@
             }
         },
         "node_modules/flatted": {
-            "version": "3.4.2",
-            "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.4.2.tgz",
-            "integrity": "sha512-PjDse7RzhcPkIJwy5t7KPWQSZ9cAbzQXcafsetQoD7sOJRQlGikNbx7yZp2OotDnJyrDcbyRq3Ttb18iYOqkxA==",
+            "version": "3.4.3",
+            "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.4.3.tgz",
+            "integrity": "sha512-/zipXxyO6rGvuNGDiULY9MvEGSkb2gaG4GGH4ygMi0ZZzyMHdUZBmntJmx5x1G2VuPytCwGN4xsJP6cw+sK+vQ==",
             "license": "ISC",
             "peer": true
         },
@@ -7330,9 +7316,9 @@
             }
         },
         "node_modules/globby/node_modules/ignore": {
-            "version": "7.0.5",
-            "resolved": "https://registry.npmjs.org/ignore/-/ignore-7.0.5.tgz",
-            "integrity": "sha512-Hs59xBNfUIunMFgWAbGX5cq6893IbWg4KnrjbYwX3tx0ztorVgTDA6B2sxf8ejHJ4wz8BqGUMYlnzNBer5NvGg==",
+            "version": "7.0.6",
+            "resolved": "https://registry.npmjs.org/ignore/-/ignore-7.0.6.tgz",
+            "integrity": "sha512-BAg6QkE8W+TuQLrrw0Ugr7HegXduRuuj8/ti2kSOc+jz1dmx8/WNcjr6XGnq5YpDWxFwwaavqD0+jIUOKelTsw==",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -8748,9 +8734,9 @@
             }
         },
         "node_modules/lightningcss": {
-            "version": "1.32.0",
-            "resolved": "https://registry.npmjs.org/lightningcss/-/lightningcss-1.32.0.tgz",
-            "integrity": "sha512-NXYBzinNrblfraPGyrbPoD19C1h9lfI/1mzgWYvXUTe414Gz/X1FD2XBZSZM7rRTrMA8JL3OtAaGifrIKhQ5yQ==",
+            "version": "1.33.0",
+            "resolved": "https://registry.npmjs.org/lightningcss/-/lightningcss-1.33.0.tgz",
+            "integrity": "sha512-WkUDrojuJs0xkgGf2udWxa3yGBRxPtxUkB79i6aCZLRgc7PM8fZe9TosfPDcvEpQZbuFASnHYmRLBLUbmLOIIA==",
             "dev": true,
             "license": "MPL-2.0",
             "dependencies": {
@@ -8764,23 +8750,23 @@
                 "url": "https://opencollective.com/parcel"
             },
             "optionalDependencies": {
-                "lightningcss-android-arm64": "1.32.0",
-                "lightningcss-darwin-arm64": "1.32.0",
-                "lightningcss-darwin-x64": "1.32.0",
-                "lightningcss-freebsd-x64": "1.32.0",
-                "lightningcss-linux-arm-gnueabihf": "1.32.0",
-                "lightningcss-linux-arm64-gnu": "1.32.0",
-                "lightningcss-linux-arm64-musl": "1.32.0",
-                "lightningcss-linux-x64-gnu": "1.32.0",
-                "lightningcss-linux-x64-musl": "1.32.0",
-                "lightningcss-win32-arm64-msvc": "1.32.0",
-                "lightningcss-win32-x64-msvc": "1.32.0"
+                "lightningcss-android-arm64": "1.33.0",
+                "lightningcss-darwin-arm64": "1.33.0",
+                "lightningcss-darwin-x64": "1.33.0",
+                "lightningcss-freebsd-x64": "1.33.0",
+                "lightningcss-linux-arm-gnueabihf": "1.33.0",
+                "lightningcss-linux-arm64-gnu": "1.33.0",
+                "lightningcss-linux-arm64-musl": "1.33.0",
+                "lightningcss-linux-x64-gnu": "1.33.0",
+                "lightningcss-linux-x64-musl": "1.33.0",
+                "lightningcss-win32-arm64-msvc": "1.33.0",
+                "lightningcss-win32-x64-msvc": "1.33.0"
             }
         },
         "node_modules/lightningcss-android-arm64": {
-            "version": "1.32.0",
-            "resolved": "https://registry.npmjs.org/lightningcss-android-arm64/-/lightningcss-android-arm64-1.32.0.tgz",
-            "integrity": "sha512-YK7/ClTt4kAK0vo6w3X+Pnm0D2cf2vPHbhOXdoNti1Ga0al1P4TBZhwjATvjNwLEBCnKvjJc2jQgHXH0NEwlAg==",
+            "version": "1.33.0",
+            "resolved": "https://registry.npmjs.org/lightningcss-android-arm64/-/lightningcss-android-arm64-1.33.0.tgz",
+            "integrity": "sha512-gEpRTalKdosp4Bb8qWtc2iOgE5SeIHlpS1up9bFq2wAyYhl1UdTObYiHe98zEM9SQvSoqQZ1IQD0JNpg3Ml5pg==",
             "cpu": [
                 "arm64"
             ],
@@ -8799,9 +8785,9 @@
             }
         },
         "node_modules/lightningcss-darwin-arm64": {
-            "version": "1.32.0",
-            "resolved": "https://registry.npmjs.org/lightningcss-darwin-arm64/-/lightningcss-darwin-arm64-1.32.0.tgz",
-            "integrity": "sha512-RzeG9Ju5bag2Bv1/lwlVJvBE3q6TtXskdZLLCyfg5pt+HLz9BqlICO7LZM7VHNTTn/5PRhHFBSjk5lc4cmscPQ==",
+            "version": "1.33.0",
+            "resolved": "https://registry.npmjs.org/lightningcss-darwin-arm64/-/lightningcss-darwin-arm64-1.33.0.tgz",
+            "integrity": "sha512-Sciaz8eenNTKn9b3t7+xr0ipTp9YxKQY4npwQ3mrRuL0BAVHBLyZxofhaKBAVtzmtRZ/zTyo0/to4B1uWG/Djg==",
             "cpu": [
                 "arm64"
             ],
@@ -8820,9 +8806,9 @@
             }
         },
         "node_modules/lightningcss-darwin-x64": {
-            "version": "1.32.0",
-            "resolved": "https://registry.npmjs.org/lightningcss-darwin-x64/-/lightningcss-darwin-x64-1.32.0.tgz",
-            "integrity": "sha512-U+QsBp2m/s2wqpUYT/6wnlagdZbtZdndSmut/NJqlCcMLTWp5muCrID+K5UJ6jqD2BFshejCYXniPDbNh73V8w==",
+            "version": "1.33.0",
+            "resolved": "https://registry.npmjs.org/lightningcss-darwin-x64/-/lightningcss-darwin-x64-1.33.0.tgz",
+            "integrity": "sha512-Z5UPAxzrjlWNNyGy6i65cJzzvgJ5D3T6wMvs+gWpY9d7qRhANrxqAp6LhxIgZhWEw18RfJTGcRxjuLIBr+m8XQ==",
             "cpu": [
                 "x64"
             ],
@@ -8841,9 +8827,9 @@
             }
         },
         "node_modules/lightningcss-freebsd-x64": {
-            "version": "1.32.0",
-            "resolved": "https://registry.npmjs.org/lightningcss-freebsd-x64/-/lightningcss-freebsd-x64-1.32.0.tgz",
-            "integrity": "sha512-JCTigedEksZk3tHTTthnMdVfGf61Fky8Ji2E4YjUTEQX14xiy/lTzXnu1vwiZe3bYe0q+SpsSH/CTeDXK6WHig==",
+            "version": "1.33.0",
+            "resolved": "https://registry.npmjs.org/lightningcss-freebsd-x64/-/lightningcss-freebsd-x64-1.33.0.tgz",
+            "integrity": "sha512-QQM/Ti/hQajJwCY+RiWuCZ9sdtI/XQk7nDK5vC8kkdwixezOlDgvDx7+RT+QjK6FcFT4MpsuoBnHIo/O3StRRg==",
             "cpu": [
                 "x64"
             ],
@@ -8862,9 +8848,9 @@
             }
         },
         "node_modules/lightningcss-linux-arm-gnueabihf": {
-            "version": "1.32.0",
-            "resolved": "https://registry.npmjs.org/lightningcss-linux-arm-gnueabihf/-/lightningcss-linux-arm-gnueabihf-1.32.0.tgz",
-            "integrity": "sha512-x6rnnpRa2GL0zQOkt6rts3YDPzduLpWvwAF6EMhXFVZXD4tPrBkEFqzGowzCsIWsPjqSK+tyNEODUBXeeVHSkw==",
+            "version": "1.33.0",
+            "resolved": "https://registry.npmjs.org/lightningcss-linux-arm-gnueabihf/-/lightningcss-linux-arm-gnueabihf-1.33.0.tgz",
+            "integrity": "sha512-N7FVBe6iS24MlM6R/4RBTxGhQheZGs7tiQ9U32UtF75NzP5Q7xWPRqLBCKxlRQRk3rY1jCIPLzx7WzOhuUIRLQ==",
             "cpu": [
                 "arm"
             ],
@@ -8883,9 +8869,9 @@
             }
         },
         "node_modules/lightningcss-linux-arm64-gnu": {
-            "version": "1.32.0",
-            "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-gnu/-/lightningcss-linux-arm64-gnu-1.32.0.tgz",
-            "integrity": "sha512-0nnMyoyOLRJXfbMOilaSRcLH3Jw5z9HDNGfT/gwCPgaDjnx0i8w7vBzFLFR1f6CMLKF8gVbebmkUN3fa/kQJpQ==",
+            "version": "1.33.0",
+            "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-gnu/-/lightningcss-linux-arm64-gnu-1.33.0.tgz",
+            "integrity": "sha512-j2v/itmy4HlNxlc6voKXYgBqNi0Ng2LShg4z7GufpEgs05P+2suBVyi9I6YHq5uoVFx9ETin3eCEhLVyXGQnKg==",
             "cpu": [
                 "arm64"
             ],
@@ -8904,9 +8890,9 @@
             }
         },
         "node_modules/lightningcss-linux-arm64-musl": {
-            "version": "1.32.0",
-            "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-musl/-/lightningcss-linux-arm64-musl-1.32.0.tgz",
-            "integrity": "sha512-UpQkoenr4UJEzgVIYpI80lDFvRmPVg6oqboNHfoH4CQIfNA+HOrZ7Mo7KZP02dC6LjghPQJeBsvXhJod/wnIBg==",
+            "version": "1.33.0",
+            "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-musl/-/lightningcss-linux-arm64-musl-1.33.0.tgz",
+            "integrity": "sha512-yiO5ROMuYQgXbC60yjZU5CYSFZGKXL0HFATXt9mHJn1+zW55oCtMI9NfcVhYLMFDL7gV7oBPon/EmMMGg2OvtQ==",
             "cpu": [
                 "arm64"
             ],
@@ -8925,9 +8911,9 @@
             }
         },
         "node_modules/lightningcss-linux-x64-gnu": {
-            "version": "1.32.0",
-            "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-gnu/-/lightningcss-linux-x64-gnu-1.32.0.tgz",
-            "integrity": "sha512-V7Qr52IhZmdKPVr+Vtw8o+WLsQJYCTd8loIfpDaMRWGUZfBOYEJeyJIkqGIDMZPwPx24pUMfwSxxI8phr/MbOA==",
+            "version": "1.33.0",
+            "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-gnu/-/lightningcss-linux-x64-gnu-1.33.0.tgz",
+            "integrity": "sha512-ar+Ju7LmcN0Jo4FpL4hpFybwNG9/3A/Br5KW2n2jyODg3MEZXaDYADdemoNS+BDNfMgKvylJLj4S5tyRActuAg==",
             "cpu": [
                 "x64"
             ],
@@ -8946,9 +8932,9 @@
             }
         },
         "node_modules/lightningcss-linux-x64-musl": {
-            "version": "1.32.0",
-            "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-musl/-/lightningcss-linux-x64-musl-1.32.0.tgz",
-            "integrity": "sha512-bYcLp+Vb0awsiXg/80uCRezCYHNg1/l3mt0gzHnWV9XP1W5sKa5/TCdGWaR/zBM2PeF/HbsQv/j2URNOiVuxWg==",
+            "version": "1.33.0",
+            "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-musl/-/lightningcss-linux-x64-musl-1.33.0.tgz",
+            "integrity": "sha512-RYiYbkokw0trfKqqzfF55lginwEPrD3OJDfTuJzFs1MK6iFnDenaz1fqLLtX4ITG3OktJQXOeTaw1awrBAlZPw==",
             "cpu": [
                 "x64"
             ],
@@ -8967,9 +8953,9 @@
             }
         },
         "node_modules/lightningcss-win32-arm64-msvc": {
-            "version": "1.32.0",
-            "resolved": "https://registry.npmjs.org/lightningcss-win32-arm64-msvc/-/lightningcss-win32-arm64-msvc-1.32.0.tgz",
-            "integrity": "sha512-8SbC8BR40pS6baCM8sbtYDSwEVQd4JlFTOlaD3gWGHfThTcABnNDBda6eTZeqbofalIJhFx0qKzgHJmcPTnGdw==",
+            "version": "1.33.0",
+            "resolved": "https://registry.npmjs.org/lightningcss-win32-arm64-msvc/-/lightningcss-win32-arm64-msvc-1.33.0.tgz",
+            "integrity": "sha512-1K+MPfLSFVpphzpdbfkhlWk6wBrTObBzS2T6db10PNOZgR9GoVsAWzwNyuhUYYbTp23j+4RrncfujZ4uAzXvwA==",
             "cpu": [
                 "arm64"
             ],
@@ -8988,9 +8974,9 @@
             }
         },
         "node_modules/lightningcss-win32-x64-msvc": {
-            "version": "1.32.0",
-            "resolved": "https://registry.npmjs.org/lightningcss-win32-x64-msvc/-/lightningcss-win32-x64-msvc-1.32.0.tgz",
-            "integrity": "sha512-Amq9B/SoZYdDi1kFrojnoqPLxYhQ4Wo5XiL8EVJrVsB8ARoC1PWW6VGtT0WKCemjy8aC+louJnjS7U18x3b06Q==",
+            "version": "1.33.0",
+            "resolved": "https://registry.npmjs.org/lightningcss-win32-x64-msvc/-/lightningcss-win32-x64-msvc-1.33.0.tgz",
+            "integrity": "sha512-OlEICDx/Xl0FqSp4bry8zFnCvGpig3Gl4gCquvYwHuqJKEC1+n9NgDniFvqHGmMv1ZkqDJrDqKKSykTDX+ehuA==",
             "cpu": [
                 "x64"
             ],
@@ -9045,20 +9031,6 @@
             "license": "MIT",
             "dependencies": {
                 "uc.micro": "^2.0.0"
-            }
-        },
-        "node_modules/loader-runner": {
-            "version": "4.3.2",
-            "resolved": "https://registry.npmjs.org/loader-runner/-/loader-runner-4.3.2.tgz",
-            "integrity": "sha512-DFEqQ3ihfS9blba08cLfYf1NRAIEm+dDjic073DRDc3/JspI/8wYmtDsHwd3+4hwvdxSK7PGaElfTmm0awWJ4w==",
-            "devOptional": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">=6.11.5"
-            },
-            "funding": {
-                "type": "opencollective",
-                "url": "https://opencollective.com/webpack"
             }
         },
         "node_modules/localforage": {
@@ -9551,9 +9523,9 @@
             }
         },
         "node_modules/mdurl": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/mdurl/-/mdurl-2.0.0.tgz",
-            "integrity": "sha512-Lf+9+2r+Tdp5wXDXC4PcIBjTDtq4UKjCPMQhKIuzpJNW0b96kVqSwW0bT7FhRSfmAiFYgP+SCRvdrDozfh0U5w==",
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/mdurl/-/mdurl-2.1.0.tgz",
+            "integrity": "sha512-1+HBaOx0zi/dQWht8rNv9MYf9qqpqL/kxI0hXImU6Y547zM6Sni8BQibt7ifgMcYtQg41ao3Ivd6cnSM86inpg==",
             "dev": true,
             "license": "MIT"
         },
@@ -10513,9 +10485,9 @@
             "license": "MIT"
         },
         "node_modules/modern-tar": {
-            "version": "0.7.6",
-            "resolved": "https://registry.npmjs.org/modern-tar/-/modern-tar-0.7.6.tgz",
-            "integrity": "sha512-sweCIVXzx1aIGTCdzcMlSZt1h8k5Tmk08VNAuRk3IU28XamGiOH5ypi11g6De2CH7PhYqSSnGy2A/EFhbWnVKg==",
+            "version": "0.7.7",
+            "resolved": "https://registry.npmjs.org/modern-tar/-/modern-tar-0.7.7.tgz",
+            "integrity": "sha512-t9VmxaqrmANnEOBhpSDI6HD192Ge48k8vmWqQQL7hSFEqHEYwZbbsu49+aKLWZeRvFs3j1pMhXOqqF4kPlvjkQ==",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -10535,9 +10507,9 @@
             "license": "MIT"
         },
         "node_modules/nanoid": {
-            "version": "3.3.15",
-            "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.15.tgz",
-            "integrity": "sha512-y7Wygv/7mEOvxTuEQDB8StXdMRBWf1kR/tlhAzBRUFkB2jfcLOAxO/SHmOO2zgz1pVgK29/kyupn059/bCHdjA==",
+            "version": "3.3.16",
+            "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.16.tgz",
+            "integrity": "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==",
             "funding": [
                 {
                     "type": "github",
@@ -10597,12 +10569,12 @@
             "license": "MIT"
         },
         "node_modules/next": {
-            "version": "16.2.10",
-            "resolved": "https://registry.npmjs.org/next/-/next-16.2.10.tgz",
-            "integrity": "sha512-2som5AVXb3kE6Yjine3/mNbBayYF58eguBWIVVUdr1y/L426xyVEgYxgBG+1QC34P2x5E+tcDup6XkuOAX3dCA==",
+            "version": "16.2.12",
+            "resolved": "https://registry.npmjs.org/next/-/next-16.2.12.tgz",
+            "integrity": "sha512-iD59eYQWmbFcEbX7v/acG5DRym9iw1DdaPoD0WTA920naWsE25wShzJW4+UvAs8MK9EC2kBfIH6vtto1H1PHGw==",
             "license": "MIT",
             "dependencies": {
-                "@next/env": "16.2.10",
+                "@next/env": "16.2.12",
                 "@swc/helpers": "0.5.15",
                 "baseline-browser-mapping": "^2.9.19",
                 "caniuse-lite": "^1.0.30001579",
@@ -10616,14 +10588,14 @@
                 "node": ">=20.9.0"
             },
             "optionalDependencies": {
-                "@next/swc-darwin-arm64": "16.2.10",
-                "@next/swc-darwin-x64": "16.2.10",
-                "@next/swc-linux-arm64-gnu": "16.2.10",
-                "@next/swc-linux-arm64-musl": "16.2.10",
-                "@next/swc-linux-x64-gnu": "16.2.10",
-                "@next/swc-linux-x64-musl": "16.2.10",
-                "@next/swc-win32-arm64-msvc": "16.2.10",
-                "@next/swc-win32-x64-msvc": "16.2.10",
+                "@next/swc-darwin-arm64": "16.2.12",
+                "@next/swc-darwin-x64": "16.2.12",
+                "@next/swc-linux-arm64-gnu": "16.2.12",
+                "@next/swc-linux-arm64-musl": "16.2.12",
+                "@next/swc-linux-x64-gnu": "16.2.12",
+                "@next/swc-linux-x64-musl": "16.2.12",
+                "@next/swc-win32-arm64-msvc": "16.2.12",
+                "@next/swc-win32-x64-msvc": "16.2.12",
                 "sharp": "^0.34.5"
             },
             "peerDependencies": {
@@ -11219,7 +11191,6 @@
             "version": "7.1.1",
             "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-7.1.1.tgz",
             "integrity": "sha512-5m3bsyrjFWE1xf7nz7YXdN4udnVtXK6/Yfgn5qnahL6bCkf2yKt4k3nuTKAtT4r3IG8JNR2ncsIMdZuAzJjHQQ==",
-            "dev": true,
             "license": "MIT",
             "optional": true
         },
@@ -11264,9 +11235,9 @@
             }
         },
         "node_modules/node-releases": {
-            "version": "2.0.50",
-            "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.50.tgz",
-            "integrity": "sha512-J6l92tKHX6w8Jy5nO1Vuc01NoIiRGi/d6qBKVxh+IQ8Cr3b6HbVNfKiF8ZpFKufTwpwxMmce2W3iQZ861ZRyTg==",
+            "version": "2.0.51",
+            "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.51.tgz",
+            "integrity": "sha512-wRNIrw4DmVLKQlbgOMdkMx27Wrpzes2hh5Jtbi2bjPd+4wJstWIqP5A+lscnqbm0xxmT5Bpg8Lec5ItEBwx6BQ==",
             "license": "MIT",
             "engines": {
                 "node": ">=18"
@@ -11410,9 +11381,9 @@
             }
         },
         "node_modules/obug": {
-            "version": "2.1.3",
-            "resolved": "https://registry.npmjs.org/obug/-/obug-2.1.3.tgz",
-            "integrity": "sha512-9miFgM2OFba7hB+pRgvtV84pYTBaoTHohvmIgiRt6dRIzbwEOIaNaP+dIlGs2fNFoB0SeISs0Jz5WFVRid6Xyg==",
+            "version": "2.1.4",
+            "resolved": "https://registry.npmjs.org/obug/-/obug-2.1.4.tgz",
+            "integrity": "sha512-4a+OsYv9UktOJKE+l1A4OufDgdRF9PifWj+tJnHURo/P+WOxpG4GzUFL9qCalmWauao6ogiG+QvnCovwPoyAWA==",
             "dev": true,
             "funding": [
                 "https://github.com/sponsors/sxzz",
@@ -11455,12 +11426,13 @@
             }
         },
         "node_modules/own-keys": {
-            "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/own-keys/-/own-keys-1.0.1.tgz",
-            "integrity": "sha512-qFOyK5PjiWZd+QQIh+1jhdb9LpxTF0qs7Pm8o5QHYZ0M3vKqSqzsZaEB6oWlxZ+q2sJBMI/Ktgd2N5ZwQoRHfg==",
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/own-keys/-/own-keys-1.0.2.tgz",
+            "integrity": "sha512-19YVAg7T+WTrxggPukVq7DjTv6+PJ867TmhCvBsYwmbFCsZd344rq2Ld1p0wo8f8Qrrhgp82c6FJRqdXWtSEhg==",
             "license": "MIT",
             "dependencies": {
-                "get-intrinsic": "^1.2.6",
+                "call-bound": "^1.0.4",
+                "get-intrinsic": "^1.3.0",
                 "object-keys": "^1.1.1",
                 "safe-push-apply": "^1.0.0"
             },
@@ -11504,9 +11476,9 @@
             }
         },
         "node_modules/p-map": {
-            "version": "7.0.5",
-            "resolved": "https://registry.npmjs.org/p-map/-/p-map-7.0.5.tgz",
-            "integrity": "sha512-e8vJF4XdVkzqqSHguEMz41mQO1wKwxKm5ENrUJQUu9kLDCtn83cxbyHZcszr4QC5zEA7WffRRC4gsTecC7J9oA==",
+            "version": "7.0.6",
+            "resolved": "https://registry.npmjs.org/p-map/-/p-map-7.0.6.tgz",
+            "integrity": "sha512-I4Prw6ivkd6p8PiYR1tXASOAOBzIJwu0TB7fqaX0c/8c3QAehNYmX57EijyGGGBt3c/BIowGwV03RVBtXvHEVg==",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -11669,9 +11641,9 @@
             }
         },
         "node_modules/path-scurry/node_modules/lru-cache": {
-            "version": "11.5.1",
-            "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.5.1.tgz",
-            "integrity": "sha512-RPimw/7aMdv2oqRrxKwvZXcPfwBrn/JZ2xYcY9Hus/6LaS3VOAKVWKWgNLCFSiOm1ESXinjsDlidVU7JlnCN2A==",
+            "version": "11.5.2",
+            "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.5.2.tgz",
+            "integrity": "sha512-4pfM1Ff0x50o0tQwb5ucw/RzNyD0/YJME6IVcStalZuMWxdt3sR3huStTtxz4PUmvZfRguvDejasvQ2kifR11g==",
             "dev": true,
             "license": "BlueOak-1.0.0",
             "engines": {
@@ -11755,9 +11727,9 @@
             }
         },
         "node_modules/postcss": {
-            "version": "8.5.16",
-            "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.16.tgz",
-            "integrity": "sha512-vuwillviilfKZsg0VGj5R/YwwcHx4SLsIOI/7K6mQkWx+l5cUHTjj5g0AasTBcyXsbfTgrwsUNmVUb5xVwyPwg==",
+            "version": "8.5.23",
+            "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.23.tgz",
+            "integrity": "sha512-g50586zr4bZmwFiTlflMu8E0bDTb5I5gertgwAKmsdUlTQIhZtunzUlD1WSzwcVWPoAVpsrA6vlfCD7oXvRwgg==",
             "funding": [
                 {
                     "type": "opencollective",
@@ -11774,7 +11746,7 @@
             ],
             "license": "MIT",
             "dependencies": {
-                "nanoid": "^3.3.12",
+                "nanoid": "^3.3.16",
                 "picocolors": "^1.1.1",
                 "source-map-js": "^1.2.1"
             },
@@ -11983,24 +11955,24 @@
             }
         },
         "node_modules/react": {
-            "version": "19.2.7",
-            "resolved": "https://registry.npmjs.org/react/-/react-19.2.7.tgz",
-            "integrity": "sha512-HNe9WslTbXmFK8o8cmwgAeJFSBvt1bPdHCVKtaaV+WlAN36mpT4hcRpwbf3fY56ar2oIXzsBpOAiIRHAdY0OlQ==",
+            "version": "19.2.8",
+            "resolved": "https://registry.npmjs.org/react/-/react-19.2.8.tgz",
+            "integrity": "sha512-PWaYA1L/q9u2u7xYQi+Y3L3Yfnie7XyLeaJICV1MGD6LprsBxcAqGjYyr0eY3p+QdsA+x/Irkt4Qif8D63+Sbw==",
             "license": "MIT",
             "engines": {
                 "node": ">=0.10.0"
             }
         },
         "node_modules/react-dom": {
-            "version": "19.2.7",
-            "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.7.tgz",
-            "integrity": "sha512-t0BRVXvbiE/o20Hfw669rLbMCDWtYZLvmJigy2f0MxsXF+71pxhR3xOkspmsO8h3ZlNzyibAmtCa3l4lYKk6gQ==",
+            "version": "19.2.8",
+            "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.8.tgz",
+            "integrity": "sha512-rVprimfGBG3DR+Tq0IQG2DT5PxKth1WIGDmj5yPmlzr4YBe7uyE+Du4oVqTDXZSHGGGXRtTJEGSSePyQCMBglQ==",
             "license": "MIT",
             "dependencies": {
                 "scheduler": "^0.27.0"
             },
             "peerDependencies": {
-                "react": "^19.2.7"
+                "react": "^19.2.8"
             }
         },
         "node_modules/react-ga4": {
@@ -12010,9 +11982,9 @@
             "license": "MIT"
         },
         "node_modules/react-is": {
-            "version": "19.2.7",
-            "resolved": "https://registry.npmjs.org/react-is/-/react-is-19.2.7.tgz",
-            "integrity": "sha512-kZFnouyVv7eP/Phmrlo9FK+zcAdriZJvzxXHF1Sl1P377WSGe2G/JxVolhTrB/jeV47lKImhNUsijjHAAbcl/A==",
+            "version": "19.2.8",
+            "resolved": "https://registry.npmjs.org/react-is/-/react-is-19.2.8.tgz",
+            "integrity": "sha512-s5un28nYxKJw5gvUHyW5PCC28CvBqLu9r3cWgzHT4Vo/5fqqkFcdRYsGcKf50WMPpjjFZS5d76fn3YCo2njKwQ==",
             "license": "MIT"
         },
         "node_modules/react-player": {
@@ -12480,13 +12452,13 @@
             }
         },
         "node_modules/rolldown": {
-            "version": "1.1.4",
-            "resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.1.4.tgz",
-            "integrity": "sha512-IjZYiLxZwpnhwhdBH2ugdTGVSdhCQUmLxLoqyjiL0JxYjyRst+5a0P3xfrTxJ5F638j4Mvvw5FAX5XE6eHpXbA==",
+            "version": "1.1.5",
+            "resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.1.5.tgz",
+            "integrity": "sha512-t9z29cJjXf/vxQ8dyhCSpt6H6aSwHTk8cT5I3iy6SMXuFpk5mB6PL6XfC8PCwrPTx93udwKUm9HRteAlTGBLiA==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@oxc-project/types": "=0.138.0",
+                "@oxc-project/types": "=0.139.0",
                 "@rolldown/pluginutils": "^1.0.0"
             },
             "bin": {
@@ -12496,21 +12468,21 @@
                 "node": "^20.19.0 || >=22.12.0"
             },
             "optionalDependencies": {
-                "@rolldown/binding-android-arm64": "1.1.4",
-                "@rolldown/binding-darwin-arm64": "1.1.4",
-                "@rolldown/binding-darwin-x64": "1.1.4",
-                "@rolldown/binding-freebsd-x64": "1.1.4",
-                "@rolldown/binding-linux-arm-gnueabihf": "1.1.4",
-                "@rolldown/binding-linux-arm64-gnu": "1.1.4",
-                "@rolldown/binding-linux-arm64-musl": "1.1.4",
-                "@rolldown/binding-linux-ppc64-gnu": "1.1.4",
-                "@rolldown/binding-linux-s390x-gnu": "1.1.4",
-                "@rolldown/binding-linux-x64-gnu": "1.1.4",
-                "@rolldown/binding-linux-x64-musl": "1.1.4",
-                "@rolldown/binding-openharmony-arm64": "1.1.4",
-                "@rolldown/binding-wasm32-wasi": "1.1.4",
-                "@rolldown/binding-win32-arm64-msvc": "1.1.4",
-                "@rolldown/binding-win32-x64-msvc": "1.1.4"
+                "@rolldown/binding-android-arm64": "1.1.5",
+                "@rolldown/binding-darwin-arm64": "1.1.5",
+                "@rolldown/binding-darwin-x64": "1.1.5",
+                "@rolldown/binding-freebsd-x64": "1.1.5",
+                "@rolldown/binding-linux-arm-gnueabihf": "1.1.5",
+                "@rolldown/binding-linux-arm64-gnu": "1.1.5",
+                "@rolldown/binding-linux-arm64-musl": "1.1.5",
+                "@rolldown/binding-linux-ppc64-gnu": "1.1.5",
+                "@rolldown/binding-linux-s390x-gnu": "1.1.5",
+                "@rolldown/binding-linux-x64-gnu": "1.1.5",
+                "@rolldown/binding-linux-x64-musl": "1.1.5",
+                "@rolldown/binding-openharmony-arm64": "1.1.5",
+                "@rolldown/binding-wasm32-wasi": "1.1.5",
+                "@rolldown/binding-win32-arm64-msvc": "1.1.5",
+                "@rolldown/binding-win32-x64-msvc": "1.1.5"
             }
         },
         "node_modules/run-parallel": {
@@ -12617,9 +12589,9 @@
             "license": "MIT"
         },
         "node_modules/sass": {
-            "version": "1.101.0",
-            "resolved": "https://registry.npmjs.org/sass/-/sass-1.101.0.tgz",
-            "integrity": "sha512-OL3GoQyoUdDt843DpVmDO6y2k1sc5IhUDSpu8XucEI+35neq5QivZ1iuegnpraEVTJXlQGK1gl27zKcTLEPbQw==",
+            "version": "1.102.0",
+            "resolved": "https://registry.npmjs.org/sass/-/sass-1.102.0.tgz",
+            "integrity": "sha512-NSOyTnaQF7rTAEOtI2fwb386vL+akyiQLBZu8Na7hXCb+umJy0GAqlcMIaqACZ6Z1VgTBS4K9PG6B3IdjHGJsw==",
             "devOptional": true,
             "license": "MIT",
             "dependencies": {
@@ -13147,9 +13119,9 @@
             }
         },
         "node_modules/std-env": {
-            "version": "4.1.0",
-            "resolved": "https://registry.npmjs.org/std-env/-/std-env-4.1.0.tgz",
-            "integrity": "sha512-Rq7ybcX2RuC55r9oaPVEW7/xu3tj8u4GeBYHBWCychFtzMIr86A7e3PPEBPT37sHStKX3+TiX/Fr/ACmJLVlLQ==",
+            "version": "4.2.0",
+            "resolved": "https://registry.npmjs.org/std-env/-/std-env-4.2.0.tgz",
+            "integrity": "sha512-oCUKSupKTHX53EyjDtuZQ64pjLJ6yYCtpmEw0goYxtjG9KpbRe8KAsl2tBUGU9DyMcJ0RwJ8GqJAFzMXcXW1Rw==",
             "dev": true,
             "license": "MIT"
         },
@@ -13167,29 +13139,21 @@
             }
         },
         "node_modules/string-width": {
-            "version": "7.2.0",
-            "resolved": "https://registry.npmjs.org/string-width/-/string-width-7.2.0.tgz",
-            "integrity": "sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ==",
+            "version": "8.2.2",
+            "resolved": "https://registry.npmjs.org/string-width/-/string-width-8.2.2.tgz",
+            "integrity": "sha512-GaPUh5gfdrYzqeVNZvUfT23vYYxXzKYidUcnMtJg/3rxRV63EFZy3k6xfKlmfeJD0176lnUV/Usr3XcwSvFzpg==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "emoji-regex": "^10.3.0",
-                "get-east-asian-width": "^1.0.0",
-                "strip-ansi": "^7.1.0"
+                "get-east-asian-width": "^1.5.0",
+                "strip-ansi": "^7.1.2"
             },
             "engines": {
-                "node": ">=18"
+                "node": ">=20"
             },
             "funding": {
                 "url": "https://github.com/sponsors/sindresorhus"
             }
-        },
-        "node_modules/string-width/node_modules/emoji-regex": {
-            "version": "10.6.0",
-            "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-10.6.0.tgz",
-            "integrity": "sha512-toUI84YS5YmxW219erniWD0CIVOo46xGKColeNQRgOzDorgBi1v4D71/OFzgD9GO2UGKIv1C3Sp8DAn0+j5w7A==",
-            "dev": true,
-            "license": "MIT"
         },
         "node_modules/string.prototype.includes": {
             "version": "2.0.1",
@@ -13453,9 +13417,9 @@
             }
         },
         "node_modules/terser": {
-            "version": "5.48.0",
-            "resolved": "https://registry.npmjs.org/terser/-/terser-5.48.0.tgz",
-            "integrity": "sha512-J/9An6vs9Us6wKRriSFXBWdRZapREHqFzdNUKk0pmu804EMR6dr6winwo7e5JDxN4xahxQsuysyYFwlwj4XN/Q==",
+            "version": "5.49.0",
+            "resolved": "https://registry.npmjs.org/terser/-/terser-5.49.0.tgz",
+            "integrity": "sha512-SNiDnXyHSrxVcIOtVbULzcTmniUiwcV7Nwdyj1twVubeTmbjoa8p69KKDpfkdoOavuM4/GRm1+ykI8qqnavHoA==",
             "devOptional": true,
             "license": "BSD-2-Clause",
             "dependencies": {
@@ -13641,9 +13605,9 @@
             "license": "0BSD"
         },
         "node_modules/tsx": {
-            "version": "4.22.5",
-            "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.22.5.tgz",
-            "integrity": "sha512-F7JnSfPl5ASt6LqwWyUQ3T8BwN3q0eQEbFMYa2iRWaVQmmudo0d7fRmwM4O002gsvW1bs0yBYioutsAjqLJMvQ==",
+            "version": "4.23.1",
+            "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.23.1.tgz",
+            "integrity": "sha512-GQHnkIfxyx1wYCOS/wonik5MVRZU9hi1TEZmzGZSCJB1y9YgoZ8H6itNE/u4suE+yLmOzuE4E5S4TZ/ZX2wcWQ==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -13774,17 +13738,17 @@
             "license": "MIT"
         },
         "node_modules/typedoc": {
-            "version": "0.28.19",
-            "resolved": "https://registry.npmjs.org/typedoc/-/typedoc-0.28.19.tgz",
-            "integrity": "sha512-wKh+lhdmMFivMlc6vRRcMGXeGEHGU2g8a2CkPTJjJlwRf1iXbimWIPcFolCqe4E0d/FRtGszpIrsp3WLpDB8Pw==",
+            "version": "0.28.20",
+            "resolved": "https://registry.npmjs.org/typedoc/-/typedoc-0.28.20.tgz",
+            "integrity": "sha512-uSKqkh8Cr48vllnEy+jdaAgOeR6Y+QCBW7usgUsKj7gJEfR7stw9U/fE49LBnj2tPRKPY0c0EBJSWe9Appmplg==",
             "dev": true,
             "license": "Apache-2.0",
             "dependencies": {
                 "@gerrit0/mini-shiki": "^3.23.0",
                 "lunr": "^2.3.9",
-                "markdown-it": "^14.1.1",
+                "markdown-it": "^14.3.0",
                 "minimatch": "^10.2.5",
-                "yaml": "^2.8.3"
+                "yaml": "^2.9.0"
             },
             "bin": {
                 "typedoc": "bin/typedoc"
@@ -13827,15 +13791,15 @@
             }
         },
         "node_modules/typescript-eslint": {
-            "version": "8.62.1",
-            "resolved": "https://registry.npmjs.org/typescript-eslint/-/typescript-eslint-8.62.1.tgz",
-            "integrity": "sha512-vymnnM5g0AKQDSAyfP12nMIBvgwgA42syg74kkuZ4x1VuTzwQKwc5h9rGxeShCjny5o+zWAb6OEoz7XLgrIkIw==",
+            "version": "8.65.0",
+            "resolved": "https://registry.npmjs.org/typescript-eslint/-/typescript-eslint-8.65.0.tgz",
+            "integrity": "sha512-/ggrHAwyjENDusvyxbuqxAC2dTnZg/Z8F+fgQtYIz+L6n/9HfSlEZcFGV/NsMNa6CkGk0xUjUAFwC0vHOflvIA==",
             "license": "MIT",
             "dependencies": {
-                "@typescript-eslint/eslint-plugin": "8.62.1",
-                "@typescript-eslint/parser": "8.62.1",
-                "@typescript-eslint/typescript-estree": "8.62.1",
-                "@typescript-eslint/utils": "8.62.1"
+                "@typescript-eslint/eslint-plugin": "8.65.0",
+                "@typescript-eslint/parser": "8.65.0",
+                "@typescript-eslint/typescript-estree": "8.65.0",
+                "@typescript-eslint/utils": "8.65.0"
             },
             "engines": {
                 "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -14249,19 +14213,19 @@
             }
         },
         "node_modules/vitest": {
-            "version": "4.1.9",
-            "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.1.9.tgz",
-            "integrity": "sha512-nE3/LEyc0z87uHYLZebqCUOaJr2hdtuPp7BQ4BosVFnfltxgAvMG08NyrSGlPpOUWvR27c5flSmYFTNr78L9GQ==",
+            "version": "4.1.10",
+            "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.1.10.tgz",
+            "integrity": "sha512-R9jUTe5S4Qb0HCd4TNqpC7oGcrMssMRGXLW80ubjWsW9VH5GF8y1Y0SFLY9AbqSk6nt0PnOx4H4WNJYZ13GUPw==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@vitest/expect": "4.1.9",
-                "@vitest/mocker": "4.1.9",
-                "@vitest/pretty-format": "4.1.9",
-                "@vitest/runner": "4.1.9",
-                "@vitest/snapshot": "4.1.9",
-                "@vitest/spy": "4.1.9",
-                "@vitest/utils": "4.1.9",
+                "@vitest/expect": "4.1.10",
+                "@vitest/mocker": "4.1.10",
+                "@vitest/pretty-format": "4.1.10",
+                "@vitest/runner": "4.1.10",
+                "@vitest/snapshot": "4.1.10",
+                "@vitest/spy": "4.1.10",
+                "@vitest/utils": "4.1.10",
                 "es-module-lexer": "^2.0.0",
                 "expect-type": "^1.3.0",
                 "magic-string": "^0.30.21",
@@ -14289,12 +14253,12 @@
                 "@edge-runtime/vm": "*",
                 "@opentelemetry/api": "^1.9.0",
                 "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0",
-                "@vitest/browser-playwright": "4.1.9",
-                "@vitest/browser-preview": "4.1.9",
-                "@vitest/browser-webdriverio": "4.1.9",
-                "@vitest/coverage-istanbul": "4.1.9",
-                "@vitest/coverage-v8": "4.1.9",
-                "@vitest/ui": "4.1.9",
+                "@vitest/browser-playwright": "4.1.10",
+                "@vitest/browser-preview": "4.1.10",
+                "@vitest/browser-webdriverio": "4.1.10",
+                "@vitest/coverage-istanbul": "4.1.10",
+                "@vitest/coverage-v8": "4.1.10",
+                "@vitest/ui": "4.1.10",
                 "happy-dom": "*",
                 "jsdom": "*",
                 "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
@@ -14339,13 +14303,13 @@
             }
         },
         "node_modules/vitest/node_modules/@vitest/mocker": {
-            "version": "4.1.9",
-            "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.1.9.tgz",
-            "integrity": "sha512-EVkXzBjrPGM+cK8/ANWgBrkUCfJfb38/EfTSO8h7pWvKkyPkpWxvR7BkD2MyItMF62C97zAEoqdpUixwR/e+Rw==",
+            "version": "4.1.10",
+            "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.1.10.tgz",
+            "integrity": "sha512-v0xaezt+DKEmKfaxg133ldzADrwLGd7Ze1MfQQTYfvs8OqZIwbxyxaYURivwV7sWy5fqn3rH5uOrSp07bp44Ow==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@vitest/spy": "4.1.9",
+                "@vitest/spy": "4.1.10",
                 "estree-walker": "^3.0.3",
                 "magic-string": "^0.30.21"
             },
@@ -14379,16 +14343,16 @@
             }
         },
         "node_modules/vitest/node_modules/vite": {
-            "version": "8.1.3",
-            "resolved": "https://registry.npmjs.org/vite/-/vite-8.1.3.tgz",
-            "integrity": "sha512-Ds+gBRbj0lwRO2Y5hwnUBdxSwlAve9LeRyU4sNnAr0ewW0gWF0n5bgXgUzbgZ49MV9BVUAQUFYVcDUcilUExMA==",
+            "version": "8.1.5",
+            "resolved": "https://registry.npmjs.org/vite/-/vite-8.1.5.tgz",
+            "integrity": "sha512-7ULLwsCdYx/nRyrpiEwvqb5TFHrMVZyBt+rg/OAXT7rgj/z+DtTDyKFeLAdDkubDVDKD8jOsndmy7m55XcfUsw==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
                 "lightningcss": "^1.32.0",
-                "picomatch": "^4.0.4",
-                "postcss": "^8.5.16",
-                "rolldown": "~1.1.3",
+                "picomatch": "^4.0.5",
+                "postcss": "^8.5.17",
+                "rolldown": "~1.1.5",
                 "tinyglobby": "^0.2.17"
             },
             "bin": {
@@ -14456,24 +14420,6 @@
                 }
             }
         },
-        "node_modules/vitest/node_modules/yaml": {
-            "version": "2.9.0",
-            "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.9.0.tgz",
-            "integrity": "sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA==",
-            "dev": true,
-            "license": "ISC",
-            "optional": true,
-            "peer": true,
-            "bin": {
-                "yaml": "bin.mjs"
-            },
-            "engines": {
-                "node": ">= 14.6"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/eemeli"
-            }
-        },
         "node_modules/watchpack": {
             "version": "2.5.2",
             "resolved": "https://registry.npmjs.org/watchpack/-/watchpack-2.5.2.tgz",
@@ -14514,9 +14460,9 @@
             "license": "Apache-2.0"
         },
         "node_modules/webpack": {
-            "version": "5.108.3",
-            "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.108.3.tgz",
-            "integrity": "sha512-hOpaCHmQVVY66IVTjofnH14IgSdmod2aquSGHGuYig/OIdWge01Hk2Wt988DZcwXumFUT4+FvJY5N+ikl8o/ww==",
+            "version": "5.109.0",
+            "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.109.0.tgz",
+            "integrity": "sha512-vomrngskVVXEZF9sMZfYAd4pXZUnfaWdJGlF+BTNF+gJBCKYCQBnOeVPlrh39Ewl7nlCsirDplMy6o5g9xJHBg==",
             "devOptional": true,
             "license": "MIT",
             "dependencies": {
@@ -14526,22 +14472,20 @@
                 "@webassemblyjs/wasm-edit": "^1.14.1",
                 "@webassemblyjs/wasm-parser": "^1.14.1",
                 "acorn": "^8.16.0",
-                "acorn-import-phases": "^1.0.3",
                 "browserslist": "^4.28.1",
                 "chrome-trace-event": "^1.0.2",
-                "enhanced-resolve": "^5.22.2",
+                "enhanced-resolve": "^5.24.2",
                 "es-module-lexer": "^2.1.0",
                 "eslint-scope": "5.1.1",
                 "events": "^3.2.0",
                 "graceful-fs": "^4.2.11",
-                "loader-runner": "^4.3.2",
                 "mime-db": "^1.54.0",
                 "minimizer-webpack-plugin": "^5.6.1",
                 "neo-async": "^2.6.2",
                 "schema-utils": "^4.3.3",
                 "tapable": "^2.3.0",
                 "watchpack": "^2.5.2",
-                "webpack-sources": "^3.5.0"
+                "webpack-sources": "^3.5.1"
             },
             "bin": {
                 "webpack": "bin/webpack.js"
@@ -14560,9 +14504,9 @@
             }
         },
         "node_modules/webpack-sources": {
-            "version": "3.5.0",
-            "resolved": "https://registry.npmjs.org/webpack-sources/-/webpack-sources-3.5.0.tgz",
-            "integrity": "sha512-HPuy+uuoTCaaoEoI1LQ3JN9+vrPBvEesnnX1jADHy728cHSMlq4wUc4afYqahq2B1mhQVZxCXOkNTnXltr+2vQ==",
+            "version": "3.5.1",
+            "resolved": "https://registry.npmjs.org/webpack-sources/-/webpack-sources-3.5.1.tgz",
+            "integrity": "sha512-jyuiGJdtvY434z5bUZrjz67v76/ePNvFZTp9Mdz29IlH4+GPsgyGjiv0fKI+M7BdkU6ADjulUcKAd3tUK3WlEw==",
             "devOptional": true,
             "license": "MIT",
             "engines": {
@@ -14771,10 +14715,35 @@
                 "url": "https://github.com/chalk/ansi-styles?sponsor=1"
             }
         },
+        "node_modules/wrap-ansi/node_modules/emoji-regex": {
+            "version": "10.6.0",
+            "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-10.6.0.tgz",
+            "integrity": "sha512-toUI84YS5YmxW219erniWD0CIVOo46xGKColeNQRgOzDorgBi1v4D71/OFzgD9GO2UGKIv1C3Sp8DAn0+j5w7A==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/wrap-ansi/node_modules/string-width": {
+            "version": "7.2.0",
+            "resolved": "https://registry.npmjs.org/string-width/-/string-width-7.2.0.tgz",
+            "integrity": "sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "emoji-regex": "^10.3.0",
+                "get-east-asian-width": "^1.0.0",
+                "strip-ansi": "^7.1.0"
+            },
+            "engines": {
+                "node": ">=18"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
         "node_modules/ws": {
-            "version": "8.21.0",
-            "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.0.tgz",
-            "integrity": "sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==",
+            "version": "8.21.1",
+            "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.1.tgz",
+            "integrity": "sha512-+0NTnW77fFN/DjQi6k/Sq/Yvk4Sgajw7urW8V+asjXnRgDs9gyGkdb7EzgfhA4goXsRIZKE28fzIXBHEzhuiWw==",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -14819,16 +14788,16 @@
             }
         },
         "node_modules/yargs": {
-            "version": "18.0.0",
-            "resolved": "https://registry.npmjs.org/yargs/-/yargs-18.0.0.tgz",
-            "integrity": "sha512-4UEqdc2RYGHZc7Doyqkrqiln3p9X2DZVxaGbwhn2pi7MrRagKaOcIKe8L3OxYcbhXLgLFUS3zAYuQjKBQgmuNg==",
+            "version": "18.1.0",
+            "resolved": "https://registry.npmjs.org/yargs/-/yargs-18.1.0.tgz",
+            "integrity": "sha512-2rAgRKu54VsHkqI0/tYkmluGXHD4KW7yZoycuqDQ15QOTnc2VVfy0nN/1eMhnQLO00A+dwtK20xuCnc1YGeUyg==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
                 "cliui": "^9.0.1",
                 "escalade": "^3.1.1",
                 "get-caller-file": "^2.0.5",
-                "string-width": "^7.2.0",
+                "string-width": "^8.2.1",
                 "y18n": "^5.0.5",
                 "yargs-parser": "^22.0.0"
             },

--- a/package-lock.json
+++ b/package-lock.json
@@ -19,7 +19,7 @@
                 "eslint-config-next": "^16.1.7",
                 "next": "^16.2.10",
                 "next-mdx-remote": "^6.0.0",
-                "node-html-parser": "^8.0.4",
+                "node-html-parser": "^9.0.0",
                 "prism-react-renderer": "^2.4.1",
                 "prop-types": "^15.8.1",
                 "react": "^19.2.7",
@@ -3466,88 +3466,6 @@
             "integrity": "sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q==",
             "license": "MIT"
         },
-        "node_modules/@typescript-eslint/eslint-plugin": {
-            "version": "8.65.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.65.0.tgz",
-            "integrity": "sha512-IEgob78X12rHpUmtcwFsXhZdVGJtwTVP8FiCLZkR6GlYVrl2PcuB+KhCE5BlVC/eQpQnu8WXRtkHZuPar+gCRA==",
-            "license": "MIT",
-            "dependencies": {
-                "@eslint-community/regexpp": "^4.12.2",
-                "@typescript-eslint/scope-manager": "8.65.0",
-                "@typescript-eslint/type-utils": "8.65.0",
-                "@typescript-eslint/utils": "8.65.0",
-                "@typescript-eslint/visitor-keys": "8.65.0",
-                "ignore": "^7.0.5",
-                "natural-compare": "^1.4.0",
-                "ts-api-utils": "^2.5.0"
-            },
-            "engines": {
-                "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
-            },
-            "funding": {
-                "type": "opencollective",
-                "url": "https://opencollective.com/typescript-eslint"
-            },
-            "peerDependencies": {
-                "@typescript-eslint/parser": "^8.65.0",
-                "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
-                "typescript": ">=4.8.4 <6.1.0"
-            }
-        },
-        "node_modules/@typescript-eslint/eslint-plugin/node_modules/ignore": {
-            "version": "7.0.6",
-            "resolved": "https://registry.npmjs.org/ignore/-/ignore-7.0.6.tgz",
-            "integrity": "sha512-BAg6QkE8W+TuQLrrw0Ugr7HegXduRuuj8/ti2kSOc+jz1dmx8/WNcjr6XGnq5YpDWxFwwaavqD0+jIUOKelTsw==",
-            "license": "MIT",
-            "engines": {
-                "node": ">= 4"
-            }
-        },
-        "node_modules/@typescript-eslint/parser": {
-            "version": "8.65.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.65.0.tgz",
-            "integrity": "sha512-CZ4nMxWwgu1HEEFNkeaCptra9QCtkmKdgf3sWh1rl1trIhmxLilgTV4cwcbQ4wemnT4sWQN8CaKOmdYx+g2gMA==",
-            "license": "MIT",
-            "dependencies": {
-                "@typescript-eslint/scope-manager": "8.65.0",
-                "@typescript-eslint/types": "8.65.0",
-                "@typescript-eslint/typescript-estree": "8.65.0",
-                "@typescript-eslint/visitor-keys": "8.65.0",
-                "debug": "^4.4.3"
-            },
-            "engines": {
-                "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
-            },
-            "funding": {
-                "type": "opencollective",
-                "url": "https://opencollective.com/typescript-eslint"
-            },
-            "peerDependencies": {
-                "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
-                "typescript": ">=4.8.4 <6.1.0"
-            }
-        },
-        "node_modules/@typescript-eslint/project-service": {
-            "version": "8.65.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/project-service/-/project-service-8.65.0.tgz",
-            "integrity": "sha512-SxnPhbTsGahizDgbu7oqFH/xVtzIqMd/s+WtnSxNxJZJpLbdT5IPdzg8EZxO3+PoKahXmwJLeNQOpKJb3/bi7Q==",
-            "license": "MIT",
-            "dependencies": {
-                "@typescript-eslint/tsconfig-utils": "^8.65.0",
-                "@typescript-eslint/types": "^8.65.0",
-                "debug": "^4.4.3"
-            },
-            "engines": {
-                "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
-            },
-            "funding": {
-                "type": "opencollective",
-                "url": "https://opencollective.com/typescript-eslint"
-            },
-            "peerDependencies": {
-                "typescript": ">=4.8.4 <6.1.0"
-            }
-        },
         "node_modules/@typescript-eslint/scope-manager": {
             "version": "8.65.0",
             "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.65.0.tgz",
@@ -3565,46 +3483,6 @@
                 "url": "https://opencollective.com/typescript-eslint"
             }
         },
-        "node_modules/@typescript-eslint/tsconfig-utils": {
-            "version": "8.65.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.65.0.tgz",
-            "integrity": "sha512-j6GzGqCiRdA7Qhur2VVmKZAkBLfnHFQfx4TaJGL9RMveZqCo48jSHHO0DTgizEnGhtWnqmbtCUSrqSkdiY/0Hg==",
-            "license": "MIT",
-            "engines": {
-                "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
-            },
-            "funding": {
-                "type": "opencollective",
-                "url": "https://opencollective.com/typescript-eslint"
-            },
-            "peerDependencies": {
-                "typescript": ">=4.8.4 <6.1.0"
-            }
-        },
-        "node_modules/@typescript-eslint/type-utils": {
-            "version": "8.65.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.65.0.tgz",
-            "integrity": "sha512-YjaZ7PRI5qY7ax2L3PbvX0rRyGtipAReCWs0mhhDBHjH/vl0g0BonaGXrKdKpMbIIsMIwDgbk/xzkBTyAltS5g==",
-            "license": "MIT",
-            "dependencies": {
-                "@typescript-eslint/types": "8.65.0",
-                "@typescript-eslint/typescript-estree": "8.65.0",
-                "@typescript-eslint/utils": "8.65.0",
-                "debug": "^4.4.3",
-                "ts-api-utils": "^2.5.0"
-            },
-            "engines": {
-                "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
-            },
-            "funding": {
-                "type": "opencollective",
-                "url": "https://opencollective.com/typescript-eslint"
-            },
-            "peerDependencies": {
-                "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
-                "typescript": ">=4.8.4 <6.1.0"
-            }
-        },
         "node_modules/@typescript-eslint/types": {
             "version": "8.65.0",
             "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.65.0.tgz",
@@ -3616,68 +3494,6 @@
             "funding": {
                 "type": "opencollective",
                 "url": "https://opencollective.com/typescript-eslint"
-            }
-        },
-        "node_modules/@typescript-eslint/typescript-estree": {
-            "version": "8.65.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.65.0.tgz",
-            "integrity": "sha512-JboAE2swaYt4tb1fHhHTABE2K+OLy09XfcTbhnk4Pw96f9dd2e9iYsJ28gBggHlo5z5x1rkyWvcPoTuNTd4oGg==",
-            "license": "MIT",
-            "dependencies": {
-                "@typescript-eslint/project-service": "8.65.0",
-                "@typescript-eslint/tsconfig-utils": "8.65.0",
-                "@typescript-eslint/types": "8.65.0",
-                "@typescript-eslint/visitor-keys": "8.65.0",
-                "debug": "^4.4.3",
-                "minimatch": "^10.2.2",
-                "semver": "^7.7.3",
-                "tinyglobby": "^0.2.15",
-                "ts-api-utils": "^2.5.0"
-            },
-            "engines": {
-                "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
-            },
-            "funding": {
-                "type": "opencollective",
-                "url": "https://opencollective.com/typescript-eslint"
-            },
-            "peerDependencies": {
-                "typescript": ">=4.8.4 <6.1.0"
-            }
-        },
-        "node_modules/@typescript-eslint/typescript-estree/node_modules/semver": {
-            "version": "7.8.5",
-            "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
-            "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
-            "license": "ISC",
-            "bin": {
-                "semver": "bin/semver.js"
-            },
-            "engines": {
-                "node": ">=10"
-            }
-        },
-        "node_modules/@typescript-eslint/utils": {
-            "version": "8.65.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.65.0.tgz",
-            "integrity": "sha512-gXiwIHsYreboxeJucHKPvgwl7dXt50mF8s1/c00cP/WoVTyWKFdtfhRWwZiXYFU5H2O8vVoSLNrexFZjYS/SGA==",
-            "license": "MIT",
-            "dependencies": {
-                "@eslint-community/eslint-utils": "^4.9.1",
-                "@typescript-eslint/scope-manager": "8.65.0",
-                "@typescript-eslint/types": "8.65.0",
-                "@typescript-eslint/typescript-estree": "8.65.0"
-            },
-            "engines": {
-                "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
-            },
-            "funding": {
-                "type": "opencollective",
-                "url": "https://opencollective.com/typescript-eslint"
-            },
-            "peerDependencies": {
-                "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
-                "typescript": ">=4.8.4 <6.1.0"
             }
         },
         "node_modules/@typescript-eslint/visitor-keys": {
@@ -6139,6 +5955,213 @@
                 "typescript": {
                     "optional": true
                 }
+            }
+        },
+        "node_modules/eslint-config-next/node_modules/ignore": {
+            "version": "7.0.6",
+            "resolved": "https://registry.npmjs.org/ignore/-/ignore-7.0.6.tgz",
+            "integrity": "sha512-BAg6QkE8W+TuQLrrw0Ugr7HegXduRuuj8/ti2kSOc+jz1dmx8/WNcjr6XGnq5YpDWxFwwaavqD0+jIUOKelTsw==",
+            "license": "MIT",
+            "engines": {
+                "node": ">= 4"
+            }
+        },
+        "node_modules/eslint-config-next/node_modules/semver": {
+            "version": "7.8.5",
+            "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
+            "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
+            "license": "ISC",
+            "bin": {
+                "semver": "bin/semver.js"
+            },
+            "engines": {
+                "node": ">=10"
+            }
+        },
+        "node_modules/eslint-config-next/node_modules/typescript-eslint": {
+            "version": "8.65.0",
+            "resolved": "https://registry.npmjs.org/typescript-eslint/-/typescript-eslint-8.65.0.tgz",
+            "integrity": "sha512-/ggrHAwyjENDusvyxbuqxAC2dTnZg/Z8F+fgQtYIz+L6n/9HfSlEZcFGV/NsMNa6CkGk0xUjUAFwC0vHOflvIA==",
+            "license": "MIT",
+            "dependencies": {
+                "@typescript-eslint/eslint-plugin": "8.65.0",
+                "@typescript-eslint/parser": "8.65.0",
+                "@typescript-eslint/typescript-estree": "8.65.0",
+                "@typescript-eslint/utils": "8.65.0"
+            },
+            "engines": {
+                "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/typescript-eslint"
+            },
+            "peerDependencies": {
+                "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
+                "typescript": ">=4.8.4 <6.1.0"
+            }
+        },
+        "node_modules/eslint-config-next/node_modules/typescript-eslint/node_modules/@typescript-eslint/eslint-plugin": {
+            "version": "8.65.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.65.0.tgz",
+            "integrity": "sha512-IEgob78X12rHpUmtcwFsXhZdVGJtwTVP8FiCLZkR6GlYVrl2PcuB+KhCE5BlVC/eQpQnu8WXRtkHZuPar+gCRA==",
+            "license": "MIT",
+            "dependencies": {
+                "@eslint-community/regexpp": "^4.12.2",
+                "@typescript-eslint/scope-manager": "8.65.0",
+                "@typescript-eslint/type-utils": "8.65.0",
+                "@typescript-eslint/utils": "8.65.0",
+                "@typescript-eslint/visitor-keys": "8.65.0",
+                "ignore": "^7.0.5",
+                "natural-compare": "^1.4.0",
+                "ts-api-utils": "^2.5.0"
+            },
+            "engines": {
+                "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/typescript-eslint"
+            },
+            "peerDependencies": {
+                "@typescript-eslint/parser": "^8.65.0",
+                "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
+                "typescript": ">=4.8.4 <6.1.0"
+            }
+        },
+        "node_modules/eslint-config-next/node_modules/typescript-eslint/node_modules/@typescript-eslint/eslint-plugin/node_modules/@typescript-eslint/type-utils": {
+            "version": "8.65.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.65.0.tgz",
+            "integrity": "sha512-YjaZ7PRI5qY7ax2L3PbvX0rRyGtipAReCWs0mhhDBHjH/vl0g0BonaGXrKdKpMbIIsMIwDgbk/xzkBTyAltS5g==",
+            "license": "MIT",
+            "dependencies": {
+                "@typescript-eslint/types": "8.65.0",
+                "@typescript-eslint/typescript-estree": "8.65.0",
+                "@typescript-eslint/utils": "8.65.0",
+                "debug": "^4.4.3",
+                "ts-api-utils": "^2.5.0"
+            },
+            "engines": {
+                "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/typescript-eslint"
+            },
+            "peerDependencies": {
+                "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
+                "typescript": ">=4.8.4 <6.1.0"
+            }
+        },
+        "node_modules/eslint-config-next/node_modules/typescript-eslint/node_modules/@typescript-eslint/parser": {
+            "version": "8.65.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.65.0.tgz",
+            "integrity": "sha512-CZ4nMxWwgu1HEEFNkeaCptra9QCtkmKdgf3sWh1rl1trIhmxLilgTV4cwcbQ4wemnT4sWQN8CaKOmdYx+g2gMA==",
+            "license": "MIT",
+            "dependencies": {
+                "@typescript-eslint/scope-manager": "8.65.0",
+                "@typescript-eslint/types": "8.65.0",
+                "@typescript-eslint/typescript-estree": "8.65.0",
+                "@typescript-eslint/visitor-keys": "8.65.0",
+                "debug": "^4.4.3"
+            },
+            "engines": {
+                "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/typescript-eslint"
+            },
+            "peerDependencies": {
+                "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
+                "typescript": ">=4.8.4 <6.1.0"
+            }
+        },
+        "node_modules/eslint-config-next/node_modules/typescript-eslint/node_modules/@typescript-eslint/typescript-estree": {
+            "version": "8.65.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.65.0.tgz",
+            "integrity": "sha512-JboAE2swaYt4tb1fHhHTABE2K+OLy09XfcTbhnk4Pw96f9dd2e9iYsJ28gBggHlo5z5x1rkyWvcPoTuNTd4oGg==",
+            "license": "MIT",
+            "dependencies": {
+                "@typescript-eslint/project-service": "8.65.0",
+                "@typescript-eslint/tsconfig-utils": "8.65.0",
+                "@typescript-eslint/types": "8.65.0",
+                "@typescript-eslint/visitor-keys": "8.65.0",
+                "debug": "^4.4.3",
+                "minimatch": "^10.2.2",
+                "semver": "^7.7.3",
+                "tinyglobby": "^0.2.15",
+                "ts-api-utils": "^2.5.0"
+            },
+            "engines": {
+                "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/typescript-eslint"
+            },
+            "peerDependencies": {
+                "typescript": ">=4.8.4 <6.1.0"
+            }
+        },
+        "node_modules/eslint-config-next/node_modules/typescript-eslint/node_modules/@typescript-eslint/typescript-estree/node_modules/@typescript-eslint/project-service": {
+            "version": "8.65.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/project-service/-/project-service-8.65.0.tgz",
+            "integrity": "sha512-SxnPhbTsGahizDgbu7oqFH/xVtzIqMd/s+WtnSxNxJZJpLbdT5IPdzg8EZxO3+PoKahXmwJLeNQOpKJb3/bi7Q==",
+            "license": "MIT",
+            "dependencies": {
+                "@typescript-eslint/tsconfig-utils": "^8.65.0",
+                "@typescript-eslint/types": "^8.65.0",
+                "debug": "^4.4.3"
+            },
+            "engines": {
+                "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/typescript-eslint"
+            },
+            "peerDependencies": {
+                "typescript": ">=4.8.4 <6.1.0"
+            }
+        },
+        "node_modules/eslint-config-next/node_modules/typescript-eslint/node_modules/@typescript-eslint/typescript-estree/node_modules/@typescript-eslint/tsconfig-utils": {
+            "version": "8.65.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.65.0.tgz",
+            "integrity": "sha512-j6GzGqCiRdA7Qhur2VVmKZAkBLfnHFQfx4TaJGL9RMveZqCo48jSHHO0DTgizEnGhtWnqmbtCUSrqSkdiY/0Hg==",
+            "license": "MIT",
+            "engines": {
+                "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/typescript-eslint"
+            },
+            "peerDependencies": {
+                "typescript": ">=4.8.4 <6.1.0"
+            }
+        },
+        "node_modules/eslint-config-next/node_modules/typescript-eslint/node_modules/@typescript-eslint/utils": {
+            "version": "8.65.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.65.0.tgz",
+            "integrity": "sha512-gXiwIHsYreboxeJucHKPvgwl7dXt50mF8s1/c00cP/WoVTyWKFdtfhRWwZiXYFU5H2O8vVoSLNrexFZjYS/SGA==",
+            "license": "MIT",
+            "dependencies": {
+                "@eslint-community/eslint-utils": "^4.9.1",
+                "@typescript-eslint/scope-manager": "8.65.0",
+                "@typescript-eslint/types": "8.65.0",
+                "@typescript-eslint/typescript-estree": "8.65.0"
+            },
+            "engines": {
+                "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/typescript-eslint"
+            },
+            "peerDependencies": {
+                "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
+                "typescript": ">=4.8.4 <6.1.0"
             }
         },
         "node_modules/eslint-import-resolver-node": {
@@ -11213,9 +11236,9 @@
             }
         },
         "node_modules/node-html-parser": {
-            "version": "8.0.4",
-            "resolved": "https://registry.npmjs.org/node-html-parser/-/node-html-parser-8.0.4.tgz",
-            "integrity": "sha512-w2YxujN/TqrSIWGVNW/fVgKKfAyQeHMXCvnKZI0owLnfP0tfjdLecUoy9zhOMZGoEFk6eP5qSDyvUarjPl3bwQ==",
+            "version": "9.0.0",
+            "resolved": "https://registry.npmjs.org/node-html-parser/-/node-html-parser-9.0.0.tgz",
+            "integrity": "sha512-MhdaHPyxnyYu/sf0TpiRvDnTrkum0UKHC7FdbDGIUQNlx3I7xzwXoyV0eMUMv/XU+lkJT1glOUzpDPq7b2p1Ew==",
             "license": "MIT",
             "dependencies": {
                 "css-select": "^5.1.0",
@@ -13788,29 +13811,6 @@
             },
             "engines": {
                 "node": ">=14.17"
-            }
-        },
-        "node_modules/typescript-eslint": {
-            "version": "8.65.0",
-            "resolved": "https://registry.npmjs.org/typescript-eslint/-/typescript-eslint-8.65.0.tgz",
-            "integrity": "sha512-/ggrHAwyjENDusvyxbuqxAC2dTnZg/Z8F+fgQtYIz+L6n/9HfSlEZcFGV/NsMNa6CkGk0xUjUAFwC0vHOflvIA==",
-            "license": "MIT",
-            "dependencies": {
-                "@typescript-eslint/eslint-plugin": "8.65.0",
-                "@typescript-eslint/parser": "8.65.0",
-                "@typescript-eslint/typescript-estree": "8.65.0",
-                "@typescript-eslint/utils": "8.65.0"
-            },
-            "engines": {
-                "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
-            },
-            "funding": {
-                "type": "opencollective",
-                "url": "https://opencollective.com/typescript-eslint"
-            },
-            "peerDependencies": {
-                "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
-                "typescript": ">=4.8.4 <6.1.0"
             }
         },
         "node_modules/uc.micro": {

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
         "eslint-config-next": "^16.1.7",
         "next": "^16.2.10",
         "next-mdx-remote": "^6.0.0",
-        "node-html-parser": "^8.0.4",
+        "node-html-parser": "^9.0.0",
         "prism-react-renderer": "^2.4.1",
         "prop-types": "^15.8.1",
         "react": "^19.2.7",

--- a/package.json
+++ b/package.json
@@ -78,7 +78,8 @@
         "@types/react": "^19.2.17"
     },
     "overrides": {
-        "postcss": "^8.5.10"
+        "postcss": "^8.5.10",
+        "sharp": "^0.35.3"
     },
     "engines": {
         "npm": ">=11.10.0"


### PR DESCRIPTION
## Summary

- **Dependency updates**: Ran `npm update` to bring dependencies to the latest semver-compatible versions (next, react, vitest, webpack, typedoc, sass, tsx, etc.), plus `npm audit fix` for non-breaking vulnerability fixes.
- **Snapshot refresh**: Regenerated `__tests__/__snapshots__/markdown-parsing.test.ts.snap` to match recent grammar fixes in `content/setup.md` and `content/addons/htmlMesh.md` (4 snapshots updated, 2 obsolete removed).
- **Major version updates attempted**:
  - ✅ `node-html-parser` `^8.0.4` → `^9.0.0` — works cleanly. Verified via the full unit test suite, the `build:typedoc` script (its only consumer), and a full `next build` + static export, serving the output and confirming pages render with real content.
  - ❌ `typescript` `^6.0.3` → `^7.0.2` — **reverted**. Breaks `next build` with `TypeScript 7.0.2 does not provide the compiler API required by Next.js`. Next.js doesn't yet support the new TypeScript 7 compiler API, so this update isn't safe to take yet.
- **sharp advisory fix**: `next@16.2.12` bundles its own nested `sharp@0.34.5` (vulnerable to CVE-2026-33327/33328/35590/35591 via libvips), separate from our own top-level `sharp@^0.35.3` devDependency, because npm couldn't dedupe across the differing 0.x minor ranges. `next.config.js` sets `images.unoptimized: true` (this is a static-export site), so Next's built-in image optimizer — and therefore its bundled sharp — is never exercised at build or runtime, making it safe to force. Added an `overrides` entry pinning `sharp` to `^0.35.3` everywhere, which dedupes next's nested copy onto the already-audited version.

## Remaining known issues (not addressed, out of scope)
- `brace-expansion` high-severity advisory fix is blocked by the repo's `min-release-age=7` npm policy (patched versions are currently <7 days old). `npm audit` now reports only this 1 remaining high-severity issue.

## Validation
- `npm test` — 71/71 tests passing
- `npm run build:typedoc` — succeeds
- `npm run build:local` (full `next build` static export) — succeeds, 6261 pages generated
- Served the static export and confirmed homepage, typedoc pages, and content pages render with correct content (HTTP 200 + expected text) — verified both before and after the sharp override

Co-authored-by: Copilot App <223556219+Copilot@users.noreply.github.com>