### PR TITLE
Document experimental WebGPU XR support

### DIFF
--- a/configuration/structure.json
+++ b/configuration/structure.json
@@ -2303,6 +2303,11 @@
                                     "children": {},
                                     "content": "features/featuresDeepDive/webXR/introToWebXR"
                                 },
+                                "webGPUXR": {
+                                    "friendlyName": "WebGPU in WebXR",
+                                    "children": {},
+                                    "content": "features/featuresDeepDive/webXR/webGPUXR"
+                                },
                                 "WebXRSelectedFeatures": {
                                     "friendlyName": "WebXR Features",
                                     "children": {

--- a/content/features/featuresDeepDive/webXR.md
+++ b/content/features/featuresDeepDive/webXR.md
@@ -11,3 +11,5 @@ video-content:
 # WebXR
 
 The WebXR API enables developers to create VR and AR experiences for the web. XR (extended reality) unifies augmented reality and virtual reality into a single API that works across supported devices.
+
+Babylon.js supports WebXR with both WebGL and, experimentally, WebGPU. WebGPU-backed XR has additional setup and browser requirements; see [WebGPU in WebXR](/features/featuresDeepDive/webXR/webGPUXR) before selecting a rendering engine.

--- a/content/features/featuresDeepDive/webXR/WebXRLayers.md
+++ b/content/features/featuresDeepDive/webXR/WebXRLayers.md
@@ -31,6 +31,16 @@ const featuresManager = xr.baseExperience.featuresManager; // or any other way t
 featuresManager.enableFeature(WebXRFeatureName.LAYERS, "stable" /* or latest */, {});
 ```
 
+### WebGPU-XR
+
+WebXR Layers is optional for WebGL-backed XR but required for WebGPU-XR. Enable the feature before calling `enterXRAsync`; it creates the `XRGPUBinding` projection layer used to render the session.
+
+<Alert severity="warning" title="Experimental WebGPU-XR support">
+WebGPU-XR currently requires projection layers and does not support multiview. The WebGPU engine must be created with `{ xrCompatible: true }`. See [WebGPU in WebXR](/features/featuresDeepDive/webXR/webGPUXR) for complete setup and fallback guidance.
+</Alert>
+
+WebGPU quad layers require the browser's `XRGPUBinding` to expose both `createQuadLayer` and `getSubImage`. Babylon logs a warning and returns `null` from the quad-layer creation path if either method is unavailable, so check the returned layer before using it.
+
 ### Enabling multiview
 
 WebXR layers can be used to enable multiview rendering of your scene. Multiview allows your scene to be rendered using a single render call, instead of rendering two cameras one after the other. This can, under certain conditions, improve your scene rendering time.
@@ -49,6 +59,8 @@ featuresManager.enableFeature(WebXRFeatureName.LAYERS, "stable" /* or latest */,
 ```
 
 If your browser supports multiview, it will be enabled. Otherwise, it will silently fall back to non-multiview rendering.
+
+Multiview is not currently supported on the WebGPU-XR path. Setting `preferMultiviewOnInit` when using a WebGPU engine still uses non-multiview rendering.
 
 ## Use cases for layers
 

--- a/content/features/featuresDeepDive/webXR/introToWebXR.md
+++ b/content/features/featuresDeepDive/webXR/introToWebXR.md
@@ -34,6 +34,14 @@ As the API continuously changes, it is difficult to keep up with feature updates
 
 Note that most of the time when we say WebXR, we actually mean WebXR **in VR immersive mode**. This is currently the most used mode of WebXR.
 
+### WebGPU rendering
+
+Babylon.js can render WebXR sessions with WebGPU through the browser's experimental `XRGPUBinding` support. This is distinct from general WebGPU support and from support for an immersive WebXR session.
+
+<Alert severity="warning" title="Experimental WebGPU-XR support">
+Before creating a scene, check each capability and create the WebGPU engine with `{ xrCompatible: true }`. WebGPU-XR also requires enabling the WebXR Layers feature before entering XR. See [WebGPU in WebXR](/features/featuresDeepDive/webXR/webGPUXR) for the complete setup, limitations, and WebGL fallback strategy.
+</Alert>
+
 ## Device and browser support
 
 ### PC

--- a/content/features/featuresDeepDive/webXR/webGPUXR.md
+++ b/content/features/featuresDeepDive/webXR/webGPUXR.md
@@ -52,8 +52,13 @@ async function createEngineForImmersiveXR(canvas) {
 
   if (webGPUSupported && immersiveXRSupported && webGPUXRSupported) {
     const engine = new BABYLON.WebGPUEngine(canvas, { xrCompatible: true });
-    await engine.initAsync();
-    return engine;
+    try {
+      await engine.initAsync();
+      return engine;
+    } catch (error) {
+      engine.dispose();
+      console.warn("Could not initialize an XR-compatible WebGPU engine; using WebGL instead.", error);
+    }
   }
 
   return new BABYLON.Engine(canvas, true);

--- a/content/features/featuresDeepDive/webXR/webGPUXR.md
+++ b/content/features/featuresDeepDive/webXR/webGPUXR.md
@@ -28,9 +28,9 @@ WebGPU, immersive WebXR, and WebGPU-XR are separate capabilities:
 
 - `WebGPUEngine.IsSupportedAsync` checks whether Babylon can create a WebGPU engine.
 - `WebXRSessionManager.IsSessionSupportedAsync("immersive-vr")` checks whether the browser reports support for that immersive WebXR session mode.
-- `WebXRSessionManager.IsWebGPUXRSupported` checks whether the runtime exposes the `XRGPUBinding` projection-layer methods required by Babylon.
+- `WebXRSessionManager.IsWebGPUXRSupported` checks whether the runtime exposes the `XRGPUBinding` projection-layer methods and the `XRGPUSubImage.getViewDescriptor` method required by Babylon.
 
-`IsWebGPUXRSupported` is an experimental, static boolean getter. It is an advisory API-shape check, not a guarantee that the active device, GPU adapter, permissions, and session will work together. The actual session request can still reject.
+`IsWebGPUXRSupported` is an experimental, static boolean getter. It requires the `XRGPUSubImage` interface and `XRGPUSubImage.prototype.getViewDescriptor` because Babylon uses that method to create texture views for each projection sub-image. This remains an advisory API-shape check, not a guarantee that the active device, GPU adapter, permissions, and session will work together. The actual session request can still reject.
 
 ## Select the engine before creating the scene
 
@@ -47,6 +47,7 @@ WebGPU has no equivalent to making an existing context XR-compatible later. If y
 async function createEngineForImmersiveXR(canvas) {
   const webGPUSupported = await BABYLON.WebGPUEngine.IsSupportedAsync;
   const immersiveXRSupported = await BABYLON.WebXRSessionManager.IsSessionSupportedAsync("immersive-vr");
+  // Includes XRGPUBinding projection APIs and XRGPUSubImage.getViewDescriptor.
   const webGPUXRSupported = BABYLON.WebXRSessionManager.IsWebGPUXRSupported;
 
   if (webGPUSupported && immersiveXRSupported && webGPUXRSupported) {
@@ -89,11 +90,11 @@ When using ES modules with tree shaking, import the Layers feature so it is regi
 import "@babylonjs/core/XR/features/WebXRLayers.js";
 ```
 
-Babylon rejects WebGPU XR entry with actionable guidance when the required `XRGPUBinding` projection path is missing or when Layers was not enabled. If the browser rejects the WebGPU session request with `NotSupportedError`, Babylon preserves the original error as the cause and reports that the application must recreate the scene with WebGL to fall back.
+Babylon rejects WebGPU XR entry with actionable guidance when the required `XRGPUBinding` projection path or `XRGPUSubImage.getViewDescriptor` support is missing, or when Layers was not enabled. If the browser rejects the WebGPU session request with `NotSupportedError`, Babylon preserves the original error as the cause and reports that the application must recreate the scene with WebGL to fall back.
 
 ## Current feature caveats
 
-- **Projection layers are required.** The WebGL `XRWebGLLayer` rendering path is not available to a WebGPU engine.
+- **Projection layers and sub-image view descriptors are required.** The runtime must expose `XRGPUSubImage.prototype.getViewDescriptor`; the WebGL `XRWebGLLayer` rendering path is not available to a WebGPU engine.
 - **Multiview is not available with WebGPU-XR yet.** `preferMultiviewOnInit` does not enable it on this path.
 - **Raw Camera Access is unavailable.** The browser exposes camera images through `XRWebGLBinding`, not `XRGPUBinding`.
 - **Space Warp is unavailable.** Its current implementation depends on WebGL-specific binding functionality.

--- a/content/features/featuresDeepDive/webXR/webGPUXR.md
+++ b/content/features/featuresDeepDive/webXR/webGPUXR.md
@@ -1,0 +1,103 @@
+---
+title: WebGPU in WebXR
+image:
+description: Learn how to create an experimental WebGPU-backed WebXR experience in Babylon.js.
+keywords: babylon.js, diving deeper, WebXR, WebGPU, VR, AR, XRGPUBinding
+further-reading:
+  - title: Introduction To WebXR
+    url: /features/featuresDeepDive/webXR/introToWebXR
+  - title: WebXR Layers
+    url: /features/featuresDeepDive/webXR/WebXRSelectedFeatures/WebXRLayers
+  - title: WebXR Session Manager
+    url: /features/featuresDeepDive/webXR/webXRSessionManagers
+video-overview:
+video-content:
+---
+
+# WebGPU in WebXR
+
+Babylon.js can render immersive WebXR sessions with a WebGPU engine through the browser's experimental `XRGPUBinding` implementation.
+
+<Alert severity="warning" title="Experimental WebGPU-XR support">
+WebGPU-XR browser and device support is experimental and may change. Test on every target browser and headset, and keep a WebGL entry path available when WebGPU-XR is not supported.
+</Alert>
+
+## Check the three levels of support
+
+WebGPU, immersive WebXR, and WebGPU-XR are separate capabilities:
+
+- `WebGPUEngine.IsSupportedAsync` checks whether Babylon can create a WebGPU engine.
+- `WebXRSessionManager.IsSessionSupportedAsync("immersive-vr")` checks whether the browser reports support for that immersive WebXR session mode.
+- `WebXRSessionManager.IsWebGPUXRSupported` checks whether the runtime exposes the `XRGPUBinding` projection-layer methods required by Babylon.
+
+`IsWebGPUXRSupported` is an experimental, static boolean getter. It is an advisory API-shape check, not a guarantee that the active device, GPU adapter, permissions, and session will work together. The actual session request can still reject.
+
+## Select the engine before creating the scene
+
+A WebGPU engine intended for XR must request an XR-compatible adapter when it is created:
+
+```javascript
+const engine = new BABYLON.WebGPUEngine(canvas, { xrCompatible: true });
+await engine.initAsync();
+```
+
+WebGPU has no equivalent to making an existing context XR-compatible later. If your application supports WebGL fallback, select the rendering backend before creating the scene or any GPU resources:
+
+```javascript
+async function createEngineForImmersiveXR(canvas) {
+  const webGPUSupported = await BABYLON.WebGPUEngine.IsSupportedAsync;
+  const immersiveXRSupported = await BABYLON.WebXRSessionManager.IsSessionSupportedAsync("immersive-vr");
+  const webGPUXRSupported = BABYLON.WebXRSessionManager.IsWebGPUXRSupported;
+
+  if (webGPUSupported && immersiveXRSupported && webGPUXRSupported) {
+    const engine = new BABYLON.WebGPUEngine(canvas, { xrCompatible: true });
+    await engine.initAsync();
+    return engine;
+  }
+
+  return new BABYLON.Engine(canvas, true);
+}
+
+const engine = await createEngineForImmersiveXR(canvas);
+const scene = new BABYLON.Scene(engine);
+// Create the rest of the scene and its resources only after selecting the engine.
+```
+
+Babylon.js never swaps an existing WebGPU engine or scene to WebGL. If WebGPU session negotiation later fails, falling back requires reloading or fully rebuilding the engine, scene, and all GPU resources with a WebGL engine.
+
+## Enable WebXR Layers before entering XR
+
+WebGPU-XR uses an `XRProjectionLayer`, so the [WebXR Layers feature](/features/featuresDeepDive/webXR/WebXRSelectedFeatures/WebXRLayers) is required. Enable it before calling `enterXRAsync`:
+
+```javascript
+const xr = await scene.createDefaultXRExperienceAsync();
+
+const featuresManager = xr.baseExperience.featuresManager;
+featuresManager.enableFeature(BABYLON.WebXRFeatureName.LAYERS, "stable");
+
+try {
+  await xr.baseExperience.enterXRAsync("immersive-vr", "local-floor");
+} catch (error) {
+  // Show the error and offer to reload or rebuild the application with WebGL.
+  console.error("Could not start the XR session:", error);
+}
+```
+
+When using ES modules with tree shaking, import the Layers feature so it is registered:
+
+```javascript
+import "@babylonjs/core/XR/features/WebXRLayers.js";
+```
+
+Babylon rejects WebGPU XR entry with actionable guidance when the required `XRGPUBinding` projection path is missing or when Layers was not enabled. If the browser rejects the WebGPU session request with `NotSupportedError`, Babylon preserves the original error as the cause and reports that the application must recreate the scene with WebGL to fall back.
+
+## Current feature caveats
+
+- **Projection layers are required.** The WebGL `XRWebGLLayer` rendering path is not available to a WebGPU engine.
+- **Multiview is not available with WebGPU-XR yet.** `preferMultiviewOnInit` does not enable it on this path.
+- **Raw Camera Access is unavailable.** The browser exposes camera images through `XRWebGLBinding`, not `XRGPUBinding`.
+- **Space Warp is unavailable.** Its current implementation depends on WebGL-specific binding functionality.
+- **Quad layers are method-gated.** They are available only when the runtime's `XRGPUBinding` implements both `createQuadLayer` and `getSubImage`. Babylon warns and returns `null` when either method is missing.
+- **Depth Sensing requires CPU-optimized depth.** Request CPU usage with `usagePreference: ["cpu"]`; GPU-optimized environment depth has no `XRGPUBinding` equivalent.
+
+These limitations are specific to the experimental WebGPU-XR path. A feature may still be available in a WebGL-backed WebXR session.

--- a/content/features/featuresDeepDive/webXR/webXRExperienceHelpers.md
+++ b/content/features/featuresDeepDive/webXR/webXRExperienceHelpers.md
@@ -67,6 +67,21 @@ After initializing the XR helper, it is possible to enter an XR session, for exa
 const sessionManager = await xrHelper.enterXRAsync("immersive-vr", "local-floor" /*, optionalRenderTarget */ );
 ```
 
+When the scene uses a WebGPU engine, enable [WebXR Layers](/features/featuresDeepDive/webXR/WebXRSelectedFeatures/WebXRLayers) before calling `enterXRAsync`:
+
+```javascript
+xrHelper.featuresManager.enableFeature(BABYLON.WebXRFeatureName.LAYERS, "stable");
+
+try {
+  await xrHelper.enterXRAsync("immersive-vr", "local-floor");
+} catch (error) {
+  // Display the actionable error and offer a reload or full rebuild with WebGL.
+  console.error("Could not enter XR:", error);
+}
+```
+
+The WebGPU engine must already have been created with `{ xrCompatible: true }`. Babylon cannot change an existing WebGPU engine or scene to WebGL after entry fails. See [WebGPU in WebXR](/features/featuresDeepDive/webXR/webGPUXR) for engine selection and fallback guidance.
+
 To read more about session modes ( `immersive-vr` in this example), and reference type modes ( `local-floor` ), please read the [WebXR specs](https://immersive-web.github.io/webxr/). The most common scenario is VR in local floor mode, which is the one we are showing here.
 
 If there is an error while creating the experience helper, the console will show it.

--- a/content/features/featuresDeepDive/webXR/webXRSessionManagers.md
+++ b/content/features/featuresDeepDive/webXR/webXRSessionManagers.md
@@ -44,7 +44,7 @@ if (supported) {
 After making sure that XR is available and that the session is supported, you can initialize the session and prepare it for rendering:
 
 ```javascript
-sessionManager.initializeSessionAsync("immersive-vr" /*, xrSessionInit */);
+await sessionManager.initializeSessionAsync("immersive-vr" /*, xrSessionInit */);
 ```
 
 This function will initialize the native session. Without calling this function, no session is available and the XR experience will not work.
@@ -67,14 +67,14 @@ A WebGPU engine used here must be created with `{ xrCompatible: true }`, and the
 Right after that, you will need to initialize the reference space of this session, which will define the coordinate system that the XR experience will use:
 
 ```javascript
-const referenceSpace = sessionManager.setReferenceSpaceTypeAsync(/*referenceSpaceType = 'local-floor'*/);
+const referenceSpace = await sessionManager.setReferenceSpaceTypeAsync(/*referenceSpaceType = 'local-floor'*/);
 ```
 
 The only thing left now is to prepare the render target and layer. WebGL engines use an [XR WebGL Layer](https://developer.mozilla.org/en-US/docs/Web/API/XRWebGLLayer), while WebGPU engines require the WebXR Layers feature and an `XRProjectionLayer`:
 
 ```javascript
 const renderTarget = sessionManager.getWebXRRenderTarget(/*outputCanvasOptions: WebXRManagedOutputCanvasOptions*/);
-const xrWebGLLayer = renderTarget.initializeXRLayerAsync(this.sessionManager.session);
+const xrLayer = await renderTarget.initializeXRLayerAsync(sessionManager.session);
 ```
 
 The session manager is now ready to render the scene using the XR session.

--- a/content/features/featuresDeepDive/webXR/webXRSessionManagers.md
+++ b/content/features/featuresDeepDive/webXR/webXRSessionManagers.md
@@ -49,13 +49,27 @@ sessionManager.initializeSessionAsync("immersive-vr" /*, xrSessionInit */);
 
 This function will initialize the native session. Without calling this function, no session is available and the XR experience will not work.
 
+### WebGPU-XR capability checks
+
+WebGPU-XR applications should distinguish three independent checks:
+
+```javascript
+const webGPUSupported = await BABYLON.WebGPUEngine.IsSupportedAsync;
+const immersiveXRSupported = await BABYLON.WebXRSessionManager.IsSessionSupportedAsync("immersive-vr");
+const webGPUXRSupported = BABYLON.WebXRSessionManager.IsWebGPUXRSupported;
+```
+
+`IsWebGPUXRSupported` is an experimental static boolean getter. It checks whether the runtime exposes the `XRGPUBinding` projection-layer API used by Babylon, but it is advisory: session negotiation can still fail for the active device, permissions, or adapter.
+
+A WebGPU engine used here must be created with `{ xrCompatible: true }`, and the WebXR Layers feature must be enabled before session entry. When a WebGPU session request rejects with `NotSupportedError`, Babylon rejects with guidance to choose WebGL before creating the scene. See [WebGPU in WebXR](/features/featuresDeepDive/webXR/webGPUXR).
+
 Right after that, you will need to initialize the reference space of this session, which will define the coordinate system that the XR experience will use:
 
 ```javascript
 const referenceSpace = sessionManager.setReferenceSpaceTypeAsync(/*referenceSpaceType = 'local-floor'*/);
 ```
 
-The only thing left now is to prepare the render target and the [XR WebGL Layer](https://developer.mozilla.org/en-US/docs/Web/API/XRWebGLLayer):
+The only thing left now is to prepare the render target and layer. WebGL engines use an [XR WebGL Layer](https://developer.mozilla.org/en-US/docs/Web/API/XRWebGLLayer), while WebGPU engines require the WebXR Layers feature and an `XRProjectionLayer`:
 
 ```javascript
 const renderTarget = sessionManager.getWebXRRenderTarget(/*outputCanvasOptions: WebXRManagedOutputCanvasOptions*/);

--- a/content/features/featuresDeepDive/webXR/webXRSessionManagers.md
+++ b/content/features/featuresDeepDive/webXR/webXRSessionManagers.md
@@ -56,10 +56,11 @@ WebGPU-XR applications should distinguish three independent checks:
 ```javascript
 const webGPUSupported = await BABYLON.WebGPUEngine.IsSupportedAsync;
 const immersiveXRSupported = await BABYLON.WebXRSessionManager.IsSessionSupportedAsync("immersive-vr");
+// Includes XRGPUBinding projection APIs and XRGPUSubImage.getViewDescriptor.
 const webGPUXRSupported = BABYLON.WebXRSessionManager.IsWebGPUXRSupported;
 ```
 
-`IsWebGPUXRSupported` is an experimental static boolean getter. It checks whether the runtime exposes the `XRGPUBinding` projection-layer API used by Babylon, but it is advisory: session negotiation can still fail for the active device, permissions, or adapter.
+`IsWebGPUXRSupported` is an experimental static boolean getter. It checks whether the runtime exposes the `XRGPUBinding` projection-layer API, the `XRGPUSubImage` interface, and `XRGPUSubImage.prototype.getViewDescriptor` used by Babylon. It is advisory: session negotiation can still fail for the active device, permissions, or adapter.
 
 A WebGPU engine used here must be created with `{ xrCompatible: true }`, and the WebXR Layers feature must be enabled before session entry. When a WebGPU session request rejects with `NotSupportedError`, Babylon rejects with guidance to choose WebGL before creating the scene. See [WebGPU in WebXR](/features/featuresDeepDive/webXR/webGPUXR).
 

--- a/content/setup/support/webGPU.md
+++ b/content/setup/support/webGPU.md
@@ -41,6 +41,12 @@ await engine.initAsync();
 ## Is WebGL still supported?
 Yes! Support for WebGL and WebGPU is maintained side by side for the foreseeable future.
 
+## WebXR support
+
+Babylon.js supports experimental WebGPU-backed WebXR through `XRGPUBinding`. WebGPU support alone does not imply WebGPU-XR support: check the target immersive session mode and `WebXRSessionManager.IsWebGPUXRSupported` separately.
+
+A WebGPU engine intended for XR must be created with `new WebGPUEngine(canvas, { xrCompatible: true })`, and the WebXR Layers feature must be enabled before entering XR. Because Babylon cannot swap an existing WebGPU scene to WebGL, choose the engine before creating the scene and its resources. See [WebGPU in WebXR](/features/featuresDeepDive/webXR/webGPUXR) for setup, fallback guidance, and current limitations.
+
 ## Testing WebGPU
 You can refer to [this page](https://github.com/gpuweb/gpuweb/wiki/Implementation-Status) for detailed information on browser support.
 

--- a/content/setup/support/webGPU.md
+++ b/content/setup/support/webGPU.md
@@ -43,7 +43,7 @@ Yes! Support for WebGL and WebGPU is maintained side by side for the foreseeable
 
 ## WebXR support
 
-Babylon.js supports experimental WebGPU-backed WebXR through `XRGPUBinding`. WebGPU support alone does not imply WebGPU-XR support: check the target immersive session mode and `WebXRSessionManager.IsWebGPUXRSupported` separately.
+Babylon.js supports experimental WebGPU-backed WebXR through `XRGPUBinding`. WebGPU support alone does not imply WebGPU-XR support: check the target immersive session mode and `WebXRSessionManager.IsWebGPUXRSupported` separately. The WebGPU-XR getter verifies both the projection binding APIs and `XRGPUSubImage.prototype.getViewDescriptor`, which Babylon requires when creating projection texture views.
 
 A WebGPU engine intended for XR must be created with `new WebGPUEngine(canvas, { xrCompatible: true })`, and the WebXR Layers feature must be enabled before entering XR. Because Babylon cannot swap an existing WebGPU scene to WebGL, choose the engine before creating the scene and its resources. See [WebGPU in WebXR](/features/featuresDeepDive/webXR/webGPUXR) for setup, fallback guidance, and current limitations.
 

--- a/content/setup/support/webGPU/webGPUBreakingChanges.md
+++ b/content/setup/support/webGPU/webGPUBreakingChanges.md
@@ -59,7 +59,7 @@ const engine = new BABYLON.WebGPUEngine(canvas, { xrCompatible: true });
 await engine.initAsync();
 ```
 
-WebGPU-XR additionally requires the experimental `XRGPUBinding` projection path and the WebXR Layers feature. Babylon does not replace an existing WebGPU engine or scene with WebGL if XR entry fails. Applications that offer a fallback must select WebGL before scene and resource creation, or fully dispose and rebuild/reload the application with WebGL. See [WebGPU in WebXR](/features/featuresDeepDive/webXR/webGPUXR).
+WebGPU-XR additionally requires the experimental `XRGPUBinding` projection path, `XRGPUSubImage.prototype.getViewDescriptor`, and the WebXR Layers feature. Babylon does not replace an existing WebGPU engine or scene with WebGL if XR entry fails. Applications that offer a fallback must select WebGL before scene and resource creation, or fully dispose and rebuild/reload the application with WebGL. See [WebGPU in WebXR](/features/featuresDeepDive/webXR/webGPUXR).
 
 ## Shader code differences
 

--- a/content/setup/support/webGPU/webGPUBreakingChanges.md
+++ b/content/setup/support/webGPU/webGPUBreakingChanges.md
@@ -50,6 +50,17 @@ async function createEngine() {
 }
 ```
 
+### WebGPU engines intended for WebXR
+
+WebGPU has no post-creation operation that makes an adapter XR-compatible. If the engine may enter WebXR, pass `xrCompatible: true` when constructing it:
+
+```javascript
+const engine = new BABYLON.WebGPUEngine(canvas, { xrCompatible: true });
+await engine.initAsync();
+```
+
+WebGPU-XR additionally requires the experimental `XRGPUBinding` projection path and the WebXR Layers feature. Babylon does not replace an existing WebGPU engine or scene with WebGL if XR entry fails. Applications that offer a fallback must select WebGL before scene and resource creation, or fully dispose and rebuild/reload the application with WebGL. See [WebGPU in WebXR](/features/featuresDeepDive/webXR/webGPUXR).
+
 ## Shader code differences
 
 ### Array of textures

--- a/content/setup/support/webGPU/webGPUStatus.md
+++ b/content/setup/support/webGPU/webGPUStatus.md
@@ -16,7 +16,7 @@ The implementation in WebGPU is complete and, besides a few exceptions, all feat
 * [Point Cloud System](/typedoc/classes/babylon.pointscloudsystem)
   * WebGPU does not support a point size different from 1, so setting the point size to a value other than 1 will not be taken into account
 * [WebGPU in WebXR](/features/featuresDeepDive/webXR/webGPUXR)
-  * WebGPU-XR is experimental and requires browser support for `XRGPUBinding` projection layers
+  * WebGPU-XR is experimental and requires browser support for `XRGPUBinding` projection layers and `XRGPUSubImage.prototype.getViewDescriptor`
   * WebGPU-XR multiview, Raw Camera Access, Space Warp, and GPU-optimized Depth Sensing are not currently supported
   * Quad layers require the runtime to expose the optional `XRGPUBinding.createQuadLayer` and `XRGPUBinding.getSubImage` methods
 

--- a/content/setup/support/webGPU/webGPUStatus.md
+++ b/content/setup/support/webGPU/webGPUStatus.md
@@ -15,12 +15,14 @@ The implementation in WebGPU is complete and, besides a few exceptions, all feat
 ### Features with incomplete support
 * [Point Cloud System](/typedoc/classes/babylon.pointscloudsystem)
   * WebGPU does not support a point size different from 1, so setting the point size to a value other than 1 will not be taken into account
+* [WebGPU in WebXR](/features/featuresDeepDive/webXR/webGPUXR)
+  * WebGPU-XR is experimental and requires browser support for `XRGPUBinding` projection layers
+  * WebGPU-XR multiview, Raw Camera Access, Space Warp, and GPU-optimized Depth Sensing are not currently supported
+  * Quad layers require the runtime to expose the optional `XRGPUBinding.createQuadLayer` and `XRGPUBinding.getSubImage` methods
 
 ### Features not working because not implemented yet
 * Support for triangle fan / line loop drawing mode
   * WebGPU does not support those modes, so we will need to emulate them with triangle strip and line strip
-* [Multiview / WebXR](/features/featuresDeepDive/cameras/multiViewsPart1)
-  * Not implemented yet, and neither Chrome nor the WebGPU specifications support it
 
 ## Make it fast: Optimizations
 The most important optimizations have now been done (see [Optimizations](/setup/support/webGPU/webGPUOptimization)), others could be considered:


### PR DESCRIPTION
## Summary

- add a dedicated experimental WebGPU-XR guide and navigation entry
- document separate WebGPU, immersive WebXR, and WebGPU-XR capability checks
- explain XR-compatible engine preselection, required WebXR Layers setup, rejection handling, and WebGL fallback constraints
- document current WebGPU-XR feature caveats, including the `XRGPUSubImage.getViewDescriptor` preflight requirement
- correct the stale WebGPU status claim that WebXR is not implemented

## Validation

- `npm run validate:content`
- `npm run build:content`
- `npm test`