### PR TITLE
Document PointerDragBehavior validateDrag example

### DIFF
--- a/content/features/featuresDeepDive/behaviors/meshBehaviors.md
+++ b/content/features/featuresDeepDive/behaviors/meshBehaviors.md
@@ -38,6 +38,18 @@ By default, the drag plane will update on every frame. To disable this, set `upd
 pointerDragBehavior.updateDragPlane = false;
 ```
 
+Before the attached mesh moves, `validateDrag` receives its proposed absolute position and determines whether to apply it. Override it to reject invalid positions or no-op updates. For example, the following prevents repeated world matrix updates once the proposed movement is within a tolerance appropriate for the scene:
+
+```javascript
+const dragEpsilon = 0.001;
+
+pointerDragBehavior.validateDrag = (targetPosition) => {
+  return !mesh.absolutePosition.equalsWithEpsilon(targetPosition, dragEpsilon);
+};
+```
+
+A larger tolerance stops the mesh farther from the exact target, so choose a value that matches the scale of the scene.
+
 To listen to drag events, you can use the following:
 
 ```javascript


### PR DESCRIPTION
## Summary
- document how `PointerDragBehavior.validateDrag` accepts or rejects proposed absolute positions
- show an explicit epsilon guard that avoids redundant world-matrix updates and explain its scene-scale tradeoff

## Validation
- `npm run validate:content`
- `npm run build`
- `npm test` (79 of 80 tests passed; the unrelated `content-graph.test.ts` Windows path assertion expects `/` but receives `\`)

Refs https://github.com/AmoebaChant/pan-work/issues/93