### PR TITLE
Fix FollowCamera rotationOffset unit

### DIFF
--- a/content/features/introductionToFeatures/chap8/follow.md
+++ b/content/features/introductionToFeatures/chap8/follow.md
@@ -33,7 +33,7 @@ radial distance from target plus height offset;
 camera.radius = 1;
 ```
 
-rotation, in radians, center of target in x y plane;
+rotation, in degrees, center of target in x y plane;
 ```javascript
 camera.rotationOffset = 0;
 ```


### PR DESCRIPTION
Corrects the documented unit for `FollowCamera.rotationOffset` from radians to degrees to match the implementation.